### PR TITLE
Add an example of QT_CMAKE_PREFIX_PATH for 5.13.2

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -44,6 +44,7 @@ This can either be entered directly into your shell session before you build or 
     export QT_CMAKE_PREFIX_PATH=/usr/local/qt/5.12.3/clang_64/lib/cmake/
     export QT_CMAKE_PREFIX_PATH=/usr/local/Cellar/qt5/5.12.3/lib/cmake
     export QT_CMAKE_PREFIX_PATH=/usr/local/opt/qt5/lib/cmake
+    export QT_CMAKE_PREFIX_PATH=$path_to_qt5_cloned_git/qt5/qtbase/lib/cmake
 
 #### Vcpkg
 

--- a/ice-server/CMakeLists.txt
+++ b/ice-server/CMakeLists.txt
@@ -21,4 +21,4 @@ include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")
 setup_memory_debugger()
 
 # append OpenSSL to our list of libraries to link
-target_link_libraries(${TARGET_NAME} ${OPENSSL_LIBRARIES})
+target_link_libraries(${TARGET_NAME} ${OPENSSL_LIBRARIES} -lpthread -lm)


### PR DESCRIPTION
Despite doing a sudo make install of the latest stable QT version 5.13.2, the only location of the appropriate directory I was able to find, is $path_to_qt5_cloned_git/qt5/qtbase/lib/cmake