### PR TITLE
Use model's pivot

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -1795,8 +1795,7 @@ float EntityItem::getVolumeEstimate() const {
 void EntityItem::setRegistrationPoint(const glm::vec3& value) {
     if (value != _registrationPoint) {
         withWriteLock([&] {
-            _registrationPoint = glm::clamp(value, glm::vec3(ENTITY_ITEM_MIN_REGISTRATION_POINT), 
-                                                   glm::vec3(ENTITY_ITEM_MAX_REGISTRATION_POINT));
+            _registrationPoint = value;
         });
         dimensionsChanged(); // Registration Point affects the bounding box
         markDirtyFlags(Simulation::DIRTY_SHAPE);

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -684,8 +684,8 @@ EntityPropertyFlags EntityItemProperties::getChangedProperties() const {
  * @property {Vec3} position=0,0,0 - The position of the entity in world coordinates.
  * @property {Quat} rotation=0,0,0,1 - The orientation of the entity in world coordinates.
  * @property {Vec3} registrationPoint=0.5,0.5,0.5 - The point in the entity that is set to the entity's position and is rotated 
- *      about, range {@link Vec3(0)|Vec3.ZERO} &ndash; {@link Vec3(0)|Vec3.ONE}. A value of {@link Vec3(0)|Vec3.ZERO} is the 
- *      entity's minimum x, y, z corner; a value of {@link Vec3(0)|Vec3.ONE} is the entity's maximum x, y, z corner.
+ *      about. A value of {@link Vec3(0)|Vec3.ZERO} is the entity's minimum x, y, z corner; a value of {@link Vec3(0)|Vec3.ONE}
+ *      is the entity's maximum x, y, z corner.
  *
  * @property {Vec3} naturalPosition=0,0,0 - The center of the entity's unscaled mesh model if it has one, otherwise
  *     {@link Vec3(0)|Vec3.ZERO}. <em>Read-only.</em>
@@ -2573,8 +2573,7 @@ bool EntityItemProperties::getPropertyInfo(const QString& propertyName, EntityPr
         ADD_PROPERTY_TO_MAP(PROP_POSITION, Position, position, vec3);
         ADD_PROPERTY_TO_MAP_WITH_RANGE(PROP_DIMENSIONS, Dimensions, dimensions, vec3, ENTITY_ITEM_MIN_DIMENSION, FLT_MAX);
         ADD_PROPERTY_TO_MAP(PROP_ROTATION, Rotation, rotation, quat);
-        ADD_PROPERTY_TO_MAP_WITH_RANGE(PROP_REGISTRATION_POINT, RegistrationPoint, registrationPoint, vec3, 
-                                       ENTITY_ITEM_MIN_REGISTRATION_POINT, ENTITY_ITEM_MAX_REGISTRATION_POINT);
+        ADD_PROPERTY_TO_MAP(PROP_REGISTRATION_POINT, RegistrationPoint, registrationPoint, vec3);
         ADD_PROPERTY_TO_MAP(PROP_CREATED, Created, created, quint64);
         ADD_PROPERTY_TO_MAP(PROP_LAST_EDITED_BY, LastEditedBy, lastEditedBy, QUuid);
         ADD_PROPERTY_TO_MAP(PROP_ENTITY_HOST_TYPE, EntityHostType, entityHostType, entity::HostType);

--- a/libraries/entities/src/EntityItemPropertiesDefaults.h
+++ b/libraries/entities/src/EntityItemPropertiesDefaults.h
@@ -56,8 +56,6 @@ const quint64 ENTITY_ITEM_DEFAULT_SCRIPT_TIMESTAMP = 0;
 const QString ENTITY_ITEM_DEFAULT_SERVER_SCRIPTS = QString("");
 const QString ENTITY_ITEM_DEFAULT_COLLISION_SOUND_URL = QString("");
 
-const float ENTITY_ITEM_MIN_REGISTRATION_POINT = 0.0f;
-const float ENTITY_ITEM_MAX_REGISTRATION_POINT = 1.0f;
 const glm::vec3 ENTITY_ITEM_DEFAULT_REGISTRATION_POINT = ENTITY_ITEM_HALF_VEC3; // center
 
 const float ENTITY_ITEM_IMMORTAL_LIFETIME = -1.0f; /// special lifetime which means the entity lives for ever

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -1348,10 +1348,9 @@ void Model::scaleToFit() {
 }
 
 void Model::setSnapModelToRegistrationPoint(bool snapModelToRegistrationPoint, const glm::vec3& registrationPoint) {
-    glm::vec3 clampedRegistrationPoint = glm::clamp(registrationPoint, 0.0f, 1.0f);
-    if (_snapModelToRegistrationPoint != snapModelToRegistrationPoint || _registrationPoint != clampedRegistrationPoint) {
+    if (_snapModelToRegistrationPoint != snapModelToRegistrationPoint || _registrationPoint != registrationPoint) {
         _snapModelToRegistrationPoint = snapModelToRegistrationPoint;
-        _registrationPoint = clampedRegistrationPoint;
+        _registrationPoint = registrationPoint;
         _snappedToRegistrationPoint = false; // force re-centering
     }
 }

--- a/scripts/system/create/edit.js
+++ b/scripts/system/create/edit.js
@@ -2489,6 +2489,35 @@ var PropertiesTool = function (opts) {
                     pushCommandForSelections();
                     selectionManager._update(false, this);
                 }
+            } else if (data.action === "resetToNaturalPivot") {
+                if (selectionManager.hasSelection()) {
+                    selectionManager.saveProperties();
+                    for (i = 0; i < selectionManager.selections.length; i++) {
+                        properties = selectionManager.savedProperties[selectionManager.selections[i]];
+                        var naturalDimensions = properties.naturalDimensions;
+
+                        // If any of the natural dimensions are not 0, set the entity's pivot according to its natural dimensions and natural position.
+                        // In this way, a model entity will match the pivot of its model.
+                        if (properties.type === "Model" && naturalDimensions.x === 0 && naturalDimensions.y === 0 &&
+                            naturalDimensions.z === 0) {
+                            Window.notifyEditError("Cannot apply the model's pivot to the entity: Model URL" +
+                                " is invalid or the model has not yet been loaded.");
+                        } else {
+                            var naturalMinimumExtent = Vec3.subtract(properties.naturalPosition, Vec3.multiply(naturalDimensions, 0.5));
+                            var negativeNaturalMinimumExtent = Vec3.multiply(naturalMinimumExtent, -1);
+
+                            var invNaturalDimensions = { x: 1.0 / naturalDimensions.x, y: 1.0 / naturalDimensions.y, z: 1.0 / naturalDimensions.z };
+
+                            var naturalPivot = Vec3.multiplyVbyV(negativeNaturalMinimumExtent, invNaturalDimensions);
+
+                            Entities.editEntity(selectionManager.selections[i], {
+                                registrationPoint: naturalPivot
+                            });
+                        }
+                    }
+                    pushCommandForSelections();
+                    selectionManager._update(false, this);
+                }
             } else if (data.action === "previewCamera") {
                 if (selectionManager.hasSelection()) {
                     Camera.mode = "entity";

--- a/scripts/system/create/entityProperties/html/js/entityProperties.js
+++ b/scripts/system/create/entityProperties/html/js/entityProperties.js
@@ -1294,6 +1294,13 @@ const GROUPS = [
                 propertyID: "registrationPoint",
             },
             {
+                // Displayed only for model entities.
+                label: "",
+                type: "buttons",
+                buttons: [ { id: "useModelsPivot", label: "Use Model's Pivot", className: "blue", onClick: resetToNaturalPivot } ],
+                propertyID: "modelSpecificPivotButtons",
+            },
+            {
                 label: "Align",
                 type: "buttons",
                 buttons: [ { id: "selection", label: "Selection to Grid", className: "black", onClick: moveSelectionToGrid },
@@ -3019,6 +3026,13 @@ function resetToNaturalDimensions() {
     }));
 }
 
+function resetToNaturalPivot() {
+    EventBridge.emitWebEvent(JSON.stringify({
+        type: "action",
+        action: "resetToNaturalPivot"
+    }));
+}
+
 function reloadScripts() {
     EventBridge.emitWebEvent(JSON.stringify({
         type: "action",
@@ -3692,6 +3706,10 @@ function handleEntitySelectionUpdate(selections, isPropertiesToolUpdate) {
 
         const certificateIDMultiValue = getMultiplePropertyValue('certificateID');
         const hasCertifiedInSelection = certificateIDMultiValue.isMultiDiffValue || certificateIDMultiValue.value !== "";
+
+        // Show model-specific buttons if only models are selected.
+        const selectionIsOnlyModels = ((entityTypes.length == 1) && (entityTypes[0] == "Model"));
+        showPropertyElement("modelSpecificPivotButtons", selectionIsOnlyModels);
 
         Object.entries(properties).forEach(function([propertyID, property]) {
             const propertyData = property.data;
@@ -4426,6 +4444,7 @@ function loaded() {
         bindAllNonJSONEditorElements(); 
 
         showGroupsForType("None");
+        showPropertyElement("modelSpecificPivotButtons", false);// Hidden until a model entitiy is selected.
         resetProperties();
         disableProperties();        
     });


### PR DESCRIPTION
This PR allows model entities to match the pivot from their model, and allows a pivot to be outside the entity's extents.  Both are required for an efficient and familiar workflow for modellers, who set their pivots at the modelling stage to facilitate placement of the objects.  It also provides a correction for the shift that occurs when a model is edited and its extents change.

### How it works:
Nothing changes by default.  In the Create app, model entities have a new button: **Pivot > Use Model's Pivot**.  This sets the registration point based on the existing `EntityItemProperties::_naturalPosition` and `EntityItemProperties::_naturalDimensions`, so that it matches the pivot given to the object by the modeller.  It's analogous to the 'Reset Dimensions' button, but for positioning instead of size.

### Test plan:
1. Go to a domain whose server is running this PR's code.
2. Place a model entity using this model of a sink: http://djdrumphil.ca/hifi/pull-requests/use-models-pivot/WC_Sink.gltf
3. Observe that the default value used for the pivot is still (0.5, 0.5, 0.5).
4. Adjust the pivot XYZ values and observe that they can now be set outside the 0..1 range.
5. Click 'Use Model's Pivot'.  Observe that this sets the pivot to (0.5, -0.9111, 1), which is illustrated in the screenshot from 3ds Max below.
6. Set the entity's pivot Y to -100, so that the sink floats high in the sky.
7. CULLING: Fly close to the sink and observe that it still renders as it should even though its entity position is out of the frustum.
8. CULLING: With no other objects in view, set a breakpoint in `ModelMeshPartPayload::render` and count the number of different `this` pointers that are cycled through.  Observe  that with the sink in the frustum, it's one more than with the sink out the frustum.  This shows that the entity is correctly culled even when its position is far outside of its extents.
9. PHYSICS: Set the entity's Scale to 1000 and click Rescale.  Change its pivot Y to -10.  Try the different Collision Shape options on the entity and observe that in all cases, you can walk on its top surface even though the entity's position is far outside of its extents.
10. PICKING: In the Create app, click on and around the object.  Observe that the picking still works precisely even though the entity's position is far outside of its extents.

### Examples:
Here are some typical pivots in model files, that the new button allows us to preserve:

![image](https://user-images.githubusercontent.com/35943148/78856429-c9a16480-79f4-11ea-9b50-73b1b4aa081f.png)

### For the future:
Ultimately we'd like an option for model entities to automatically **always** apply 'Reset Dimensions' and 'Use Model's Pivot', without having to use the buttons to correct each instance of an object whenever the geometry is edited.