### PR TITLE
The domain server should see Packet ID=1 as a (broken) attempt to connect to the domain server

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -661,7 +661,7 @@ bool DomainServer::isPacketVerified(const udt::Packet& packet) {
 
     // if this is a mismatching connect packet, we can't simply drop it on the floor
     // send back a packet to the interface that tells them we refuse connection for a mismatch
-    if (headerType == PacketType::DomainConnectRequest
+    if ((headerType == PacketType::DomainConnectRequest || headerType == PacketType::DomainConnectRequestPending)
         && headerVersion != versionForPacketType(PacketType::DomainConnectRequest)) {
         DomainGatekeeper::sendProtocolMismatchConnectionDenial(packet.getSenderSockAddr());
     }
@@ -806,6 +806,8 @@ void DomainServer::setupNodeListAndAssignments() {
 
     // register the gatekeeper for the packets it needs to receive
     packetReceiver.registerListener(PacketType::DomainConnectRequest,
+        PacketReceiver::makeUnsourcedListenerReference<DomainGatekeeper>(&_gatekeeper, &DomainGatekeeper::processConnectRequestPacket));
+    packetReceiver.registerListener(PacketType::DomainConnectRequestPending,
         PacketReceiver::makeUnsourcedListenerReference<DomainGatekeeper>(&_gatekeeper, &DomainGatekeeper::processConnectRequestPacket));
     packetReceiver.registerListener(PacketType::ICEPing,
         PacketReceiver::makeUnsourcedListenerReference<DomainGatekeeper>(&_gatekeeper, &DomainGatekeeper::processICEPingPacket));

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -24,7 +24,7 @@ int packetTypeMetaTypeId = qRegisterMetaType<PacketType>();
 
 PacketVersion versionForPacketType(PacketType packetType) {
     switch (packetType) {
-        case PacketType::StunResponse:
+        case PacketType::DomainConnectRequestPending: // keeping the old version to maintain the protocol hash
             return 17;
         case PacketType::DomainList:
             return static_cast<PacketVersion>(DomainListVersion::HasConnectReason);

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -33,7 +33,7 @@ public:
     // This enum must hold 256 or fewer packet types (so the value is <= 255) since it is statically typed as a uint8_t
     enum class Value : uint8_t {
         Unknown,
-        StunResponse,
+        DomainConnectRequestPending,
         DomainList,
         Ping,
         PingReply,
@@ -170,7 +170,7 @@ public:
 
     const static QSet<PacketTypeEnum::Value> getNonSourcedPackets() {
         const static QSet<PacketTypeEnum::Value> NON_SOURCED_PACKETS = QSet<PacketTypeEnum::Value>()
-            << PacketTypeEnum::Value::StunResponse << PacketTypeEnum::Value::CreateAssignment
+            << PacketTypeEnum::Value::DomainConnectRequestPending << PacketTypeEnum::Value::CreateAssignment
             << PacketTypeEnum::Value::RequestAssignment << PacketTypeEnum::Value::DomainServerRequireDTLS
             << PacketTypeEnum::Value::DomainConnectRequest << PacketTypeEnum::Value::DomainList
             << PacketTypeEnum::Value::DomainConnectionDenied << PacketTypeEnum::Value::DomainServerPathQuery

--- a/tools/dissectors/1-hfudt.lua
+++ b/tools/dissectors/1-hfudt.lua
@@ -53,7 +53,7 @@ local message_positions = {
 
 local packet_types = {
   [0] = "Unknown",
-  [1] = "StunResponse",
+  [1] = "DomainConnectRequestPending",
   [2] = "DomainList",
   [3] = "Ping",
   [4] = "PingReply",


### PR DESCRIPTION
Given the following:
- Any addition or removal of packet types will generally require a protocol bump.
- Adding a new packet type will add it to the end of the list (in PacketHeaders.h), taking the value one larger than the previous largest packet type
- Removing a packet type (in theory) will renumber all of the following packet types
- Detection of a protocol mismatch is done through PacketType "DomainConnectRequest", which has a Packet Type ID of 31.
- StunResponse (ID=1) is no longer in use (as of df47f1dd0bbfbfa54c51f5fa913c91c9d5851f14 )

Proposed:
- Rename StunResponse to DomainConnectRequestNew and have servers immediately begin treating it the same as DomainConnectRequest
- At some point swap the codes so interfaces will start using ID=1 to connect rather than ID=31
- This will permit removing packet type enums without disturbing the ID of the packet used to identify protocol bumps
