### PR TITLE
Send address and port with each metaverse heartbeat.

### DIFF
--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -2024,7 +2024,7 @@
           "default": ""
         },
         {
-          "name": "port",
+          "name": "network_port",
           "type": "int",
           "default": 0
         }

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -2014,6 +2014,23 @@
       ]
     },
     {
+      "name": "domain_server",
+      "label": "Setup Domain Server",
+      "restart": false,
+      "hidden": true,
+      "settings": [
+        {
+          "name": "network_address",
+          "default": ""
+        },
+        {
+          "name": "port",
+          "type": "int",
+          "default": 0
+        }
+      ]
+    },
+    {
       "name": "installed_content",
       "label": "Installed Content",
       "hidden": true,

--- a/domain-server/resources/web/js/shared.js
+++ b/domain-server/resources/web/js/shared.js
@@ -129,9 +129,10 @@ function getCurrentDomainIDType() {
     return DOMAIN_ID_TYPE_UNKNOWN;
   }
   if (DomainInfo !== null) {
-    if (DomainInfo.name !== undefined) {
-      return DOMAIN_ID_TYPE_TEMP;
-    }
+    // Disabled because detecting as temp domain... and we're not even using temp domains right now.
+    // if (DomainInfo.name !== undefined) {
+    //   return DOMAIN_ID_TYPE_TEMP;
+    // }
     return DOMAIN_ID_TYPE_FULL;
   }
   return DOMAIN_ID_TYPE_UNKNOWN;

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1507,18 +1507,19 @@ QJsonObject jsonForDomainSocketUpdate(const HifiSockAddr& socket) {
 }
 
 void DomainServer::performIPAddressPortUpdate(const HifiSockAddr& newPublicSockAddr) {
+    const QString& DOMAIN_SERVER_SETTINGS_KEY = "domain_server";
     const QString& publicSocketAddress = newPublicSockAddr.getAddress().toString();
     const int publicSocketPort = newPublicSockAddr.getPort();
 
     sendHeartbeatToMetaverse(publicSocketAddress, publicSocketPort);
 
-    QString newSettingsJSON = QString("{\"domain_server\": { \"%1\": \"%2\", \"%3\": %4}}")
-            .arg(PUBLIC_SOCKET_ADDRESS_KEY)
-            .arg(publicSocketAddress)
-            .arg(PUBLIC_SOCKET_PORT_KEY)
-            .arg(publicSocketPort);
-    auto settingsDocument = QJsonDocument::fromJson(newSettingsJSON.toUtf8());
-    _settingsManager.recurseJSONObjectAndOverwriteSettings(settingsDocument.object(), DomainSettings);
+    QJsonObject rootObject;
+    QJsonObject domainServerObject;
+    domainServerObject.insert(PUBLIC_SOCKET_ADDRESS_KEY, publicSocketAddress);
+    domainServerObject.insert(PUBLIC_SOCKET_PORT_KEY, publicSocketPort);
+    rootObject.insert(DOMAIN_SERVER_SETTINGS_KEY, domainServerObject);
+    QJsonDocument doc(rootObject);
+    _settingsManager.recurseJSONObjectAndOverwriteSettings(rootObject, DomainSettings);
 }
 
 void DomainServer::sendHeartbeatToMetaverse(const QString& networkAddress, const int port) {

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -68,6 +68,9 @@ Q_LOGGING_CATEGORY(domain_server_ice, "hifi.domain_server.ice")
 
 const QString ACCESS_TOKEN_KEY_PATH = "metaverse.access_token";
 const QString DomainServer::REPLACEMENT_FILE_EXTENSION = ".replace";
+const QString PUBLIC_SOCKET_ADDRESS_KEY = "network_address";
+const QString PUBLIC_SOCKET_PORT_KEY = "network_port";
+const QString DOMAIN_UPDATE_AUTOMATIC_NETWORKING_KEY = "automatic_networking";
 const int MIN_PORT = 1;
 const int MAX_PORT = 65535;
 
@@ -1503,11 +1506,7 @@ QJsonObject jsonForDomainSocketUpdate(const HifiSockAddr& socket) {
     return socketObject;
 }
 
-const QString DOMAIN_UPDATE_AUTOMATIC_NETWORKING_KEY = "automatic_networking";
-
 void DomainServer::performIPAddressPortUpdate(const HifiSockAddr& newPublicSockAddr) {
-    static const QString PUBLIC_SOCKET_ADDRESS_KEY = "network_address";
-    static const QString PUBLIC_SOCKET_PORT_KEY = "network_port";
     const QString& publicSocketAddress = newPublicSockAddr.getAddress().toString();
     const int publicSocketPort = newPublicSockAddr.getPort();
 
@@ -1531,9 +1530,6 @@ void DomainServer::sendHeartbeatToMetaverse(const QString& networkAddress, const
     domainObject[VERSION_KEY] = BuildInfo::VERSION;
     static const QString PROTOCOL_VERSION_KEY = "protocol";
     domainObject[PROTOCOL_VERSION_KEY] = protocolVersionsSignatureBase64();
-
-    static const QString PUBLIC_SOCKET_ADDRESS_KEY = "network_address";
-    static const QString PUBLIC_SOCKET_PORT_KEY = "network_port";
 
     static const QString NETWORK_ADDRESS_SETTINGS_KEY = "domain_server." + PUBLIC_SOCKET_ADDRESS_KEY;
     const QString networkAddressFromSettings = _settingsManager.valueForKeyPath(NETWORK_ADDRESS_SETTINGS_KEY).toString();

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -1507,7 +1507,7 @@ const QString DOMAIN_UPDATE_AUTOMATIC_NETWORKING_KEY = "automatic_networking";
 
 void DomainServer::performIPAddressPortUpdate(const HifiSockAddr& newPublicSockAddr) {
     static const QString PUBLIC_SOCKET_ADDRESS_KEY = "network_address";
-    static const QString PUBLIC_SOCKET_PORT_KEY = "port";
+    static const QString PUBLIC_SOCKET_PORT_KEY = "network_port";
     const QString& publicSocketAddress = newPublicSockAddr.getAddress().toString();
     const int publicSocketPort = newPublicSockAddr.getPort();
 
@@ -1533,7 +1533,7 @@ void DomainServer::sendHeartbeatToMetaverse(const QString& networkAddress, const
     domainObject[PROTOCOL_VERSION_KEY] = protocolVersionsSignatureBase64();
 
     static const QString PUBLIC_SOCKET_ADDRESS_KEY = "network_address";
-    static const QString PUBLIC_SOCKET_PORT_KEY = "port";
+    static const QString PUBLIC_SOCKET_PORT_KEY = "network_port";
 
     static const QString NETWORK_ADDRESS_SETTINGS_KEY = "domain_server." + PUBLIC_SOCKET_ADDRESS_KEY;
     const QString networkAddressFromSettings = _settingsManager.valueForKeyPath(NETWORK_ADDRESS_SETTINGS_KEY).toString();

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -901,14 +901,13 @@ void DomainServer::setupAutomaticNetworking() {
                 qDebug() << "domain-server" << _automaticNetworkingSetting << "automatic networking enabled for ID"
                     << uuidStringWithoutCurlyBraces(domainID) << "via" << _oauthProviderURL.toString();
 
+                auto nodeList = DependencyManager::get<LimitedNodeList>();
+
+                // send any public socket changes to the data server so nodes can find us at our new IP
+                connect(nodeList.data(), &LimitedNodeList::publicSockAddrChanged, this,
+                        &DomainServer::performIPAddressPortUpdate);
+
                 if (_automaticNetworkingSetting == IP_ONLY_AUTOMATIC_NETWORKING_VALUE) {
-
-                    auto nodeList = DependencyManager::get<LimitedNodeList>();
-
-                    // send any public socket changes to the data server so nodes can find us at our new IP
-                    connect(nodeList.data(), &LimitedNodeList::publicSockAddrChanged,
-                            this, &DomainServer::performIPAddressUpdate);
-
                     // have the LNL enable public socket updating via STUN
                     nodeList->startSTUNPublicSocketUpdate();
                 }
@@ -1506,7 +1505,7 @@ QJsonObject jsonForDomainSocketUpdate(const HifiSockAddr& socket) {
 
 const QString DOMAIN_UPDATE_AUTOMATIC_NETWORKING_KEY = "automatic_networking";
 
-void DomainServer::performIPAddressUpdate(const HifiSockAddr& newPublicSockAddr) {
+void DomainServer::performIPAddressPortUpdate(const HifiSockAddr& newPublicSockAddr) {
     static const QString PUBLIC_SOCKET_ADDRESS_KEY = "network_address";
     static const QString PUBLIC_SOCKET_PORT_KEY = "port";
     const QString& publicSocketAddress = newPublicSockAddr.getAddress().toString();

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -112,7 +112,7 @@ private slots:
     void setupPendingAssignmentCredits();
     void sendPendingTransactionsToServer();
 
-    void performIPAddressUpdate(const HifiSockAddr& newPublicSockAddr);
+    void performIPAddressPortUpdate(const HifiSockAddr& newPublicSockAddr);
     void sendHeartbeatToMetaverse() { sendHeartbeatToMetaverse(QString(), int()); }
     void sendHeartbeatToIceServer();
     void nodePingMonitor();

--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -113,7 +113,7 @@ private slots:
     void sendPendingTransactionsToServer();
 
     void performIPAddressUpdate(const HifiSockAddr& newPublicSockAddr);
-    void sendHeartbeatToMetaverse() { sendHeartbeatToMetaverse(QString()); }
+    void sendHeartbeatToMetaverse() { sendHeartbeatToMetaverse(QString(), int()); }
     void sendHeartbeatToIceServer();
     void nodePingMonitor();
 
@@ -176,7 +176,7 @@ private:
     void setupAutomaticNetworking();
     void setupICEHeartbeatForFullNetworking();
     void setupHeartbeatToMetaverse();
-    void sendHeartbeatToMetaverse(const QString& networkAddress);
+    void sendHeartbeatToMetaverse(const QString& networkAddress, const int port);
 
     void randomizeICEServerAddress(bool shouldTriggerHostLookup);
 

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -1197,7 +1197,7 @@ void LimitedNodeList::stopInitialSTUNUpdate(bool success) {
     }
 
     // We now setup a timer here to fire every so often to check that our IP address has not changed.
-    // Or, if we failed - if will check if we can eventually get a public socket
+    // Or, if we failed - it will check if we can eventually get a public socket
     const int STUN_IP_ADDRESS_CHECK_INTERVAL_MSECS = 10 * 1000;
 
     QTimer* stunOccasionalTimer = new QTimer { this };


### PR DESCRIPTION
This saves the IP and port to the domain server settings whenever a change is detected, then it will pull from settings to send these values in each metaverse heartbeat. It will also send one heartbeat at the time of a change in the IP address and port.

I believe that the bandwidth impact will be minimal for the domain-server side of things.

Also I believe I solved the bug where the automatic networking dropdown would not show.

The reason for this PR is because the metaverse server only gets an IP and port from the domain server in one packet and that is only when the domain server detects a change. If the metaverse server for any reason never got and saved that packet (through a bug or whatever) then the metaverse server will continue working with your Domain server and not have some vital information.