### PR TITLE
Add initial data export API.

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -251,6 +251,8 @@ public:
 
     void setActiveDisplayPlugin(const QString& pluginName);
 
+    void setInterfaceScriptDataPath(const QString& dataPath);
+
 #ifndef Q_OS_ANDROID
     FileLogger* getLogger() const { return _logger; }
 #endif
@@ -377,6 +379,7 @@ signals:
 
 public slots:
     QVector<EntityItemID> pasteEntities(const QString& entityHostType, float x, float y, float z);
+    bool exportData(const QString& dataString);
     bool exportEntities(const QString& filename, const QVector<QUuid>& entityIDs, const glm::vec3* givenOffset = nullptr);
     bool exportEntities(const QString& filename, float x, float y, float z, float scale);
     bool importEntities(const QString& url, const bool isObservable = true, const qint64 callerId = -1);
@@ -707,6 +710,8 @@ private:
     quint64 _lastSendDownstreamAudioStats;
 
     bool _notifiedPacketVersionMismatchThisDomain;
+
+    QString interfaceScriptDataPath;
 
     ConditionalGuard _settingsGuard;
 

--- a/interface/src/scripting/ClipboardScriptingInterface.cpp
+++ b/interface/src/scripting/ClipboardScriptingInterface.cpp
@@ -3,6 +3,7 @@
 //  interface/src/scripting
 //
 //  Copyright 2014 High Fidelity, Inc.
+//  Copyright 2020 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -23,6 +24,14 @@ glm::vec3 ClipboardScriptingInterface::getContentsDimensions() {
 
 float ClipboardScriptingInterface::getClipboardContentsLargestDimension() {
     return qApp->getEntityClipboard()->getContentsLargestDimension();
+}
+
+bool ClipboardScriptingInterface::exportData(const QString& dataString) {
+    bool retVal;
+    BLOCKING_INVOKE_METHOD(qApp, "exportData",
+                              Q_RETURN_ARG(bool, retVal),
+                              Q_ARG(const QString&, dataString));
+    return retVal;
 }
 
 bool ClipboardScriptingInterface::exportEntities(const QString& filename, const QVector<QUuid>& entityIDs) {

--- a/interface/src/scripting/ClipboardScriptingInterface.h
+++ b/interface/src/scripting/ClipboardScriptingInterface.h
@@ -3,6 +3,7 @@
 //  interface/src/scripting
 //
 //  Copyright 2014 High Fidelity, Inc.
+//  Copyright 2020 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -112,6 +113,15 @@ public:
     * @returns {boolean} <code>true</code> if entities were found and the file was written, otherwise <code>false</code>.
     */
     Q_INVOKABLE bool exportEntities(const QString& filename, float x, float y, float z, float scale);
+    
+    /**jsdoc
+    * Export a string of data to a file path previously set by Window.setInterfaceD
+    * @function Clipboard.exportData
+    * @variation 0
+    * @param {string} data - The string of data to export. (If exporting JSON, use JSON.stringify() first.)
+    * @returns {boolean} <code>true</code> if the file was written, otherwise <code>false</code>.
+    */
+    Q_INVOKABLE bool exportData(const QString& dataString);
 
     /**jsdoc
      * Pastes the contents of the clipboard into the domain.

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -330,6 +330,19 @@ QScriptValue WindowScriptingInterface::save(const QString& title, const QString&
 /// \param const QString& title title of the window
 /// \param const QString& directory directory to start the file browser at
 /// \param const QString& nameFilter filter to filter filenames by - see `QFileDialog`
+/// \return QScriptValue file path as a string if one was selected, otherwise `QScriptValue::NullValue`
+QScriptValue WindowScriptingInterface::setInterfaceScriptDataPath(const QString& title, const QString& directory, const QString& nameFilter) {
+    QScriptValue result = WindowScriptingInterface::save(title, directory, nameFilter);
+    QString resultString = result.toString();
+    qApp->setInterfaceScriptDataPath(resultString);
+    return resultString.isEmpty() ? QScriptValue::NullValue : result;
+}
+
+/// Display a save file dialog.  If `directory` is an invalid file or directory the browser will start at the current
+/// working directory.
+/// \param const QString& title title of the window
+/// \param const QString& directory directory to start the file browser at
+/// \param const QString& nameFilter filter to filter filenames by - see `QFileDialog`
 void WindowScriptingInterface::saveAsync(const QString& title, const QString& directory, const QString& nameFilter) {
     ensureReticleVisible();
     QString path = directory;
@@ -467,7 +480,7 @@ void WindowScriptingInterface::copyToClipboard(const QString& text) {
 
 
 bool WindowScriptingInterface::setDisplayTexture(const QString& name) {
-    return  qApp->getActiveDisplayPlugin()->setDisplayTexture(name);   // Plugins that don't know how, answer false.
+    return qApp->getActiveDisplayPlugin()->setDisplayTexture(name);   // Plugins that don't know how, answer false.
 }
 
 void WindowScriptingInterface::takeSnapshot(bool notify, bool includeAnimated, float aspectRatio, const QString& filename) {

--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -222,6 +222,24 @@ public slots:
     QScriptValue save(const QString& title = "", const QString& directory = "",  const QString& nameFilter = "");
 
     /**jsdoc
+     * Prompts the user to specify the path and name of a file to use as the script data path. Displays a modal dialog that navigates the directory
+     * tree and allows the user to type in a file name.
+     * @function Window.setInterfaceScriptDataPath
+     * @param {string} [title=""] - The title to display at the top of the dialog.
+     * @param {string} [directory=""] - The initial directory to start browsing at.
+     * @param {string} [nameFilter=""] - The types of files to display. Examples: <code>"*.json"</code> and
+     *     <code>"Images (*.png *.jpg *.svg)"</code>. All files are displayed if a filter isn't specified.
+     * @returns {string} The path and name of the file if one is specified, otherwise <code>null</code>. If a single file type
+     *     is specified in the nameFilter, that file type extension is automatically appended to the result when appropriate.
+     * @example <caption>Ask the user to specify a file to save to.</caption>
+     * var filename = Window.setInterfaceScriptDataPath("Save to JSON file", Paths.resources, "*.json");
+     * print("File: " + filename);
+     */
+    QScriptValue setInterfaceScriptDataPath(const QString& title = "",
+                                            const QString& directory = "",
+                                            const QString& nameFilter = "");
+
+    /**jsdoc
      * Prompts the user to specify the path and name of a file to save to. Displays a non-modal dialog that navigates the
      * directory tree and allows the user to type in a file name. A {@link Window.saveFileChanged|saveFileChanged} signal is
      * emitted when a file is specified; no signal is emitted if the user cancels the dialog.


### PR DESCRIPTION
This is an initial working version of a data export API for Interface scripts to use. It's a bit dangerous since it can of course write (or overwrite) files on the system of a specified name and path... so the way I set it up is that the actual path and filename can only be set by the user using a Qt/QML dialog. Once set, all scripts can write to that path.

I think what's missing still is a reset function to stop scripts from mucking with your export after you've completed it. 

Generation 2 should consist of: a per-app export API that allows you to set paths per-app that persist restarts. (this would of course have to use the private context in order to prevent scripts from altering the paths.)

Generation 3 should consist of: a per-app limited storage based on path+filename/URL+filename. Maybe a 512KB data limit would be good with mayhaps a permission dialog opening to say the app wants to have its own space to write to that sits in the Vircadia appData folder.