### PR TITLE
Fix 404 not found on hifi-scribe nvidia-texture-tools and etc2comp

### DIFF
--- a/cmake/ports/etc2comp/portfile.cmake
+++ b/cmake/ports/etc2comp/portfile.cmake
@@ -19,7 +19,7 @@ include(vcpkg_common_functions)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO kasenvr/etc2comp
+    REPO vircadia/etc2comp
     REF 7f1843bf07825c21cab711360c1ddbad04641036
     SHA512 d747076acda8537d39585858c793a35c3dcc9ef283d723619a47f8c81ec1454c95b3340ad35f0655a939eae5b8271c801c48a9a7568311a01903a344c44af25b
     HEAD_REF master

--- a/cmake/ports/hifi-scribe/portfile.cmake
+++ b/cmake/ports/hifi-scribe/portfile.cmake
@@ -3,7 +3,7 @@ include(vcpkg_common_functions)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO kasenvr/scribe
+    REPO vircadia/scribe
     REF 1bd638a36ca771e5a68d01985b6389b71835cbd2
     SHA512 dbe241d86df3912e544f6b9839873f9875df54efc93822b145e7b13243eaf2e3d690bc8a28b1e52d05bdcd7e68fca6b0b2f5c43ffd0f56a9b7a50d54dcf9e31e
     HEAD_REF master

--- a/cmake/ports/nvtt/portfile.cmake
+++ b/cmake/ports/nvtt/portfile.cmake
@@ -9,7 +9,7 @@ include(vcpkg_common_functions)
 
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
-    REPO kasenvr/nvidia-texture-tools
+    REPO vircadia/nvidia-texture-tools
     REF 330c4d56274a0f602a5c70596e2eb670a4ed56c2
     SHA512 4c0bc2f369120d696cc27710b6d33086b27eef55f537ec66b9a5c8b1839bc2426c0413670b0f65be52c5d353468f0126dfe024be1f0690611d4d7e33ac530127
     HEAD_REF master


### PR DESCRIPTION
This fixes cmake urls pointing to kasenvr instead of Vircadia and thous not being found.
I haven't noticed any other cmake stuff that still points to kasenvr.