### PR TITLE
Fix for spinner boxes not using the _step property of SpinnerPreference

### DIFF
--- a/interface/resources/qml/controlsUit/SpinBox.qml
+++ b/interface/resources/qml/controlsUit/SpinBox.qml
@@ -73,9 +73,9 @@ SpinBox {
         }
     }
 
-    stepSize: realStepSize * factor
-    to : realTo*factor
-    from : realFrom*factor
+    stepSize: Math.round(realStepSize * factor)
+    to : Math.round(realTo*factor)
+    from : Math.round(realFrom*factor)
 
     font.family: "Fira Sans SemiBold"
     font.pixelSize: hifi.fontSizes.textFieldInput

--- a/interface/resources/qml/controlsUit/SpinBox.qml
+++ b/interface/resources/qml/controlsUit/SpinBox.qml
@@ -97,11 +97,11 @@ SpinBox {
     }
 
     textFromValue: function(value, locale) {
-        return parseFloat(value / factor).toFixed(decimals);
+        return (value / factor).toFixed(decimals);
     }
 
     valueFromText: function(text, locale) {
-        return Number.fromLocaleString(locale, text) * factor;
+        return Math.round(Number.fromLocaleString(locale, text) * factor);
     }
 
 

--- a/interface/resources/qml/dialogs/preferences/SpinBoxPreference.qml
+++ b/interface/resources/qml/dialogs/preferences/SpinBoxPreference.qml
@@ -51,6 +51,7 @@ Preference {
             decimals: preference.decimals
             minimumValue: preference.min
             maximumValue: preference.max
+            realStepSize: preference.step
             width: 100
             anchors {
                 verticalCenter: parent.verticalCenter

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -465,8 +465,8 @@ void setupPreferences() {
         auto preference = new SpinnerPreference(VR_MOVEMENT, "User real-world height (meters)", getter, setter);
         preference->setMin(1.0f);
         preference->setMax(2.2f);
-        preference->setDecimals(3);
-        preference->setStep(0.001f);
+        preference->setDecimals(2);
+        preference->setStep(0.01);
         preferences->addPreference(preference);
     }
 

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -466,7 +466,7 @@ void setupPreferences() {
         preference->setMin(1.0f);
         preference->setMax(2.2f);
         preference->setDecimals(2);
-        preference->setStep(0.01);
+        preference->setStep(0.01f);
         preferences->addPreference(preference);
     }
 

--- a/libraries/shared/src/Preferences.h
+++ b/libraries/shared/src/Preferences.h
@@ -152,8 +152,8 @@ class FloatPreference : public Preference {
     Q_PROPERTY(float value READ getValue WRITE setValue NOTIFY valueChanged)
     Q_PROPERTY(float min READ getMin CONSTANT)
     Q_PROPERTY(float max READ getMax CONSTANT)
-    Q_PROPERTY(float step READ getStep CONSTANT)
-    Q_PROPERTY(float decimals READ getDecimals CONSTANT)
+    Q_PROPERTY(double step READ getStep CONSTANT)
+    Q_PROPERTY(uint decimals READ getDecimals CONSTANT)
 
 public:
     using Getter = std::function<float()>;
@@ -178,11 +178,11 @@ public:
     float getMax() const { return _max; }
     void setMax(float max) { _max = max; };
 
-    float getStep() const { return _step; }
-    void setStep(float step) { _step = step; };
+    double getStep() const { return _step; }
+    void setStep(double step) { _step = step; };
 
-    float getDecimals() const { return _decimals; }
-    void setDecimals(float decimals) { _decimals = decimals; };
+    uint getDecimals() const { return _decimals; }
+    void setDecimals(uint decimals) { _decimals = decimals; };
 
 signals:
     void valueChanged();
@@ -194,10 +194,10 @@ protected:
     const Getter _getter;
     const Setter _setter;
 
-    float _decimals { 0 };
+    uint _decimals { 0 };
     float _min { 0 };
     float _max { 1 };
-    float _step { 0.1f };
+    double _step { 0.1 };
 };
 
 class IntPreference : public Preference {

--- a/libraries/shared/src/Preferences.h
+++ b/libraries/shared/src/Preferences.h
@@ -152,7 +152,7 @@ class FloatPreference : public Preference {
     Q_PROPERTY(float value READ getValue WRITE setValue NOTIFY valueChanged)
     Q_PROPERTY(float min READ getMin CONSTANT)
     Q_PROPERTY(float max READ getMax CONSTANT)
-    Q_PROPERTY(double step READ getStep CONSTANT)
+    Q_PROPERTY(float step READ getStep CONSTANT)
     Q_PROPERTY(uint decimals READ getDecimals CONSTANT)
 
 public:
@@ -178,11 +178,11 @@ public:
     float getMax() const { return _max; }
     void setMax(float max) { _max = max; };
 
-    double getStep() const { return _step; }
-    void setStep(double step) { _step = step; };
+    float getStep() const { return _step; }
+    void setStep(float step) { _step = step; };
 
-    uint getDecimals() const { return _decimals; }
-    void setDecimals(uint decimals) { _decimals = decimals; };
+    float getDecimals() const { return _decimals; }
+    void setDecimals(float decimals) { _decimals = decimals; };
 
 signals:
     void valueChanged();
@@ -197,7 +197,7 @@ protected:
     uint _decimals { 0 };
     float _min { 0 };
     float _max { 1 };
-    double _step { 0.1 };
+    float _step { 0.1f };
 };
 
 class IntPreference : public Preference {

--- a/libraries/shared/src/Preferences.h
+++ b/libraries/shared/src/Preferences.h
@@ -197,7 +197,7 @@ protected:
     uint _decimals { 0 };
     float _min { 0 };
     float _max { 1 };
-    float _step { 0.1f };
+    float _step { 1 };
 };
 
 class IntPreference : public Preference {


### PR DESCRIPTION
This PR fixes spinner boxes changing their values in steps of 1.0 instead of the _step property specified in SpinnerPreference (fixes https://github.com/vircadia/vircadia/issues/117).

- In SpinBoxPreference.qml, SpinBox was missing `realStepSize: preference.step`.
- In SpinBox.qml SpinBox was missing Math.round for `step`, `to` and `from`, and in `valueFromText`.
- Changed FloatPreference::decimals (number of decimal places) from float to uint, because it seemed to make more sense.
- Changed the 'User real-world height' spinbox to use a resolution of 1cm (for display and step) rather than 1mm.