### PR TITLE
Skip repeated log entries

### DIFF
--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -64,6 +64,8 @@ LogHandler::LogHandler() {
             _shouldOutputThreadID = true;
         } else if (option == "milliseconds") {
             _shouldDisplayMilliseconds = true;
+        } else if (option == "keep_repeats") {
+            _keepRepeats = true;
         } else if (option != "") {
             fprintf(stdout, "Unrecognized option in VIRCADIA_LOG_OPTIONS: '%s'\n", option.toUtf8().constData());
         }
@@ -202,7 +204,18 @@ QString LogHandler::printMessage(LogMsgType type, const QMessageLogContext& cont
         resetColor = colorReset();
     }
 
-    fprintf(stdout, "%s%s%s", color, qPrintable(logMessage), resetColor);
+    if (_keepRepeats || _previousMessage != message) {
+        if (_repeatCount > 0) {
+            fprintf(stdout, "[Previous message was repeated %i times]\n", _repeatCount);
+        }
+
+        fprintf(stdout, "%s%s%s", color, qPrintable(logMessage), resetColor);
+        _repeatCount = 0;
+    } else {
+        _repeatCount++;
+    }
+
+    _previousMessage = message;
 #ifdef Q_OS_WIN
     // On windows, this will output log lines into the Visual Studio "output" tab
     OutputDebugStringA(qPrintable(logMessage));

--- a/libraries/shared/src/LogHandler.h
+++ b/libraries/shared/src/LogHandler.h
@@ -67,6 +67,11 @@ private:
     bool _shouldOutputThreadID { false };
     bool _shouldDisplayMilliseconds { false };
     bool _useColor { false };
+    bool _keepRepeats { false };
+
+    QString _previousMessage;
+    int _repeatCount { 0 };
+
 
     int _currentMessageID { 0 };
     struct RepeatedMessageRecord {


### PR DESCRIPTION
This helps with log flooding. Successive repeated log messages will be skipped and counted, the count will be output when a different message is logged.    

A new option of 'keep_repeats' has been added to `VIRCADIA_LOG_OPTIONS` to disable this.

Fixes #934 