### PR TITLE
Avatar auto scale: match avatar eye height to user eye height.

### DIFF
--- a/interface/resources/qml/hifi/avatarapp/Settings.qml
+++ b/interface/resources/qml/hifi/avatarapp/Settings.qml
@@ -178,6 +178,12 @@ Rectangle {
                     Layout.alignment: Qt.AlignVCenter
                 }
             }
+        }
+
+        RowLayout {
+            id: avatarScaleButtonsRow
+            anchors.top: avatarScaleRow.bottom
+            anchors.topMargin: 0
 
             ShadowRectangle {
                 width: 37
@@ -203,7 +209,43 @@ Rectangle {
                 MouseArea {
                     anchors.fill: parent
                     onClicked: {
-                        scaleSlider.value = 10
+                        scaleSlider.notify = false;
+                        scaleSlider.value = 10;
+                        scaleSlider.notify = true;
+                        root.scaleChanged(1.0);
+                    }
+                }
+            }
+
+            ShadowRectangle {
+                width: 50
+                height: 28
+                AvatarAppStyle {
+                    id: style2
+                }
+
+                gradient: Gradient {
+                    GradientStop { position: 0.0; color: style2.colors.blueHighlight }
+                    GradientStop { position: 1.0; color: style2.colors.blueAccent }
+                }
+
+                radius: 3
+
+                RalewaySemiBold {
+                    color: 'white'
+                    anchors.centerIn: parent
+                    text: "Auto"
+                    size: 18
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    onClicked: {
+                        scaleValue = MyAvatar.getAutoAvatarScale();
+                        scaleSlider.notify = false;
+                        scaleSlider.value = Math.round(scaleValue * 10);
+                        scaleSlider.notify = true;
+                        root.scaleChanged(scaleValue);
                     }
                 }
             }

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -4566,6 +4566,13 @@ float MyAvatar::getAvatarScale() {
     return getTargetScale();
 }
 
+// Gets the scale for the avatar that makes the avatar's eye height match the user's real-world eye height
+// (derived from the 'User real world height' setting).
+float MyAvatar::getAutoAvatarScale() const
+{
+    return getUserEyeHeight() / getUnscaledEyeHeight();
+}
+
 void MyAvatar::setAvatarScale(float val) {
 
     if (QThread::currentThread() != thread()) {

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1599,6 +1599,14 @@ public:
     Q_INVOKABLE float getAvatarScale();
 
     /**jsdoc
+     * Gets the scale for the avatar that makes the avatar's eye height match the user's real-world eye height (derived from
+     * the 'User real world height' setting).
+     * @function MyAvatar.getAutoAvatarScale
+     * @returns {number} The scale for the avatar that makes the avatar's eye height match the user's real-world eye height.
+     */
+    Q_INVOKABLE float getAutoAvatarScale() const;
+
+    /**jsdoc
      * Sets the target scale of the avatar. The target scale is the desired scale of the avatar without any restrictions on 
      * permissible scale values imposed by the domain. 
      * @function MyAvatar.setAvatarScale


### PR DESCRIPTION
This PR adds an 'Auto' button to the avatar scale slider.  The Auto button scales the avatar so that its eye height matches the user's real-world eye height (based on the 'User real world height' setting).  In this way, the world is displayed at exactly 100% scale to the user in VR (fixes https://github.com/vircadia/vircadia/issues/939).

### Tests done

- In VR, kneel to position your head as if you were 1m tall.
- Set 'User real-world height' to 1m (in Settings > Controls).
- Open the Avatar app and choose the default avatar, or one with a height similar to the default avatar.
- Click on the sliders icon at the top-right.
- Click the '1x' scale button and observe that the world is miniaturised.
- Click the 'Auto' scale button and observe that the world is displayed at actual size.

### Screenshots

![image](https://user-images.githubusercontent.com/35943148/103225042-0b619a80-48f7-11eb-99f5-cb59e3a1ab7f.png)