### PR TITLE
Possible fix for bad physics performance

### DIFF
--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -189,9 +189,6 @@ void RenderableModelEntityItem::updateModelBounds() {
         glm::vec3 scale = model->getScale();
         model->setUseDualQuaternionSkinning(!isNonUniformScale(scale));
         model->updateRenderItems();
-
-        markDirtyFlags(Simulation::DIRTY_SHAPE | Simulation::DIRTY_MASS);
-        locationChanged();
     }
 }
 
@@ -1267,6 +1264,9 @@ void ModelEntityRenderer::doRenderUpdateAsynchronousTyped(const TypedEntityPoint
                 entity->_originalTexturesRead = false;
                 entity->_needsJointSimulation = true;
                 entity->_needsToRescaleModel = true;
+
+                entity->markDirtyFlags(Simulation::DIRTY_SHAPE | Simulation::DIRTY_MASS);
+                entity->locationChanged();
                 emit requestRenderUpdate();
             });
             scene->enqueueTransaction(transaction);


### PR DESCRIPTION
fixes #941 

caused by https://github.com/vircadia/vircadia/pull/830

Test plan:
- To test the model dimensions/collision bug fix, run this script: https://gist.githubusercontent.com/HifiExperiments/5b3a0207e222546b27ed182244a6861a/raw/cce164f967f7632cdccc845b75028e64ee1ef4ce/ModelTest.js
- turn on Show Bullet Collisions in Developer -> Physics
- Press `o` to toggle the modelURL. Verify that the dimensions and the collision shape are correct.
- for both models, confirm that modifying the dimensions/position/etc correctly updates the bullet physics