### PR TITLE
Fix crashes when running with QML disabled in VR

### DIFF
--- a/interface/src/AboutUtil.cpp
+++ b/interface/src/AboutUtil.cpp
@@ -57,15 +57,15 @@ void AboutUtil::openUrl(const QString& url) const {
 
     auto tablet = DependencyManager::get<TabletScriptingInterface>()->getTablet("com.highfidelity.interface.tablet.system");
     auto hmd = DependencyManager::get<HMDScriptingInterface>();
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    auto offscreenUI = DependencyManager::get<OffscreenUi>();
 
-    if (tablet->getToolbarMode()) {
-        offscreenUi->load("Browser.qml", [=](QQmlContext* context, QObject* newObject) {
+    if (tablet->getToolbarMode() && offscreenUI) {
+        offscreenUI->load("Browser.qml", [=](QQmlContext* context, QObject* newObject) {
             newObject->setProperty("url", url);
         });
     } else {
-        if (!hmd->getShouldShowTablet() && !qApp->isHMDMode()) {
-            offscreenUi->load("Browser.qml", [=](QQmlContext* context, QObject* newObject) {
+        if (!hmd->getShouldShowTablet() && !qApp->isHMDMode() && offscreenUI) {
+            offscreenUI->load("Browser.qml", [=](QQmlContext* context, QObject* newObject) {
                 newObject->setProperty("url", url);
             });
         } else {

--- a/interface/src/Bookmarks.cpp
+++ b/interface/src/Bookmarks.cpp
@@ -61,7 +61,6 @@ void Bookmarks::deleteBookmark(const QString& bookmarkName) {
 void Bookmarks::addBookmarkToFile(const QString& bookmarkName, const QVariant& bookmark) {
     Menu* menubar = Menu::getInstance();
     if (contains(bookmarkName)) {
-        auto offscreenUi = DependencyManager::get<OffscreenUi>();
         ModalDialogListener* dlg = OffscreenUi::asyncWarning("Duplicate Bookmark",
                                   "The bookmark name you entered already exists in your list.",
                                   QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);

--- a/interface/src/avatar/AvatarPackager.cpp
+++ b/interface/src/avatar/AvatarPackager.cpp
@@ -58,7 +58,9 @@ bool AvatarPackager::open() {
 
     if (tablet->getToolbarMode()) {
         static const QUrl url{ "hifi/AvatarPackagerWindow.qml" };
-        DependencyManager::get<OffscreenUi>()->show(url, "AvatarPackager", packageModelDialogCreated);
+        if (auto offscreenUI = DependencyManager::get<OffscreenUi>()) {
+            offscreenUI->show(url, "AvatarPackager", packageModelDialogCreated);
+        }
         return true;
     }
 

--- a/interface/src/scripting/AssetMappingsScriptingInterface.cpp
+++ b/interface/src/scripting/AssetMappingsScriptingInterface.cpp
@@ -77,6 +77,11 @@ void AssetMappingsScriptingInterface::uploadFile(QString path, QString mapping, 
         "Specifying a new folder name will automatically create that folder for you.";
 
     auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    if (!offscreenUi) {
+        completedCallback.call({ -1 });
+        return;
+    }
+
     auto result = offscreenUi->inputDialog(OffscreenUi::ICON_INFORMATION, "Specify Asset Path",
                                            dropEvent ? dropHelpText : helpText, mapping);
 

--- a/interface/src/scripting/AssetMappingsScriptingInterface.cpp
+++ b/interface/src/scripting/AssetMappingsScriptingInterface.cpp
@@ -76,8 +76,8 @@ void AssetMappingsScriptingInterface::uploadFile(QString path, QString mapping, 
         "Use the field below to place your file in a specific folder or to rename it. "
         "Specifying a new folder name will automatically create that folder for you.";
 
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
-    if (!offscreenUi) {
+    auto offscreenUI = DependencyManager::get<OffscreenUi>();
+    if (!offscreenUI) {
         completedCallback.call({ -1 });
         return;
     }

--- a/interface/src/scripting/AssetMappingsScriptingInterface.cpp
+++ b/interface/src/scripting/AssetMappingsScriptingInterface.cpp
@@ -82,7 +82,7 @@ void AssetMappingsScriptingInterface::uploadFile(QString path, QString mapping, 
         return;
     }
 
-    auto result = offscreenUi->inputDialog(OffscreenUi::ICON_INFORMATION, "Specify Asset Path",
+    auto result = offscreenUI->inputDialog(OffscreenUi::ICON_INFORMATION, "Specify Asset Path",
                                            dropEvent ? dropHelpText : helpText, mapping);
 
     if (!result.isValid() || result.toString() == "") {
@@ -99,7 +99,7 @@ void AssetMappingsScriptingInterface::uploadFile(QString path, QString mapping, 
     // Check for override
     if (isKnownMapping(mapping)) {
         auto message = mapping + "\n" + "This file already exists. Do you want to overwrite it?";
-        auto button = offscreenUi->messageBox(OffscreenUi::ICON_QUESTION, "Overwrite File", message,
+        auto button = offscreenUI->messageBox(OffscreenUi::ICON_QUESTION, "Overwrite File", message,
                                               QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
         if (button == QMessageBox::No) {
             completedCallback.call({ -1 });

--- a/interface/src/scripting/DesktopScriptingInterface.cpp
+++ b/interface/src/scripting/DesktopScriptingInterface.cpp
@@ -99,11 +99,16 @@ void DesktopScriptingInterface::setHUDAlpha(float alpha) {
 }
 
 void DesktopScriptingInterface::show(const QString& path, const QString&  title) {
+    auto offscreenUI = DependencyManager::get<OffscreenUi>();
+    if (!offscreenUI) {
+        return;
+    }
+
     if (QThread::currentThread() != thread()) {
         QMetaObject::invokeMethod(this, "show", Qt::QueuedConnection, Q_ARG(QString, path), Q_ARG(QString, title));
         return;
     }
-    DependencyManager::get<OffscreenUi>()->show(path, title);
+    offscreenUI->show(path, title);
 }
 
 InteractiveWindowPointer DesktopScriptingInterface::createWindow(const QString& sourceUrl, const QVariantMap& properties) {

--- a/interface/src/scripting/HMDScriptingInterface.cpp
+++ b/interface/src/scripting/HMDScriptingInterface.cpp
@@ -96,8 +96,9 @@ bool HMDScriptingInterface::shouldShowHandControllers() const {
 
 void HMDScriptingInterface::activateHMDHandMouse() {
     QWriteLocker lock(&_hmdHandMouseLock);
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
-    offscreenUi->getDesktop()->setProperty("hmdHandMouseActive", true);
+    if (auto offscreenUI = DependencyManager::get<OffscreenUi>()) {
+        offscreenUI->getDesktop()->setProperty("hmdHandMouseActive", true);
+    }
     _hmdHandMouseCount++;
 }
 
@@ -105,8 +106,9 @@ void HMDScriptingInterface::deactivateHMDHandMouse() {
     QWriteLocker lock(&_hmdHandMouseLock);
     _hmdHandMouseCount = std::max(_hmdHandMouseCount - 1, 0);
     if (_hmdHandMouseCount == 0) {
-        auto offscreenUi = DependencyManager::get<OffscreenUi>();
-        offscreenUi->getDesktop()->setProperty("hmdHandMouseActive", false);
+        if (auto offscreenUI = DependencyManager::get<OffscreenUi>()) {
+            offscreenUI->getDesktop()->setProperty("hmdHandMouseActive", false);
+        }
     }
 }
 

--- a/interface/src/ui/ApplicationOverlay.cpp
+++ b/interface/src/ui/ApplicationOverlay.cpp
@@ -100,10 +100,10 @@ void ApplicationOverlay::renderQmlUi(RenderArgs* renderArgs) {
     // threads, we need to use a sync object to deteremine when
     // the current UI texture is no longer being read from, and only
     // then release it back to the UI for re-use
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    auto offscreenUI = DependencyManager::get<OffscreenUi>();
 
     OffscreenQmlSurface::TextureAndFence newTextureAndFence;
-    bool newTextureAvailable = offscreenUi->fetchTexture(newTextureAndFence);
+    bool newTextureAvailable = offscreenUI ? offscreenUI->fetchTexture(newTextureAndFence) : false;
     if (newTextureAvailable) {
         _uiTexture->setExternalTexture(newTextureAndFence.first, newTextureAndFence.second);
     }

--- a/interface/src/ui/InteractiveWindow.cpp
+++ b/interface/src/ui/InteractiveWindow.cpp
@@ -362,10 +362,11 @@ InteractiveWindow::InteractiveWindow(const QString& sourceUrl, const QVariantMap
             object->setObjectName("InteractiveWindow");
             object->setProperty(SOURCE_PROPERTY, sourceURL);
         };
-        auto offscreenUi = DependencyManager::get<OffscreenUi>();
 
-        // Build the event bridge and wrapper on the main thread
-        offscreenUi->loadInNewContext(CONTENT_WINDOW_QML, objectInitLambda, contextInitLambda);
+        if (auto offscreenUi = DependencyManager::get<OffscreenUi>()) {
+            // Build the event bridge and wrapper on the main thread
+            offscreenUi->loadInNewContext(CONTENT_WINDOW_QML, objectInitLambda, contextInitLambda);
+        }
     }
 }
 

--- a/interface/src/ui/InteractiveWindow.cpp
+++ b/interface/src/ui/InteractiveWindow.cpp
@@ -363,9 +363,9 @@ InteractiveWindow::InteractiveWindow(const QString& sourceUrl, const QVariantMap
             object->setProperty(SOURCE_PROPERTY, sourceURL);
         };
 
-        if (auto offscreenUi = DependencyManager::get<OffscreenUi>()) {
+        if (auto offscreenUI = DependencyManager::get<OffscreenUi>()) {
             // Build the event bridge and wrapper on the main thread
-            offscreenUi->loadInNewContext(CONTENT_WINDOW_QML, objectInitLambda, contextInitLambda);
+            offscreenUI->loadInNewContext(CONTENT_WINDOW_QML, objectInitLambda, contextInitLambda);
         }
     }
 }

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -1212,8 +1212,8 @@ float Overlays::width() {
         return result;
     }
 
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
-    return offscreenUi->getWindow()->size().width();
+    auto offscreenUI = DependencyManager::get<OffscreenUi>();
+    return offscreenUI ? offscreenUI->getWindow()->size().width() : -1.0f;
 }
 
 float Overlays::height() {
@@ -1224,8 +1224,8 @@ float Overlays::height() {
         return result;
     }
 
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
-    return offscreenUi->getWindow()->size().height();
+    auto offscreenUI = DependencyManager::get<OffscreenUi>();
+    return offscreenUI ? offscreenUI->getWindow()->size().height() : -1.0f;
 }
 
 void Overlays::mousePressOnPointerEvent(const QUuid& id, const PointerEvent& event) {

--- a/interface/src/ui/overlays/QmlOverlay.cpp
+++ b/interface/src/ui/overlays/QmlOverlay.cpp
@@ -24,13 +24,17 @@ QmlOverlay::QmlOverlay(const QUrl& url, const QmlOverlay* overlay)
 }
 
 void QmlOverlay::buildQmlElement(const QUrl& url) {
+    auto offscreenUI = DependencyManager::get<OffscreenUi>();
+    if (!offscreenUI) {
+        return;
+    }
+
     if (QThread::currentThread() != thread()) {
         QMetaObject::invokeMethod(this, "buildQmlElement", Q_ARG(QUrl, url));
         return;
     }
 
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
-    offscreenUi->load(url, [=](QQmlContext* context, QObject* object) {
+    offscreenUI->load(url, [=](QQmlContext* context, QObject* object) {
         _qmlElement = dynamic_cast<QQuickItem*>(object);
         connect(_qmlElement, &QObject::destroyed, this, &QmlOverlay::qmlElementDestroyed);
     });

--- a/libraries/ui/src/DockWidget.cpp
+++ b/libraries/ui/src/DockWidget.cpp
@@ -26,14 +26,15 @@ static void quickViewDeleter(QQuickView* quickView) {
 }
 
 DockWidget::DockWidget(const QString& title, QWidget* parent) : QDockWidget(title, parent) {
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
-    auto qmlEngine = offscreenUi->getSurfaceContext()->engine();
-    _quickView = std::shared_ptr<QQuickView>(new QQuickView(qmlEngine, nullptr), quickViewDeleter);
-    _quickView->setFormat(getDefaultOpenGLSurfaceFormat());
-    QWidget* widget = QWidget::createWindowContainer(_quickView.get());
-    setWidget(widget);
-    QWidget* headerWidget = new QWidget();
-    setTitleBarWidget(headerWidget);
+    if (auto offscreenUI = DependencyManager::get<OffscreenUi>()) {
+        auto qmlEngine = offscreenUI->getSurfaceContext()->engine();
+        _quickView = std::shared_ptr<QQuickView>(new QQuickView(qmlEngine, nullptr), quickViewDeleter);
+        _quickView->setFormat(getDefaultOpenGLSurfaceFormat());
+        QWidget* widget = QWidget::createWindowContainer(_quickView.get());
+        setWidget(widget);
+        QWidget* headerWidget = new QWidget();
+        setTitleBarWidget(headerWidget);
+    }
 }
 
 void DockWidget::setSource(const QUrl& url) {

--- a/libraries/ui/src/InfoView.cpp
+++ b/libraries/ui/src/InfoView.cpp
@@ -65,17 +65,18 @@ void InfoView::show(const QString& path, bool firstOrChangedOnly, QString urlQue
         }
         infoVersion.set(version);
     }
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
-    QString infoViewName(NAME + "_" + path);
-    offscreenUi->show(QML, NAME + "_" + path, [=](QQmlContext* context, QObject* newObject){
-        QQuickItem* item = dynamic_cast<QQuickItem*>(newObject);
-        item->setWidth(1024);
-        item->setHeight(720);
-        InfoView* newInfoView = newObject->findChild<InfoView*>();
-        Q_ASSERT(newInfoView);
-        newInfoView->parent()->setObjectName(infoViewName);
-        newInfoView->setUrl(url);
-    });
+    if (auto offscreenUI = DependencyManager::get<OffscreenUi>()) {
+        QString infoViewName(NAME + "_" + path);
+        offscreenUI->show(QML, NAME + "_" + path, [=](QQmlContext* context, QObject* newObject){
+            QQuickItem* item = dynamic_cast<QQuickItem*>(newObject);
+            item->setWidth(1024);
+            item->setHeight(720);
+            InfoView* newInfoView = newObject->findChild<InfoView*>();
+            Q_ASSERT(newInfoView);
+            newInfoView->parent()->setObjectName(infoViewName);
+            newInfoView->setUrl(url);
+        });
+    }
 }
 
 QUrl InfoView::url() {

--- a/libraries/ui/src/InfoView.cpp
+++ b/libraries/ui/src/InfoView.cpp
@@ -67,7 +67,7 @@ void InfoView::show(const QString& path, bool firstOrChangedOnly, QString urlQue
     }
     if (auto offscreenUI = DependencyManager::get<OffscreenUi>()) {
         QString infoViewName(NAME + "_" + path);
-        offscreenUI->show(QML, NAME + "_" + path, [=](QQmlContext* context, QObject* newObject){
+        offscreenUI->show(QML, NAME + "_" + path, [=] (QQmlContext* context, QObject* newObject) {
             QQuickItem* item = dynamic_cast<QQuickItem*>(newObject);
             item->setWidth(1024);
             item->setHeight(720);

--- a/libraries/ui/src/OffscreenQmlElement.h
+++ b/libraries/ui/src/OffscreenQmlElement.h
@@ -53,25 +53,30 @@ private:
     } \
     \
     void x::show(std::function<void(QQmlContext*, QObject*)> f) { \
-        auto offscreenUi = DependencyManager::get<OffscreenUi>(); \
+        auto offscreenUI = DependencyManager::get<OffscreenUi>(); \
         if (!registered) { \
             x::registerType(); \
         } \
-        offscreenUi->show(QML, NAME, f); \
+        if (offscreenUI) { \
+            offscreenUI->show(QML, NAME, f); \
+        } \
     } \
     \
     void x::hide() { \
-        auto offscreenUi = DependencyManager::get<OffscreenUi>(); \
-        offscreenUi->hide(NAME); \
+        if (auto offscreenUI = DependencyManager::get<OffscreenUi>()) { \
+            offscreenUI->hide(NAME); \
+        } \
     } \
     \
     void x::toggle(std::function<void(QQmlContext*, QObject*)> f) { \
-        auto offscreenUi = DependencyManager::get<OffscreenUi>(); \
-        offscreenUi->toggle(QML, NAME, f); \
+        if (auto offscreenUI = DependencyManager::get<OffscreenUi>()) { \
+            offscreenUI->toggle(QML, NAME, f); \
+        } \
     } \
     void x::load(std::function<void(QQmlContext*, QObject*)> f) { \
-        auto offscreenUi = DependencyManager::get<OffscreenUi>(); \
-        offscreenUi->load(QML, f); \
+        if (auto offscreenUI = DependencyManager::get<OffscreenUi>()) { \
+            offscreenUI->load(QML, f); \
+        } \
     }
 
 #define HIFI_QML_DEF_LAMBDA(x, f) \
@@ -82,21 +87,25 @@ private:
         qmlRegisterType<x>("Hifi", 1, 0, NAME.toLocal8Bit().constData()); \
     } \
     void x::show() { \
-        auto offscreenUi = DependencyManager::get<OffscreenUi>(); \
-        offscreenUi->show(QML, NAME, f); \
+        if (auto offscreenUI = DependencyManager::get<OffscreenUi>()) { \
+            offscreenUI->show(QML, NAME, f); \
+        } \
     } \
     void x::hide() { \
-        auto offscreenUi = DependencyManager::get<OffscreenUi>(); \
-        offscreenUi->hide(NAME); \
+        if (auto offscreenUI = DependencyManager::get<OffscreenUi>()) { \
+            offscreenUI->hide(NAME); \
+        } \
     } \
     \
     void x::toggle() { \
-        auto offscreenUi = DependencyManager::get<OffscreenUi>(); \
-        offscreenUi->toggle(QML, NAME, f); \
+        if (auto offscreenUI = DependencyManager::get<OffscreenUi>()) { \
+            offscreenUI->toggle(QML, NAME, f); \
+        } \
     } \
     void x::load() { \
-        auto offscreenUi = DependencyManager::get<OffscreenUi>(); \
-        offscreenUi->load(QML, f); \
+        if (auto offscreenUI = DependencyManager::get<OffscreenUi>()) { \
+            offscreenUI->load(QML, f); \
+        } \
     }
 
 #endif

--- a/libraries/ui/src/OffscreenUi.cpp
+++ b/libraries/ui/src/OffscreenUi.cpp
@@ -189,10 +189,12 @@ void OffscreenUi::show(const QUrl& url, const QString& name, std::function<void(
 }
 
 void OffscreenUi::hideDesktopWindows() {
-    if (QThread::currentThread() != thread()) {
-        BLOCKING_INVOKE_METHOD(this, "hideDesktopWindows");
+    if (_desktop) {
+        if (QThread::currentThread() != thread()) {
+            BLOCKING_INVOKE_METHOD(this, "hideDesktopWindows");
+        }
+        QMetaObject::invokeMethod(_desktop, "hideDesktopWindows");
     }
-    QMetaObject::invokeMethod(_desktop, "hideDesktopWindows");
 }
 
 void OffscreenUi::toggle(const QUrl& url, const QString& name, std::function<void(QQmlContext*, QObject*)> f) {
@@ -208,11 +210,14 @@ void OffscreenUi::toggle(const QUrl& url, const QString& name, std::function<voi
 }
 
 bool OffscreenUi::isPointOnDesktopWindow(QVariant point) {
-    QVariant result;
-    BLOCKING_INVOKE_METHOD(_desktop, "isPointOnWindow",
-                           Q_RETURN_ARG(QVariant, result),
-                           Q_ARG(QVariant, point));
-    return result.toBool();
+    if (_desktop) {
+        QVariant result;
+        BLOCKING_INVOKE_METHOD(_desktop, "isPointOnWindow",
+                               Q_RETURN_ARG(QVariant, result),
+                               Q_ARG(QVariant, point));
+        return result.toBool();
+    }
+    return false;
 }
 
 void OffscreenUi::hide(const QString& name) {
@@ -226,12 +231,14 @@ void OffscreenUi::hide(const QString& name) {
 }
 
 bool OffscreenUi::isVisible(const QString& name) {
-    QQuickItem* item = getRootItem()->findChild<QQuickItem*>(name);
-    if (item) {
-        return QQmlProperty(item, OFFSCREEN_VISIBILITY_PROPERTY).read().toBool();
-    } else {
-        return false;
+    auto rootItem = getRootItem();
+    if (rootItem) {
+        QQuickItem* item = rootItem->findChild<QQuickItem*>(name);
+        if (item) {
+            return QQmlProperty(item, OFFSCREEN_VISIBILITY_PROPERTY).read().toBool();
+        }
     }
+    return false;
 }
 
 class MessageBoxListener : public ModalDialogListener {
@@ -280,12 +287,11 @@ QQuickItem* OffscreenUi::createMessageBox(Icon icon, const QString& title, const
     bool invokeResult;
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
     TabletProxy* tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
-    if (tablet->getToolbarMode()) {
+    if (tablet->getToolbarMode() && _desktop) {
        invokeResult =  QMetaObject::invokeMethod(_desktop, "messageBox",
                                   Q_RETURN_ARG(QVariant, result),
                                   Q_ARG(QVariant, QVariant::fromValue(map)));
-    } else {
-        QQuickItem* tabletRoot = tablet->getTabletRoot();
+    } else if (QQuickItem* tabletRoot = tablet->getTabletRoot()) {
         invokeResult =  QMetaObject::invokeMethod(tabletRoot, "messageBox",
                                                   Q_RETURN_ARG(QVariant, result),
                                                   Q_ARG(QVariant, QVariant::fromValue(map)));
@@ -533,21 +539,21 @@ ModalDialogListener* OffscreenUi::customInputDialogAsync(const Icon icon, const 
 }
 
 void OffscreenUi::togglePinned() {
-    bool invokeResult = QMetaObject::invokeMethod(_desktop, "togglePinned");
+    bool invokeResult = _desktop && QMetaObject::invokeMethod(_desktop, "togglePinned");
     if (!invokeResult) {
         qWarning() << "Failed to toggle window visibility";
     }
 }
 
 void OffscreenUi::setPinned(bool pinned) {
-    bool invokeResult = QMetaObject::invokeMethod(_desktop, "setPinned", Q_ARG(QVariant, pinned));
+    bool invokeResult = _desktop && QMetaObject::invokeMethod(_desktop, "setPinned", Q_ARG(QVariant, pinned));
     if (!invokeResult) {
         qWarning() << "Failed to set window visibility";
     }
 }
 
 void OffscreenUi::setConstrainToolbarToCenterX(bool constrained) {
-    bool invokeResult = QMetaObject::invokeMethod(_desktop, "setConstrainToolbarToCenterX", Q_ARG(QVariant, constrained));
+    bool invokeResult = _desktop && QMetaObject::invokeMethod(_desktop, "setConstrainToolbarToCenterX", Q_ARG(QVariant, constrained));
     if (!invokeResult) {
         qWarning() << "Failed to set toolbar constraint";
     }
@@ -575,17 +581,17 @@ QQuickItem* OffscreenUi::createInputDialog(const Icon icon, const QString& title
     TabletProxy* tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
 
     bool invokeResult;
-    if (tablet->getToolbarMode()) {
+    if (tablet->getToolbarMode() && _desktop) {
         invokeResult = QMetaObject::invokeMethod(_desktop, "inputDialog",
                                                  Q_RETURN_ARG(QVariant, result),
                                                  Q_ARG(QVariant, QVariant::fromValue(map)));
-    } else {
-        QQuickItem* tabletRoot = tablet->getTabletRoot();
+    } else if (QQuickItem* tabletRoot = tablet->getTabletRoot()) {
         invokeResult = QMetaObject::invokeMethod(tabletRoot, "inputDialog",
                                                  Q_RETURN_ARG(QVariant, result),
                                                  Q_ARG(QVariant, QVariant::fromValue(map)));
         emit tabletScriptingInterface->tabletNotification();
     }
+
     if (!invokeResult) {
         qWarning() << "Failed to create message box";
         return nullptr;
@@ -603,12 +609,11 @@ QQuickItem* OffscreenUi::createCustomInputDialog(const Icon icon, const QString&
     TabletProxy* tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
 
     bool invokeResult;
-    if (tablet->getToolbarMode()) {
+    if (tablet->getToolbarMode() && _desktop) {
         invokeResult = QMetaObject::invokeMethod(_desktop, "inputDialog",
                                                  Q_RETURN_ARG(QVariant, result),
                                                  Q_ARG(QVariant, QVariant::fromValue(map)));
-    } else {
-        QQuickItem* tabletRoot = tablet->getTabletRoot();
+    } else if (QQuickItem* tabletRoot = tablet->getTabletRoot()) {
         invokeResult = QMetaObject::invokeMethod(tabletRoot, "inputDialog",
                                                  Q_RETURN_ARG(QVariant, result),
                                                  Q_ARG(QVariant, QVariant::fromValue(map)));
@@ -718,7 +723,7 @@ QObject* OffscreenUi::getRootMenu() {
 }
 
 void OffscreenUi::unfocusWindows() {
-    bool invokeResult = QMetaObject::invokeMethod(_desktop, "unfocusWindows");
+    bool invokeResult = _desktop && QMetaObject::invokeMethod(_desktop, "unfocusWindows");
     Q_ASSERT(invokeResult);
 }
 
@@ -752,12 +757,11 @@ QString OffscreenUi::fileDialog(const QVariantMap& properties) {
     bool invokeResult;
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
     TabletProxy* tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
-    if (tablet->getToolbarMode()) {
+    if (tablet->getToolbarMode() && _desktop) {
        invokeResult =  QMetaObject::invokeMethod(_desktop, "fileDialog",
                                   Q_RETURN_ARG(QVariant, buildDialogResult),
                                   Q_ARG(QVariant, QVariant::fromValue(properties)));
-    } else {
-        QQuickItem* tabletRoot = tablet->getTabletRoot();
+    } else if (QQuickItem* tabletRoot = tablet->getTabletRoot()) {
         invokeResult =  QMetaObject::invokeMethod(tabletRoot, "fileDialog",
                                   Q_RETURN_ARG(QVariant, buildDialogResult),
                                   Q_ARG(QVariant, QVariant::fromValue(properties)));
@@ -782,12 +786,11 @@ ModalDialogListener* OffscreenUi::fileDialogAsync(const QVariantMap& properties)
     bool invokeResult;
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
     TabletProxy* tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
-    if (tablet->getToolbarMode()) {
+    if (tablet->getToolbarMode() && _desktop) {
        invokeResult =  QMetaObject::invokeMethod(_desktop, "fileDialog",
                                   Q_RETURN_ARG(QVariant, buildDialogResult),
                                   Q_ARG(QVariant, QVariant::fromValue(properties)));
-    } else {
-        QQuickItem* tabletRoot = tablet->getTabletRoot();
+    } else if (QQuickItem* tabletRoot = tablet->getTabletRoot()) {
         invokeResult =  QMetaObject::invokeMethod(tabletRoot, "fileDialog",
                                   Q_RETURN_ARG(QVariant, buildDialogResult),
                                   Q_ARG(QVariant, QVariant::fromValue(properties)));
@@ -1003,12 +1006,11 @@ QString OffscreenUi::assetDialog(const QVariantMap& properties) {
     bool invokeResult;
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
     TabletProxy* tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
-    if (tablet->getToolbarMode()) {
+    if (tablet->getToolbarMode() && _desktop) {
         invokeResult = QMetaObject::invokeMethod(_desktop, "assetDialog",
             Q_RETURN_ARG(QVariant, buildDialogResult),
             Q_ARG(QVariant, QVariant::fromValue(properties)));
-    } else {
-        QQuickItem* tabletRoot = tablet->getTabletRoot();
+    } else if (QQuickItem* tabletRoot = tablet->getTabletRoot()) {
         invokeResult = QMetaObject::invokeMethod(tabletRoot, "assetDialog",
             Q_RETURN_ARG(QVariant, buildDialogResult),
             Q_ARG(QVariant, QVariant::fromValue(properties)));
@@ -1034,12 +1036,11 @@ ModalDialogListener *OffscreenUi::assetDialogAsync(const QVariantMap& properties
     bool invokeResult;
     auto tabletScriptingInterface = DependencyManager::get<TabletScriptingInterface>();
     TabletProxy* tablet = dynamic_cast<TabletProxy*>(tabletScriptingInterface->getTablet("com.highfidelity.interface.tablet.system"));
-    if (tablet->getToolbarMode()) {
+    if (tablet->getToolbarMode() && _desktop) {
         invokeResult = QMetaObject::invokeMethod(_desktop, "assetDialog",
             Q_RETURN_ARG(QVariant, buildDialogResult),
             Q_ARG(QVariant, QVariant::fromValue(properties)));
-    } else {
-        QQuickItem* tabletRoot = tablet->getTabletRoot();
+    } else if (QQuickItem* tabletRoot = tablet->getTabletRoot()) {
         invokeResult = QMetaObject::invokeMethod(tabletRoot, "assetDialog",
             Q_RETURN_ARG(QVariant, buildDialogResult),
             Q_ARG(QVariant, QVariant::fromValue(properties)));

--- a/libraries/ui/src/QmlFragmentClass.cpp
+++ b/libraries/ui/src/QmlFragmentClass.cpp
@@ -14,9 +14,6 @@
 
 #include <shared/QtHelpers.h>
 
-#include "OffscreenUi.h"
-
-
 std::mutex QmlFragmentClass::_mutex;
 std::map<QString, QScriptValue> QmlFragmentClass::_fragments;
 
@@ -40,7 +37,6 @@ QScriptValue QmlFragmentClass::internal_constructor(QScriptContext* context, QSc
     }
 
     auto properties = parseArguments(context);
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
     QmlFragmentClass* retVal = new QmlFragmentClass(restricted, qml.toString());
     Q_ASSERT(retVal);
     if (QThread::currentThread() != qApp->thread()) {

--- a/libraries/ui/src/QmlWebWindowClass.cpp
+++ b/libraries/ui/src/QmlWebWindowClass.cpp
@@ -14,7 +14,6 @@
 #include <QtScript/QScriptEngine>
 
 #include <shared/QtHelpers.h>
-#include "OffscreenUi.h"
 
 static const char* const URL_PROPERTY = "source";
 static const char* const SCRIPT_PROPERTY = "scriptUrl";
@@ -22,7 +21,6 @@ static const char* const SCRIPT_PROPERTY = "scriptUrl";
 // Method called by Qt scripts to create a new web window in the overlay
 QScriptValue QmlWebWindowClass::internal_constructor(QScriptContext* context, QScriptEngine* engine, bool restricted) {
     auto properties = parseArguments(context);
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
     QmlWebWindowClass* retVal = new QmlWebWindowClass(restricted);
     Q_ASSERT(retVal);
     if (QThread::currentThread() != qApp->thread()) {

--- a/libraries/ui/src/QmlWindowClass.cpp
+++ b/libraries/ui/src/QmlWindowClass.cpp
@@ -72,7 +72,6 @@ QVariantMap QmlWindowClass::parseArguments(QScriptContext* context) {
 // Method called by Qt scripts to create a new web window in the overlay
 QScriptValue QmlWindowClass::internal_constructor(QScriptContext* context, QScriptEngine* engine, bool restricted) {
     auto properties = parseArguments(context);
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
     QmlWindowClass* retVal = new QmlWindowClass(restricted);
     Q_ASSERT(retVal);
     if (QThread::currentThread() != qApp->thread()) {
@@ -349,7 +348,6 @@ void QmlWindowClass::raise() {
         return;
     }
 
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
     if (_qmlWindow) {
         QMetaObject::invokeMethod(asQuickItem(), "raise", Qt::DirectConnection);
     }

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -385,9 +385,11 @@ void TabletProxy::setToolbarMode(bool toolbarMode) {
         connect(tabletRootWindow, &QmlWindowClass::fromQml, this, &TabletProxy::fromQml);
 #endif
     } else {
+#if !defined(DISABLE_QML)
         if (_currentPathLoaded != TABLET_HOME_SOURCE_URL) {
             loadHomeScreen(true);
         }
+#endif
         //check if running scripts window opened and save it for reopen in Tablet
         if (offscreenUi->isVisible("RunningScripts")) {
             offscreenUi->hide("RunningScripts");

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -321,8 +321,8 @@ void TabletScriptingInterface::processEvent(const QKeyEvent* event) {
 
 QObject* TabletScriptingInterface::getFlags() {
     Q_ASSERT(QThread::currentThread() == qApp->thread());
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
-    return offscreenUi->getFlags();
+    auto offscreenUI = DependencyManager::get<OffscreenUi>();
+    return offscreenUI ? offscreenUI->getFlags() : nullptr;
 }
 
 //
@@ -364,8 +364,6 @@ void TabletProxy::setToolbarMode(bool toolbarMode) {
 
     _toolbarMode = toolbarMode;
 
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
-
     if (toolbarMode) {
 #if !defined(DISABLE_QML)
         closeDialog();
@@ -385,18 +383,21 @@ void TabletProxy::setToolbarMode(bool toolbarMode) {
         connect(tabletRootWindow, &QmlWindowClass::fromQml, this, &TabletProxy::fromQml);
 #endif
     } else {
-#if !defined(DISABLE_QML)
         if (_currentPathLoaded != TABLET_HOME_SOURCE_URL) {
             loadHomeScreen(true);
         }
-#endif
-        //check if running scripts window opened and save it for reopen in Tablet
-        if (offscreenUi->isVisible("RunningScripts")) {
-            offscreenUi->hide("RunningScripts");
-            _showRunningScripts = true;
+
+        auto offscreenUI = DependencyManager::get<OffscreenUi>();
+        if (offscreenUI) {
+            //check if running scripts window opened and save it for reopen in Tablet
+            if (offscreenUI->isVisible("RunningScripts")) {
+                offscreenUI->hide("RunningScripts");
+                _showRunningScripts = true;
+            }
+
+            offscreenUI->hideDesktopWindows();
         }
 
-        offscreenUi->hideDesktopWindows();
         // destroy desktop window
         if (_desktopWindow) {
             _desktopWindow->deleteLater();
@@ -579,9 +580,9 @@ void TabletProxy::gotoMenuScreen(const QString& submenu) {
         root = _desktopWindow->asQuickItem();
     }
 
-    if (root) {
-        auto offscreenUi = DependencyManager::get<OffscreenUi>();
-        QObject* menu = offscreenUi->getRootMenu();
+    auto offscreenUI = DependencyManager::get<OffscreenUi>();
+    if (root && offscreenUI) {
+        QObject* menu = offscreenUI->getRootMenu();
         QMetaObject::invokeMethod(root, "setMenuProperties", Q_ARG(QVariant, QVariant::fromValue(menu)), Q_ARG(const QVariant&, QVariant(submenu)));
         QMetaObject::invokeMethod(root, "loadSource", Q_ARG(const QVariant&, QVariant(VRMENU_SOURCE_URL)));
         _state = State::Menu;

--- a/plugins/openvr/src/OpenVrHelpers.cpp
+++ b/plugins/openvr/src/OpenVrHelpers.cpp
@@ -203,14 +203,14 @@ void updateFromOpenVrKeyboardInput() {
 }
 
 void finishOpenVrKeyboardInput() {
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
+    auto offscreenUI = DependencyManager::get<OffscreenUi>();
     updateFromOpenVrKeyboardInput();
     // Simulate an enter press on the top level window to trigger the action
-    if (0 == (_currentHints & Qt::ImhMultiLine)) {
+    if (0 == (_currentHints & Qt::ImhMultiLine) && offscreenUI) {
         auto keyPress = QKeyEvent(QEvent::KeyPress, Qt::Key_Return, Qt::KeyboardModifiers(), QString("\n"));
         auto keyRelease = QKeyEvent(QEvent::KeyRelease, Qt::Key_Return, Qt::KeyboardModifiers());
-        qApp->sendEvent(offscreenUi->getWindow(), &keyPress);
-        qApp->sendEvent(offscreenUi->getWindow(), &keyRelease);
+        qApp->sendEvent(offscreenUI->getWindow(), &keyPress);
+        qApp->sendEvent(offscreenUI->getWindow(), &keyRelease);
     }
 }
 
@@ -221,9 +221,7 @@ void enableOpenVrKeyboard(PluginContainer* container) {
     if (disableSteamVrKeyboard) {
         return;
     }
-    auto offscreenUi = DependencyManager::get<OffscreenUi>();
     _overlay = vr::VROverlay();
-
 
     auto menu = container->getPrimaryMenu();
     auto action = menu->getActionForOption(MenuOption::Overlays);
@@ -282,7 +280,9 @@ void handleOpenVrEvents() {
             case vr::VREvent_KeyboardClosed:
                 _keyboardFocusObject = nullptr;
                 _keyboardShown = false;
-                DependencyManager::get<OffscreenUi>()->unfocusWindows();
+                if (auto offscreenUI = DependencyManager::get<OffscreenUi>()) {
+                    offscreenUI->unfocusWindows();
+                }
                 break;
 
             default:


### PR DESCRIPTION
fixes #810 
fixes #811 

Test plan:
- No change to normal builds
- If you build manually with QML disabled, run, and switch to VR, you should no longer crash