### PR TITLE
Initial audit logging, for review.

### DIFF
--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -310,6 +310,10 @@ void EntityServer::readAdditionalConfiguration(const QJsonObject& settingsSectio
     bool wantEditLogging = false;
     readOptionBool(QString("wantEditLogging"), settingsSectionObject, wantEditLogging);
     qDebug("wantEditLogging=%s", debug::valueOf(wantEditLogging));
+    
+    bool wantAuditEditLogging = false;
+    readOptionBool(QString("wantAuditEditLogging"), settingsSectionObject, wantAuditEditLogging);
+    qDebug("wantAuditEditLogging=%s", debug::valueOf(wantAuditEditLogging));
 
     bool wantTerseEditLogging = false;
     readOptionBool(QString("wantTerseEditLogging"), settingsSectionObject, wantTerseEditLogging);
@@ -337,6 +341,7 @@ void EntityServer::readAdditionalConfiguration(const QJsonObject& settingsSectio
     startDynamicDomainVerification();
 
     tree->setWantEditLogging(wantEditLogging);
+    tree->setWantAuditEditLogging(wantAuditEditLogging);
     tree->setWantTerseEditLogging(wantTerseEditLogging);
 
     QString entityScriptSourceWhitelist;

--- a/assignment-client/src/entities/EntityServer.h
+++ b/assignment-client/src/entities/EntityServer.h
@@ -45,7 +45,7 @@ public:
     virtual PacketType getMyEditNackType() const override { return PacketType::EntityEditNack; }
     virtual QString getMyDomainSettingsKey() const override { return QString("entity_server_settings"); }
 
-    // subclass may implement these method
+    // subclass may implement these methods
     virtual void beforeRun() override;
     virtual bool hasSpecialPacketsToSend(const SharedNodePointer& node) override;
     virtual int sendSpecialPackets(const SharedNodePointer& node, OctreeQueryNode* queryNode, int& packetsSent) override;

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -1617,6 +1617,14 @@
           "advanced": true
         },
         {
+          "name": "wantAuditEditLogging",
+          "type": "checkbox",
+          "label": "Audit Edit Logging",
+          "help": "Log edits with audit information.",
+          "default": true,
+          "advanced": true
+        },
+        {
           "name": "verboseDebug",
           "type": "checkbox",
           "label": "Verbose Debug",

--- a/libraries/entities/src/EntitiesAuditLogging.cpp
+++ b/libraries/entities/src/EntitiesAuditLogging.cpp
@@ -1,0 +1,14 @@
+//
+//  EntitiesAuditLogging.cpp
+//  libraries/entities/src
+//
+//  Created by Kalila L on Feb 5 2021.
+//  Copyright 2021 Vircadia contributors.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "EntitiesAuditLogging.h"
+
+Q_LOGGING_CATEGORY(entities_audit, "vircadia.entities.audit")

--- a/libraries/entities/src/EntitiesAuditLogging.h
+++ b/libraries/entities/src/EntitiesAuditLogging.h
@@ -1,0 +1,19 @@
+//
+//  EntitiesAuditLogging.h
+//  libraries/entities/src
+//
+//  Created by Kalila L on Feb 5 2021.
+//  Copyright 2021 Vircadia contributors.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef vircadia_EntitiesAuditLogging_h
+#define vircadia_EntitiesAuditLogging_h
+
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(entities_audit)
+
+#endif // vircadia_EntitiesAuditLogging_h

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -190,6 +190,9 @@ public:
 
     bool wantEditLogging() const { return _wantEditLogging; }
     void setWantEditLogging(bool value) { _wantEditLogging = value; }
+    
+    bool wantAuditEditLogging() const { return _wantAuditEditLogging; }
+    void setWantAuditEditLogging(bool value) { _wantAuditEditLogging = value; }
 
     bool wantTerseEditLogging() const { return _wantTerseEditLogging; }
     void setWantTerseEditLogging(bool value) { _wantTerseEditLogging = value; }
@@ -339,6 +342,7 @@ protected:
     EntitySimulationPointer _simulation;
 
     bool _wantEditLogging = false;
+    bool _wantAuditEditLogging = true;
     bool _wantTerseEditLogging = false;
 
 
@@ -388,6 +392,10 @@ private:
     void sendChallengeOwnershipPacket(const QString& certID, const QString& ownerKey, const EntityItemID& entityItemID, const SharedNodePointer& senderNode);
     void sendChallengeOwnershipRequestPacket(const QByteArray& id, const QByteArray& text, const QByteArray& nodeToChallenge, const SharedNodePointer& senderNode);
     void validatePop(const QString& certID, const EntityItemID& entityItemID, const SharedNodePointer& senderNode);
+
+    void EntityTree::processAuditLogBuffers();
+    void EntityTree::startAuditLogProcessor();
+    void EntityTree::stopAuditLogProcessor();
 
     std::shared_ptr<AvatarData> _myAvatar{ nullptr };
 


### PR DESCRIPTION
Before I break it out into its own class and all that jazz (if I should even...), I'd like to know if this is relatively performant or would be, what better ways can I do this? I also wanted to do a push of changed properties each time. However that requires looping and that adds more overhead.

Now this can be good for general times when rapid edits aren't necessary, but would like to know if this is/can be performant enough for general use running in the background too.