### PR TITLE
Experiment with Qt HTTP caching options

### DIFF
--- a/libraries/networking/src/AssetClient.h
+++ b/libraries/networking/src/AssetClient.h
@@ -64,8 +64,6 @@ public:
     Q_INVOKABLE AssetUpload* createUpload(const QByteArray& data);
 
 public slots:
-    void initCaching();
-
     void cacheInfoRequest(QObject* reciever, QString slot);
     MiniPromise::Promise cacheInfoRequestAsync(MiniPromise::Promise deferred = nullptr);
     MiniPromise::Promise queryCacheMetaAsync(const QUrl& url, MiniPromise::Promise deferred = nullptr);
@@ -116,8 +114,6 @@ private:
     std::unordered_map<SharedNodePointer, std::unordered_map<MessageID, GetAssetRequestData>> _pendingRequests;
     std::unordered_map<SharedNodePointer, std::unordered_map<MessageID, GetInfoCallback>> _pendingInfoRequests;
     std::unordered_map<SharedNodePointer, std::unordered_map<MessageID, UploadResultCallback>> _pendingUploads;
-
-    QString _cacheDir;
 
     friend class AssetRequest;
     friend class AssetUpload;

--- a/libraries/networking/src/BaseAssetScriptingInterface.cpp
+++ b/libraries/networking/src/BaseAssetScriptingInterface.cpp
@@ -46,9 +46,6 @@ bool BaseAssetScriptingInterface::initializeCache() {
         return true; // cache is ready
     }
 
-    // attempt to initialize the cache
-    QMetaObject::invokeMethod(assetClient().data(), "initCaching");
-
     Promise deferred = makePromise("BaseAssetScriptingInterface--queryCacheStatus");
     deferred->then([this](QVariantMap result) {
         _cacheReady = !result.value("cacheDirectory").toString().isEmpty();

--- a/libraries/networking/src/HTTPResourceRequest.cpp
+++ b/libraries/networking/src/HTTPResourceRequest.cpp
@@ -58,7 +58,7 @@ void HTTPResourceRequest::doSend() {
     networkRequest.setHeader(QNetworkRequest::UserAgentHeader, NetworkingConstants::VIRCADIA_USER_AGENT);
 
     if (_cacheEnabled) {
-        networkRequest.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache);
+        networkRequest.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferNetwork);
     } else {
         networkRequest.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::AlwaysNetwork);
     }

--- a/libraries/networking/src/ResourceManager.cpp
+++ b/libraries/networking/src/ResourceManager.cpp
@@ -13,9 +13,6 @@
 
 #include <mutex>
 
-#include <QNetworkDiskCache>
-#include <QStandardPaths>
-#include <QThread>
 #include <QFileInfo>
 
 #include <SharedUtil.h>
@@ -33,7 +30,6 @@ ResourceManager::ResourceManager(bool atpSupportEnabled) : _atpSupportEnabled(at
     if (_atpSupportEnabled) {
         auto assetClient = DependencyManager::set<AssetClient>();
         assetClient->moveToThread(&_thread);
-        QObject::connect(&_thread, &QThread::started, assetClient.data(), &AssetClient::initCaching);
     }
 
     _thread.start();

--- a/tools/atp-client/src/ATPClientApp.cpp
+++ b/tools/atp-client/src/ATPClientApp.cpp
@@ -197,9 +197,6 @@ ATPClientApp::ATPClientApp(int argc, char* argv[]) :
         accountManager->requestAccessToken(_username, _password);
     }
 
-    auto assetClient = DependencyManager::set<AssetClient>();
-    assetClient->initCaching();
-
     if (_verbose) {
         qDebug() << "domain-server address is" << _domainServerAddress;
     }


### PR DESCRIPTION
potentially closes https://github.com/vircadia/vircadia/issues/92 and https://github.com/vircadia/vircadia/issues/990

should theoretically
1. remove the need for cachebusting
2. improve loading times

Test plan/open questions:
- confirm that cachebusting scripts/models is no longer necessary (links won't update automatically, you'll still need to refresh the script or modelURL).  but...we might need to add a refresh button in Create next to modelURL, because otherwise it will probably ignore model URL changes before even checking the network?
- compare loading times (initial/loading from cache) between this PR and master.  is this PR faster?
- does it respect HTTP expiry times?  can someone smarter than me make a test for this