### PR TITLE
triggerHapticPulse supports arbitrary device index instead of just two hands

### DIFF
--- a/libraries/controllers/src/controllers/InputDevice.h
+++ b/libraries/controllers/src/controllers/InputDevice.h
@@ -118,7 +118,7 @@ public:
     const QString& getName() const { return _name; }
 
     // By default, Input Devices do not support haptics
-    virtual bool triggerHapticPulse(float strength, float duration, controller::Hand hand) { return false; }
+    virtual bool triggerHapticPulse(float strength, float duration, uint16_t index) { return false; }
 
     // Update call MUST be called once per simulation loop
     // It takes care of updating the action states and deltas

--- a/libraries/controllers/src/controllers/ScriptingInterface.cpp
+++ b/libraries/controllers/src/controllers/ScriptingInterface.cpp
@@ -134,13 +134,13 @@ namespace controller {
         return DependencyManager::get<UserInputMapper>()->getActionNames();
     }
 
-    bool ScriptingInterface::triggerHapticPulse(float strength, float duration, controller::Hand hand) const {
-        return DependencyManager::get<UserInputMapper>()->triggerHapticPulse(strength, duration, hand);
+    bool ScriptingInterface::triggerHapticPulse(float strength, float duration, uint16_t index) const {
+        return DependencyManager::get<UserInputMapper>()->triggerHapticPulse(strength, duration, index);
     }
 
-    bool ScriptingInterface::triggerShortHapticPulse(float strength, controller::Hand hand) const {
+    bool ScriptingInterface::triggerShortHapticPulse(float strength, uint16_t index) const {
         const float SHORT_HAPTIC_DURATION_MS = 250.0f;
-        return DependencyManager::get<UserInputMapper>()->triggerHapticPulse(strength, SHORT_HAPTIC_DURATION_MS, hand);
+        return DependencyManager::get<UserInputMapper>()->triggerHapticPulse(strength, SHORT_HAPTIC_DURATION_MS, index);
     }
 
     void ScriptingInterface::startInputRecording() {
@@ -189,13 +189,13 @@ namespace controller {
         emit inputDeviceRunningChanged(deviceName, isRunning);
     }
 
-    bool ScriptingInterface::triggerHapticPulseOnDevice(unsigned int device, float strength, float duration, controller::Hand hand) const {
-        return DependencyManager::get<UserInputMapper>()->triggerHapticPulseOnDevice(device, strength, duration, hand);
+    bool ScriptingInterface::triggerHapticPulseOnDevice(unsigned int device, float strength, float duration, uint16_t index) const {
+        return DependencyManager::get<UserInputMapper>()->triggerHapticPulseOnDevice(device, strength, duration, index);
     }
 
-    bool ScriptingInterface::triggerShortHapticPulseOnDevice(unsigned int device, float strength, controller::Hand hand) const {
+    bool ScriptingInterface::triggerShortHapticPulseOnDevice(unsigned int device, float strength, uint16_t index) const {
         const float SHORT_HAPTIC_DURATION_MS = 250.0f;
-        return DependencyManager::get<UserInputMapper>()->triggerHapticPulseOnDevice(device, strength, SHORT_HAPTIC_DURATION_MS, hand);
+        return DependencyManager::get<UserInputMapper>()->triggerHapticPulseOnDevice(device, strength, SHORT_HAPTIC_DURATION_MS, index);
     }
 
     void ScriptingInterface::updateMaps() {

--- a/libraries/controllers/src/controllers/ScriptingInterface.h
+++ b/libraries/controllers/src/controllers/ScriptingInterface.h
@@ -212,22 +212,28 @@ namespace controller {
          * @function Controller.triggerHapticPulse
          * @param {number} strength - The strength of the haptic pulse, range <code>0.0</code> &ndash; <code>1.0</code>.
          * @param {number} duration - The duration of the haptic pulse, in milliseconds.
-         * @param {Controller.Hand} [hand=2] - The hand or hands to trigger the haptic pulse on.
+         * @param {number} [index=2] - The index on devices on which to trigger the haptic pulse.  The meaning of each index
+         *     will vary by device.  For example, for hand controllers, <code>index = 0</code> is the left hand,
+         *     <code>index = 1</code> is the right hand, and <code>index = 2</code> is both hands.  For other devices,
+         *     such as haptic vests, index will have a different meaning, defined by the input device.
          * @example <caption>Trigger a haptic pulse on the right hand.</caption>
          * var HAPTIC_STRENGTH = 0.5;
          * var HAPTIC_DURATION = 10;
          * var RIGHT_HAND = 1;
          * Controller.triggerHapticPulse(HAPTIC_STRENGTH, HAPTIC_DURATION, RIGHT_HAND);
          */
-        Q_INVOKABLE bool triggerHapticPulse(float strength, float duration, controller::Hand hand = BOTH) const;
+        Q_INVOKABLE bool triggerHapticPulse(float strength, float duration, uint16_t index = 2) const;
 
         /**jsdoc
          * Triggers a 250ms haptic pulse on connected and enabled devices that have the capability.
          * @function Controller.triggerShortHapticPulse
          * @param {number} strength - The strength of the haptic pulse, range <code>0.0</code> &ndash; <code>1.0</code>.
-         * @param {Controller.Hand} [hand=2] - The hand or hands to trigger the haptic pulse on.
+         * @param {number} [index=2] - The index on devices on which to trigger the haptic pulse.  The meaning of each index
+         *     will vary by device.  For example, for hand controllers, <code>index = 0</code> is the left hand,
+         *     <code>index = 1</code> is the right hand, and <code>index = 2</code> is both hands.  For other devices,
+         *     such as haptic vests, index will have a different meaning, defined by the input device.
          */
-        Q_INVOKABLE bool triggerShortHapticPulse(float strength, controller::Hand hand = BOTH) const;
+        Q_INVOKABLE bool triggerShortHapticPulse(float strength, uint16_t index = 2) const;
 
         /**jsdoc
          * Triggers a haptic pulse on a particular device if connected and enabled and it has the capability.
@@ -235,7 +241,10 @@ namespace controller {
          * @param {number} deviceID - The ID of the device to trigger the haptic pulse on.
          * @param {number} strength - The strength of the haptic pulse, range <code>0.0</code> &ndash; <code>1.0</code>.
          * @param {number} duration - The duration of the haptic pulse, in milliseconds.
-         * @param {Controller.Hand} [hand=2] - The hand or hands to trigger the haptic pulse on.
+         * @param {number} [index=2] - The index on this device on which to trigger the haptic pulse.  The meaning of each index
+         *     will vary by device.  For example, for hand controllers, <code>index = 0</code> is the left hand,
+         *     <code>index = 1</code> is the right hand, and <code>index = 2</code> is both hands.  For other devices,
+         *     such as haptic vests, index will have a different meaning, defined by the input device.
          * @example <caption>Trigger a haptic pulse on an Oculus Touch controller.</caption>
          * var HAPTIC_STRENGTH = 0.5;
          * var deviceID = Controller.findDevice("OculusTouch");
@@ -243,19 +252,20 @@ namespace controller {
          * var RIGHT_HAND = 1;
          * Controller.triggerHapticPulseOnDevice(deviceID, HAPTIC_STRENGTH, HAPTIC_DURATION, RIGHT_HAND);
          */
-        Q_INVOKABLE bool triggerHapticPulseOnDevice(unsigned int device, float strength, float duration, 
-            controller::Hand hand = BOTH) const;
+        Q_INVOKABLE bool triggerHapticPulseOnDevice(unsigned int device, float strength, float duration,
+            uint16_t index = 2) const;
 
         /**jsdoc
          * Triggers a 250ms haptic pulse on a particular device if connected and enabled and it has the capability.
          * @function Controller.triggerShortHapticPulseOnDevice
          * @param {number} deviceID - The ID of the device to trigger the haptic pulse on.
          * @param {number} strength - The strength of the haptic pulse, range <code>0.0</code> &ndash; <code>1.0</code>.
-         * @param {Controller.Hand} [hand=2] - The hand or hands to trigger the haptic pulse on.
+         * @param {number} [index=2] - The index on this device on which to trigger the haptic pulse.  The meaning of each index
+         *     will vary by device.  For example, for hand controllers, <code>index = 0</code> is the left hand,
+         *     <code>index = 1</code> is the right hand, and <code>index = 2</code> is both hands.  For other devices,
+         *     such as haptic vests, index will have a different meaning, defined by the input device.
          */
-        Q_INVOKABLE bool triggerShortHapticPulseOnDevice(unsigned int device, float strength, controller::Hand hand = BOTH) 
-            const;
-
+        Q_INVOKABLE bool triggerShortHapticPulseOnDevice(unsigned int device, float strength, uint16_t index = 2) const;
 
         /**jsdoc
          * Creates a new controller mapping. Routes can then be added to the mapping using {@link MappingObject} methods and 

--- a/libraries/controllers/src/controllers/UserInputMapper.cpp
+++ b/libraries/controllers/src/controllers/UserInputMapper.cpp
@@ -365,19 +365,19 @@ Pose UserInputMapper::getPoseState(Action action) const {
 }
 
 
-bool UserInputMapper::triggerHapticPulse(float strength, float duration, controller::Hand hand) {
+bool UserInputMapper::triggerHapticPulse(float strength, float duration, uint16_t index) {
     Locker locker(_lock);
     bool toReturn = false;
     for (const auto& device : _registeredDevices) {
-        toReturn = device.second->triggerHapticPulse(strength, duration, hand) || toReturn;
+        toReturn = device.second->triggerHapticPulse(strength, duration, index) || toReturn;
     }
     return toReturn;
 }
 
-bool UserInputMapper::triggerHapticPulseOnDevice(uint16 deviceID, float strength, float duration, controller::Hand hand) {
+bool UserInputMapper::triggerHapticPulseOnDevice(uint16 deviceID, float strength, float duration, uint16_t index) {
     Locker locker(_lock);
     if (_registeredDevices.find(deviceID) != _registeredDevices.end()) {
-        return _registeredDevices[deviceID]->triggerHapticPulse(strength, duration, hand);
+        return _registeredDevices[deviceID]->triggerHapticPulse(strength, duration, index);
     }
     return false;
 }

--- a/libraries/controllers/src/controllers/UserInputMapper.h
+++ b/libraries/controllers/src/controllers/UserInputMapper.h
@@ -91,8 +91,8 @@ namespace controller {
         void setActionState(Action action, float value, bool valid = true);
         void deltaActionState(Action action, float delta, bool valid = true);
         void setActionState(Action action, const Pose& value) { _poseStates[toInt(action)] = value; }
-        bool triggerHapticPulse(float strength, float duration, controller::Hand hand);
-        bool triggerHapticPulseOnDevice(uint16 deviceID, float strength, float duration, controller::Hand hand);
+        bool triggerHapticPulse(float strength, float duration, uint16_t index);
+        bool triggerHapticPulseOnDevice(uint16 deviceID, float strength, float duration, uint16_t index);
 
         static Input makeStandardInput(controller::StandardButtonChannel button);
         static Input makeStandardInput(controller::StandardAxisChannel axis);

--- a/libraries/input-plugins/src/input-plugins/TouchscreenVirtualPadDevice.cpp
+++ b/libraries/input-plugins/src/input-plugins/TouchscreenVirtualPadDevice.cpp
@@ -199,7 +199,7 @@ void TouchscreenVirtualPadDevice::InputDevice::update(float deltaTime, const con
     _axisStateMap.clear();
 }
 
-bool TouchscreenVirtualPadDevice::InputDevice::triggerHapticPulse(float strength, float duration, controller::Hand hand) {
+bool TouchscreenVirtualPadDevice::InputDevice::triggerHapticPulse(float strength, float duration, uint16_t index) {
     auto& virtualPadManager = VirtualPad::Manager::instance();
     virtualPadManager.requestHapticFeedback((int) duration);
     return true;

--- a/libraries/input-plugins/src/input-plugins/TouchscreenVirtualPadDevice.h
+++ b/libraries/input-plugins/src/input-plugins/TouchscreenVirtualPadDevice.h
@@ -71,7 +71,7 @@ protected:
         virtual controller::Input::NamedVector getAvailableInputs() const override;
         virtual QString getDefaultMappingConfig() const override;
 
-        virtual bool triggerHapticPulse(float strength, float duration, controller::Hand hand) override;
+        virtual bool triggerHapticPulse(float strength, float duration, uint16_t index) override;
         virtual void update(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) override;
         virtual void focusOutEvent() override;
 

--- a/libraries/oculusMobilePlugin/src/OculusMobileControllerManager.cpp
+++ b/libraries/oculusMobilePlugin/src/OculusMobileControllerManager.cpp
@@ -161,7 +161,7 @@ public:
     QString getDefaultMappingConfig() const override;
     void update(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) override;
     void focusOutEvent() override;
-    bool triggerHapticPulse(float strength, float duration, controller::Hand hand) override;
+    bool triggerHapticPulse(float strength, float duration, uint16_t index) override;
 
 private:
     void handlePose(float deltaTime, const controller::InputCalibrationData& inputCalibrationData,
@@ -516,11 +516,15 @@ void OculusMobileInputDevice::handleRotationForUntrackedHand(const controller::I
     pose = pose.transform(controllerToAvatar);
 }
 
-bool OculusMobileInputDevice::triggerHapticPulse(float strength, float duration, controller::Hand hand) {
+bool OculusMobileInputDevice::triggerHapticPulse(float strength, float duration, uint16_t index) {
+    if (index > 2) {
+        return false;
+    }
+
+    controller::Hand hand = (controller::Hand)index;
+
     Locker locker(_lock);
     bool success = true;
-
-    qDebug()<<"AAAA: Haptic duration %f " << duration;
 
     if (hand == controller::BOTH || hand == controller::LEFT) {
         success &= _hands[0].setHapticFeedback(strength, duration);

--- a/plugins/hifiSdl2/src/Joystick.cpp
+++ b/plugins/hifiSdl2/src/Joystick.cpp
@@ -72,7 +72,7 @@ void Joystick::handleButtonEvent(const SDL_ControllerButtonEvent& event) {
     }
 }
 
-bool Joystick::triggerHapticPulse(float strength, float duration, controller::Hand hand) {
+bool Joystick::triggerHapticPulse(float strength, float duration, uint16_t index) {
     if (SDL_HapticRumblePlay(_sdlHaptic, strength, duration) != 0) {
         return false;
     }

--- a/plugins/hifiSdl2/src/Joystick.h
+++ b/plugins/hifiSdl2/src/Joystick.h
@@ -39,7 +39,7 @@ public:
     virtual void update(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) override;
     virtual void focusOutEvent() override;
 
-    bool triggerHapticPulse(float strength, float duration, controller::Hand hand) override;
+    bool triggerHapticPulse(float strength, float duration, uint16_t index) override;
     
     Joystick() : InputDevice("GamePad") {}
     ~Joystick();

--- a/plugins/oculus/src/OculusControllerManager.cpp
+++ b/plugins/oculus/src/OculusControllerManager.cpp
@@ -369,7 +369,13 @@ void OculusControllerManager::TouchDevice::handleRotationForUntrackedHand(const 
     pose = pose.transform(controllerToAvatar);
 }
 
-bool OculusControllerManager::TouchDevice::triggerHapticPulse(float strength, float duration, controller::Hand hand) {
+bool OculusControllerManager::TouchDevice::triggerHapticPulse(float strength, float duration, uint16_t index) {
+    if (index > 2) {
+        return false;
+    }
+
+    controller::Hand hand = (controller::Hand)index;
+
     Locker locker(_lock);
     bool toReturn = true;
     ovr::withSession([&](ovrSession session) {

--- a/plugins/oculus/src/OculusControllerManager.h
+++ b/plugins/oculus/src/OculusControllerManager.h
@@ -76,7 +76,7 @@ private:
         void update(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) override;
         void focusOutEvent() override;
 
-        bool triggerHapticPulse(float strength, float duration, controller::Hand hand) override;
+        bool triggerHapticPulse(float strength, float duration, uint16_t index) override;
 
     private:
         void stopHapticPulse(bool leftHand);

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -1559,7 +1559,13 @@ void ViveControllerManager::InputDevice::handlePoseEvent(float deltaTime, const 
     _poseStateMap[isLeftHand ? controller::LEFT_HAND : controller::RIGHT_HAND] = pose.transform(controllerToAvatar);
 }
 
-bool ViveControllerManager::InputDevice::triggerHapticPulse(float strength, float duration, controller::Hand hand) {
+bool ViveControllerManager::InputDevice::triggerHapticPulse(float strength, float duration, uint16_t index) {
+    if (index > 2) {
+        return false;
+    }
+
+    controller::Hand hand = (controller::Hand)index;
+
     Locker locker(_lock);
     if (hand == controller::BOTH || hand == controller::LEFT) {
         if (strength == 0.0f) {

--- a/plugins/openvr/src/ViveControllerManager.h
+++ b/plugins/openvr/src/ViveControllerManager.h
@@ -112,7 +112,7 @@ private:
         QString getDefaultMappingConfig() const override;
         void update(float deltaTime, const controller::InputCalibrationData& inputCalibrationData) override;
         void focusOutEvent() override;
-        bool triggerHapticPulse(float strength, float duration, controller::Hand hand) override;
+        bool triggerHapticPulse(float strength, float duration, uint16_t index) override;
         void hapticsHelper(float deltaTime, bool leftHand);
         void calibrateOrUncalibrate(const controller::InputCalibrationData& inputCalibration);
         void calibrate(const controller::InputCalibrationData& inputCalibration);


### PR DESCRIPTION
inspired by @daleglass's FOSDEM talk, I've been meaning to change this for a while

Test plan:
- no real functional change
- make sure you can still trigger a haptic pulse on existing hand controllers, for example: `Controller.triggerHapticPulse(0.5, 10, 2);` should trigger a pulse on both hands