### PR TITLE
Fix profile errors in QML. (also add FIXME's)

### DIFF
--- a/interface/resources/qml/controls/+webengine/FlickableWebViewCore.qml
+++ b/interface/resources/qml/controls/+webengine/FlickableWebViewCore.qml
@@ -13,6 +13,9 @@ Item {
     property alias url: webViewCore.url
     property alias canGoBack: webViewCore.canGoBack
     property alias webViewCore: webViewCore
+    // FIXME - This was commented out to allow for manual setting of the userAgent.
+    //
+    // property alias webViewCoreProfile: webViewCore.profile
     property string webViewCoreUserAgent
 
     property bool useBackground: webViewCore.useBackground

--- a/interface/resources/qml/controls/FlickableWebViewCore.qml
+++ b/interface/resources/qml/controls/FlickableWebViewCore.qml
@@ -11,6 +11,9 @@ Item {
     property alias url: webViewCore.url
     property alias canGoBack: webViewCore.canGoBack
     property alias webViewCore: webViewCore
+    // FIXME - This was commented out to allow for manual setting of the userAgent.
+    //
+    // property alias webViewCoreProfile: webViewCore.profile
 
     property alias useBackground: webViewCore.useBackground
     property alias userAgent: webViewCore.userAgent

--- a/interface/resources/qml/controls/TabletWebScreen.qml
+++ b/interface/resources/qml/controls/TabletWebScreen.qml
@@ -27,7 +27,11 @@ Item {
     }
     */
 
-    property alias viewProfile: webroot.webViewCoreProfile
+    // FIXME - Reimplement profiles for... why? Was it so that new windows opened share the same profile? 
+    //         Are profiles written to by the webengine during the session?
+    //         Removed in PR Feature/web entity user agent #988
+    //
+    // property alias viewProfile: webroot.webViewCoreProfile
 
     FlickableWebViewCore {
         id: webroot

--- a/interface/resources/qml/controls/TabletWebView.qml
+++ b/interface/resources/qml/controls/TabletWebView.qml
@@ -25,7 +25,11 @@ Item {
     property bool isDesktop: false
     property alias url: web.url
     property alias webView: web.webViewCore
-    property alias profile: web.webViewCoreProfile
+    // FIXME - Reimplement profiles for... why? Was it so that new windows opened share the same profile? 
+    //         Are profiles written to by the webengine during the session?
+    //         Removed in PR Feature/web entity user agent #988
+    //
+    // property alias profile: web.webViewCoreProfile
     property bool remove: false
     property bool closeButtonVisible: true
 

--- a/interface/resources/qml/controls/WebView.qml
+++ b/interface/resources/qml/controls/WebView.qml
@@ -38,6 +38,12 @@ Item {
     }
     */
 
+    // FIXME - Reimplement profiles for... why? Was it so that new windows opened share the same profile? 
+    //         Are profiles written to by the webengine during the session?
+    //         Removed in PR Feature/web entity user agent #988
+    //
+    // property alias viewProfile: webroot.webViewCoreProfile
+
     FlickableWebViewCore {
         id: webroot
         width: parent.width


### PR DESCRIPTION
Any ideas on exactly what profiles were doing/how they were used? https://github.com/vircadia/vircadia/pull/988/files is where I made changes to it originally, I'm not entirely sure what the use of profiles are without an interceptor being needed to add to the user agent.

Was it that profiles are used to pass it on to new browser instances? But if that's the case, then can the webengine actually modify them? Is it needed to be an alias all the way down? Why not copy it from the bottom up one way?

I could also just manual put in the relevant profile pieces like I did for the FlickableCore, but then those are already there. So I'm not really sure.

EITHER WAY: this PR does solve the issue of the web views not working in all areas that I could effectively test.

NOTE: I was incorrect about my assumption of storage not persisting for webviews, after installing PR576 (I had an installer laying around) I ran a test and the history for a Google search did in fact persist.

What does this mean? It's likely that I've changed no real functionality by doing this. But at this point, who knows?