### PR TITLE
Non-uniformly scaled sphere zones and models behave like ellipsoids (and fix EntityItem::contains sphere case)

### DIFF
--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -1764,8 +1764,7 @@ bool EntityItem::contains(const glm::vec3& point) const {
         // therefore we must do math using an unscaled localPoint relative to sphere center
         glm::vec3 dimensions = getScaledDimensions();
         glm::vec3 localPoint = point - (getWorldPosition() + getWorldOrientation() * (dimensions * (ENTITY_ITEM_DEFAULT_REGISTRATION_POINT - getRegistrationPoint()) + getPivot()));
-        const float HALF_SQUARED = 0.25f;
-        return glm::length2(localPoint) < HALF_SQUARED * glm::length2(dimensions);
+        return glm::length2(localPoint) < glm::length2(0.5f * glm::max(dimensions.x, glm::max(dimensions.y, dimensions.z)));
     }
 
     // we transform into the "normalized entity-frame" where the bounding box is centered on the origin

--- a/libraries/entities/src/EntityItem.cpp
+++ b/libraries/entities/src/EntityItem.cpp
@@ -1759,12 +1759,11 @@ bool EntityItem::contains(const glm::vec3& point) const {
     ShapeType shapeType = getShapeType();
 
     if (shapeType == SHAPE_TYPE_SPHERE) {
-        // SPHERE case is special:
-        // anything with shapeType == SPHERE must collide as a bounding sphere in the world-frame regardless of dimensions
-        // therefore we must do math using an unscaled localPoint relative to sphere center
         glm::vec3 dimensions = getScaledDimensions();
-        glm::vec3 localPoint = point - (getWorldPosition() + getWorldOrientation() * (dimensions * (ENTITY_ITEM_DEFAULT_REGISTRATION_POINT - getRegistrationPoint()) + getPivot()));
-        return glm::length2(localPoint) < glm::length2(0.5f * glm::max(dimensions.x, glm::max(dimensions.y, dimensions.z)));
+        if (dimensions.x == dimensions.y && dimensions.y == dimensions.z) {
+            glm::vec3 localPoint = point - (getWorldPosition() + getWorldOrientation() * (dimensions * (ENTITY_ITEM_DEFAULT_REGISTRATION_POINT - getRegistrationPoint()) + getPivot()));
+            return glm::length2(localPoint) < glm::length2(0.5f * dimensions.x);
+        }
     }
 
     // we transform into the "normalized entity-frame" where the bounding box is centered on the origin
@@ -1791,6 +1790,7 @@ bool EntityItem::contains(const glm::vec3& point) const {
             localPoint = glm::abs(localPoint);
             return glm::all(glm::lessThanEqual(localPoint, glm::vec3(NORMALIZED_HALF_SIDE)));
         }
+        case SHAPE_TYPE_SPHERE:
         case SHAPE_TYPE_ELLIPSOID: {
             // since we've transformed into the normalized space this is just a sphere-point intersection test
             return glm::length2(localPoint) <= NORMALIZED_RADIUS_SQUARED;

--- a/libraries/physics/src/ShapeFactory.cpp
+++ b/libraries/physics/src/ShapeFactory.cpp
@@ -278,12 +278,6 @@ const btCollisionShape* ShapeFactory::createShapeFromInfo(const ShapeInfo& info)
             shape = new btBoxShape(glmToBullet(info.getHalfExtents()));
         }
         break;
-        case SHAPE_TYPE_SPHERE: {
-            glm::vec3 halfExtents = info.getHalfExtents();
-            float radius = glm::max(halfExtents.x, glm::max(halfExtents.y, halfExtents.z));
-            shape = new btSphereShape(radius);
-        }
-        break;
         case SHAPE_TYPE_MULTISPHERE: {
             std::vector<btVector3> positions;
             std::vector<float> radiuses;
@@ -297,6 +291,7 @@ const btCollisionShape* ShapeFactory::createShapeFromInfo(const ShapeInfo& info)
             shape->setMargin(MULTI_SPHERE_MARGIN);
         }
         break;
+        case SHAPE_TYPE_SPHERE:
         case SHAPE_TYPE_ELLIPSOID: {
             glm::vec3 halfExtents = info.getHalfExtents();
             float radius = halfExtents.x;

--- a/libraries/shared/src/ShapeInfo.cpp
+++ b/libraries/shared/src/ShapeInfo.cpp
@@ -115,12 +115,6 @@ void ShapeInfo::setParams(ShapeType type, const glm::vec3& halfExtents, QString 
         case SHAPE_TYPE_HULL:
         case SHAPE_TYPE_MULTISPHERE:
             break;
-        case SHAPE_TYPE_SPHERE: {
-                float radius = glm::length(halfExtents) / SQUARE_ROOT_OF_3;
-                radius = glm::max(radius, MIN_HALF_EXTENT);
-                _halfExtents = glm::vec3(radius);
-            }
-            break;
         case SHAPE_TYPE_CIRCLE: {
             _halfExtents = glm::vec3(_halfExtents.x, MIN_HALF_EXTENT, _halfExtents.z);
         }
@@ -228,6 +222,7 @@ float ShapeInfo::computeVolume() const {
             volume = 8.0f * _halfExtents.x * _halfExtents.y * _halfExtents.z;
             break;
         }
+        case SHAPE_TYPE_ELLIPSOID:
         case SHAPE_TYPE_SPHERE: {
             volume = 4.0f * PI * _halfExtents.x * _halfExtents.y * _halfExtents.z / 3.0f;
             break;

--- a/scripts/system/create/entityProperties/html/js/entityProperties.js
+++ b/scripts/system/create/entityProperties/html/js/entityProperties.js
@@ -281,7 +281,7 @@ const GROUPS = [
             {
                 label: "Shape Type",
                 type: "dropdown",
-                options: { "box": "Box", "sphere": "Sphere", "ellipsoid": "Ellipsoid", 
+                options: { "box": "Box", "sphere": "Sphere",
                            "cylinder-y": "Cylinder", "compound": "Use Compound Shape URL" },
                 propertyID: "zoneShapeType",
                 propertyName: "shapeType", // actual entity property name

--- a/scripts/system/create/modules/entityShapeVisualizer.js
+++ b/scripts/system/create/modules/entityShapeVisualizer.js
@@ -13,6 +13,7 @@
 var SHAPETYPE_TO_SHAPE = {
     "box": "Cube",
     "ellipsoid": "Sphere",
+    "sphere": "Sphere",
     "cylinder-y": "Cylinder",
 };
 
@@ -34,14 +35,6 @@ function getEntityShapePropertiesForType(properties) {
                     type: "Model",
                     modelURL: properties.compoundShapeURL,
                     localDimensions: properties.localDimensions
-                };
-            } else if (properties.shapeType === "sphere") {
-                var sphereDiameter = Math.max(properties.localDimensions.x, properties.localDimensions.y,
-                    properties.localDimensions.z);
-                return {
-                    type: "Sphere",
-                    modelURL: properties.compoundShapeURL,
-                    localDimensions: {x: sphereDiameter, y: sphereDiameter, z: sphereDiameter}
                 };
             }
             break;


### PR DESCRIPTION
fix https://github.com/vircadia/vircadia/issues/172

which zones you are in is determined by `EntityTreeRenderer::findBestZoneAndMaybeContainingEntities`, which first calls `evalEntitiesInSphere` (which does a rough bounding box/sphere check) and then, under certain circumstances, calls `contains` on each of those entities to make sure we're actually inside them.  however, when a zone's visibility or transform is edited, we also immediately call `EntityTreeRenderer::LayeredZones::update`, which calls `contains` on the zone (not `evalEntitiesInSphere`).  `EntityItem::contains` was wrong for this case, so it would improperly return `true` when you were in the corner, but then next frame, when we call `evalEntitiesInSphere`, it would remove the zone before `contains` could be called.  this would result in a single frame pop of the spherical zone anytime you edited its transform

the fix is simple, but exposes another question: when you non-uniformly scale a "sphere" zone currently, we use its *max* dimension (both in EntityItem::contains and in entityShapeVisualizer.js for Create).  this means that if you make one dimension bigger, it actually extends outside of its bounding box in the other two dimensions, which seems wrong.  for zones specifically, it also means that this sphere clips against its bounding box (because `evalEntitiesInSphere` falls back to a bounding box check for non-uniformly scaled spheres).  is this current behavior for non-uniformly scaled sphere zones correct?  it would be easy to change these to `min`s in EntityItem::contains and entityShapeVisualizer.js

...but models actually have the same behavior when you give them sphere colliders and non-uniform dimensions.  see `ShapeInfo::setParams` and `ShapeFactory::createShapeFromInfo` should these be changed too?

UPDATE: "sphere" zones and models now behave like sphere shapes; they handle uniform dimensions and automatically switch to ellipsoids internally to handle non-uniform dimensions.

Test plan:
- Confirm that the repro steps in #172 no longer show a flash
- Confirm that "sphere" zones work properly, when they are scaled uniformly and when they are stretched
- Confirm that "sphere" collisions for models now scale with them properly, unlike in master