### PR TITLE
Name a bunch of threads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ tools/unity-avatar-exporter
 server-console/package-lock.json
 vcpkg/
 /tools/nitpick/compiledResources
+qt/

--- a/assignment-client/src/audio/AudioMixerSlavePool.cpp
+++ b/assignment-client/src/audio/AudioMixerSlavePool.cpp
@@ -11,8 +11,12 @@
 
 #include "AudioMixerSlavePool.h"
 
+#include <QObject>
+
 #include <assert.h>
 #include <algorithm>
+
+#include <ThreadHelpers.h>
 
 void AudioMixerSlaveThread::run() {
     while (true) {
@@ -157,6 +161,7 @@ void AudioMixerSlavePool::resize(int numThreads) {
         // start new slaves
         for (int i = 0; i < numThreads - _numThreads; ++i) {
             auto slave = new AudioMixerSlaveThread(*this, _workerSharedData);
+            QObject::connect(slave, &QThread::started, [] { setThreadName("AudioMixerSlaveThread"); });
             slave->start();
             _slaves.emplace_back(slave);
         }

--- a/assignment-client/src/octree/OctreeServer.cpp
+++ b/assignment-client/src/octree/OctreeServer.cpp
@@ -34,6 +34,7 @@
 #include <QtCore/QDir>
 
 #include <OctreeDataUtils.h>
+#include <ThreadHelpers.h>
 
 Q_LOGGING_CATEGORY(octree_server, "hifi.octree-server")
 
@@ -1192,7 +1193,10 @@ void OctreeServer::domainSettingsRequestComplete() {
                                                  _persistAsFileType);
         _persistManager->moveToThread(&_persistThread);
         connect(&_persistThread, &QThread::finished, _persistManager, &QObject::deleteLater);
-        connect(&_persistThread, &QThread::started, _persistManager, &OctreePersistThread::start);
+        connect(&_persistThread, &QThread::started, _persistManager, [this] {
+            setThreadName("OctreePersistThread");
+            _persistManager->start();
+        });
         connect(_persistManager, &OctreePersistThread::loadCompleted, this, [this]() {
             beginRunning();
         });

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -60,6 +60,7 @@
 #include <Gzip.h>
 
 #include <OctreeDataUtils.h>
+#include <ThreadHelpers.h>
 
 using namespace std::chrono;
 
@@ -830,9 +831,11 @@ void DomainServer::setupNodeListAndAssignments() {
     // set a custom packetVersionMatch as the verify packet operator for the udt::Socket
     nodeList->setPacketFilterOperator(&DomainServer::isPacketVerified);
 
-    _assetClientThread.setObjectName("AssetClient Thread");
+    QString name = "AssetClient Thread";
+    _assetClientThread.setObjectName(name);
     auto assetClient = DependencyManager::set<AssetClient>();
     assetClient->moveToThread(&_assetClientThread);
+    connect(&_assetClientThread, &QThread::started, [name] { setThreadName(name.toStdString()); });
     _assetClientThread.start();
     // add whatever static assignments that have been parsed to the queue
     addStaticAssignmentsToQueue();

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -254,6 +254,7 @@
 
 #include "AboutUtil.h"
 #include "ExternalResource.h"
+#include <ThreadHelpers.h>
 
 #if defined(Q_OS_WIN)
 #include <VersionHelpers.h>
@@ -1168,6 +1169,7 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     if (!DISABLE_WATCHDOG) {
         auto deadlockWatchdogThread = new DeadlockWatchdogThread();
         deadlockWatchdogThread->setMainThreadID(QThread::currentThreadId());
+        connect(deadlockWatchdogThread, &QThread::started, [] { setThreadName("DeadlockWatchdogThread"); });
         deadlockWatchdogThread->start();
 
         // Pause the deadlock watchdog when we sleep, or it might
@@ -5206,6 +5208,7 @@ void getCpuUsage(vec3& systemAndUser) {
 void setupCpuMonitorThread() {
     initCpuUsage();
     auto cpuMonitorThread = QThread::currentThread();
+    setThreadName("CPU Monitor Thread");
 
     QTimer* timer = new QTimer();
     timer->setInterval(50);

--- a/libraries/audio/src/AudioInjectorManager.cpp
+++ b/libraries/audio/src/AudioInjectorManager.cpp
@@ -15,6 +15,7 @@
 
 #include <SharedUtil.h>
 #include <shared/QtHelpers.h>
+#include <ThreadHelpers.h>
 
 #include "AudioConstants.h"
 #include "AudioInjector.h"
@@ -54,11 +55,14 @@ AudioInjectorManager::~AudioInjectorManager() {
 }
 
 void AudioInjectorManager::createThread() {
-    _thread = new QThread;
+    _thread = new QThread();
     _thread->setObjectName("Audio Injector Thread");
 
     // when the thread is started, have it call our run to handle injection of audio
-    connect(_thread, &QThread::started, this, &AudioInjectorManager::run, Qt::DirectConnection);
+    connect(_thread, &QThread::started, this, [this] {
+        setThreadName("AudioInjectorManager");
+        run();
+    }, Qt::DirectConnection);
 
     moveToThread(_thread);
 

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -50,6 +50,7 @@
 #include "CompositorHelper.h"
 #include "Logging.h"
 #include "RefreshRateController.h"
+#include <ThreadHelpers.h>
 
 using namespace shader::gpu::program;
 
@@ -285,6 +286,7 @@ bool OpenGLDisplayPlugin::activate() {
         widget->context()->doneCurrent();
 
         presentThread->setContext(widget->context());
+        connect(presentThread.data(), &QThread::started, [] { setThreadName("OpenGL Present Thread"); });
         // Start execution
         presentThread->start();
     }

--- a/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
@@ -304,7 +304,9 @@ void GLTextureTransferEngineDefault::processTransferQueues() {
 #if THREADED_TEXTURE_BUFFERING
     if (!_transferThread) {
         _transferThread = new TextureBufferThread(*this);
-        QObject::connect(_transferThread, &QThread::started, [] { setThreadName("TextureBufferThread"); });
+        QString name = "TextureBufferThread";
+        _transferThread->setObjectName(name);
+        QObject::connect(_transferThread, &QThread::started, [name] { setThreadName(name.toStdString()); });
         _transferThread->start();
     }
 #endif

--- a/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
+++ b/libraries/gpu-gl-common/src/gpu/gl/GLTextureTransfer.cpp
@@ -8,8 +8,10 @@
 
 #include "GLTexture.h"
 
+#include <QObject>
 #include <QtCore/QThread>
 #include <NumericalConstants.h>
+#include <ThreadHelpers.h>
 
 #include "GLBackend.h"
 
@@ -64,7 +66,7 @@ public:
 protected:
     class TextureBufferThread : public QThread {
     public:
-        TextureBufferThread(GLTextureTransferEngineDefault& parent) : _parent(parent) { start(); }
+        TextureBufferThread(GLTextureTransferEngineDefault& parent) : _parent(parent) {}
 
     protected:
         void run() override {
@@ -302,6 +304,8 @@ void GLTextureTransferEngineDefault::processTransferQueues() {
 #if THREADED_TEXTURE_BUFFERING
     if (!_transferThread) {
         _transferThread = new TextureBufferThread(*this);
+        QObject::connect(_transferThread, &QThread::started, [] { setThreadName("TextureBufferThread"); });
+        _transferThread->start();
     }
 #endif
 

--- a/libraries/networking/src/ResourceManager.cpp
+++ b/libraries/networking/src/ResourceManager.cpp
@@ -19,6 +19,7 @@
 #include <QFileInfo>
 
 #include <SharedUtil.h>
+#include <ThreadHelpers.h>
 
 #include "AssetResourceRequest.h"
 #include "FileResourceRequest.h"
@@ -28,12 +29,16 @@
 #include "NetworkingConstants.h"
 
 ResourceManager::ResourceManager(bool atpSupportEnabled) : _atpSupportEnabled(atpSupportEnabled) {
-    _thread.setObjectName("Resource Manager Thread");
+    QString name = "Resource Manager Thread";
+    _thread.setObjectName(name);
 
     if (_atpSupportEnabled) {
         auto assetClient = DependencyManager::set<AssetClient>();
         assetClient->moveToThread(&_thread);
-        QObject::connect(&_thread, &QThread::started, assetClient.data(), &AssetClient::initCaching);
+        QObject::connect(&_thread, &QThread::started, assetClient.data(), [assetClient, name] {
+            setThreadName(name.toStdString());
+            assetClient->initCaching();
+        });
     }
 
     _thread.start();

--- a/libraries/qml/src/qml/impl/SharedObject.cpp
+++ b/libraries/qml/src/qml/impl/SharedObject.cpp
@@ -29,6 +29,7 @@
 #include "RenderControl.h"
 #include "RenderEventHandler.h"
 #include "TextureCache.h"
+#include <ThreadHelpers.h>
 
 // Time between receiving a request to render the offscreen UI actually triggering
 // the render.  Could possibly be increased depending on the framerate we expect to
@@ -162,7 +163,9 @@ void SharedObject::setRootItem(QQuickItem* rootItem) {
 
     // Create the render thread
     _renderThread = new QThread();
-    _renderThread->setObjectName(objectName());
+    QString name = objectName();
+    _renderThread->setObjectName(name);
+    QObject::connect(_renderThread, &QThread::started, [name] { setThreadName("QML SharedObject " + name.toStdString()); });
     _renderThread->start();
 
     // Create event handler for the render thread

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -87,7 +87,7 @@
 #include "SettingHandle.h"
 #include <AddressManager.h>
 #include <NetworkingConstants.h>
-
+#include <ThreadHelpers.h>
 
 const QString ScriptEngine::_SETTINGS_ENABLE_EXTENDED_EXCEPTIONS {
     "com.highfidelity.experimental.enableExtendedJSExceptions"
@@ -429,13 +429,17 @@ void ScriptEngine::runInThread() {
     // The thread interface cannot live on itself, and we want to move this into the thread, so
     // the thread cannot have this as a parent.
     QThread* workerThread = new QThread();
-    workerThread->setObjectName(QString("js:") + getFilename().replace("about:",""));
+    QString name = QString("js:") + getFilename().replace("about:","");
+    workerThread->setObjectName(name);
     moveToThread(workerThread);
 
     // NOTE: If you connect any essential signals for proper shutdown or cleanup of
     // the script engine, make sure to add code to "reconnect" them to the
     // disconnectNonEssentialSignals() method
-    connect(workerThread, &QThread::started, this, &ScriptEngine::run);
+    connect(workerThread, &QThread::started, this, [this, name] {
+        setThreadName(name.toStdString());
+        run();
+    });
     connect(this, &QObject::destroyed, workerThread, &QThread::quit);
     connect(workerThread, &QThread::finished, workerThread, &QObject::deleteLater);
 

--- a/libraries/shared/src/GenericThread.cpp
+++ b/libraries/shared/src/GenericThread.cpp
@@ -14,6 +14,8 @@
 #include <QDebug>
 #include <QtCore/QCoreApplication>
 
+#include "ThreadHelpers.h"
+
 GenericThread::GenericThread() :
     _stopThread(false),
     _isThreaded(false) // assume non-threaded, must call initialize()
@@ -36,8 +38,11 @@ void GenericThread::initialize(bool isThreaded, QThread::Priority priority) {
         // match the thread name to our object name
         _thread->setObjectName(objectName());
 
-        connect(_thread, &QThread::started, this, &GenericThread::started);
-        connect(_thread, &QThread::started, this, &GenericThread::threadRoutine);
+        connect(_thread, &QThread::started, this, [this] {
+            setThreadName("Generic thread " + objectName().toStdString());
+            started();
+            threadRoutine();
+        });
         connect(_thread, &QThread::finished, this, &GenericThread::finished);
 
         moveToThread(_thread);

--- a/libraries/shared/src/SettingInterface.cpp
+++ b/libraries/shared/src/SettingInterface.cpp
@@ -21,6 +21,7 @@
 #include "SettingManager.h"
 #include "SharedLogging.h"
 #include "SharedUtil.h"
+#include "ThreadHelpers.h"
 
 namespace Setting {
     // This should only run as a post-routine in the QCoreApplication destructor
@@ -53,7 +54,10 @@ namespace Setting {
         thread->setObjectName("Settings Thread");
 
         // Setup setting periodical save timer
-        QObject::connect(thread, &QThread::started, globalManager.data(), &Manager::startTimer);
+        QObject::connect(thread, &QThread::started, globalManager.data(), [globalManager] {
+            setThreadName("Settings Save Thread");
+            globalManager->startTimer();
+        });
         QObject::connect(thread, &QThread::finished, globalManager.data(), &Manager::stopTimer);
 
         // Setup manager threading affinity

--- a/libraries/shared/src/ThreadHelpers.h
+++ b/libraries/shared/src/ThreadHelpers.h
@@ -32,6 +32,8 @@ void withLock(QMutex& lock, F function) {
     function();
 }
 
+void setThreadName(const std::string& name);
+
 void moveToNewNamedThread(QObject* object, const QString& name, 
     std::function<void(QThread*)> preStartCallback, 
     std::function<void()> startCallback, 

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -595,7 +595,7 @@ void TabletProxy::gotoMenuScreen(const QString& submenu) {
 }
 
 void TabletProxy::loadQMLOnTopImpl(const QVariant& path, bool localSafeContext) {
-     if (QThread::currentThread() != thread()) {
+    if (QThread::currentThread() != thread()) {
         qCWarning(uiLogging) << __FUNCTION__ << "may not be called directly by scripts";
         return;
     }

--- a/plugins/openvr/src/OpenVrDisplayPlugin.cpp
+++ b/plugins/openvr/src/OpenVrDisplayPlugin.cpp
@@ -31,6 +31,7 @@
 #include <display-plugins/CompositorHelper.h>
 #include <ui-plugins/PluginContainer.h>
 #include <gl/OffscreenGLCanvas.h>
+#include <ThreadHelpers.h>
 
 #include "OpenVrHelpers.h"
 
@@ -494,6 +495,7 @@ bool OpenVrDisplayPlugin::internalActivate() {
                 _submitCanvas->doneCurrent();
             });
         }
+        connect(_submitThread.get(), &QThread::started, [] { setThreadName("OpenVR Submit Thread"); });
         _submitCanvas->moveToThread(_submitThread.get());
     }
 

--- a/plugins/openvr/src/ViveControllerManager.cpp
+++ b/plugins/openvr/src/ViveControllerManager.cpp
@@ -49,6 +49,7 @@
 #include <glm/gtc/quaternion.hpp>
 #include <ui-plugins/PluginContainer.h>
 #include <plugins/DisplayPlugin.h>
+#include <ThreadHelpers.h>
 
 #include <controllers/UserInputMapper.h>
 #include <plugins/InputConfiguration.h>
@@ -403,6 +404,7 @@ bool ViveControllerManager::activate() {
 
         if (_viveProEye) {
             _viveProEyeReadThread = std::make_shared<ViveProEyeReadThread>();
+            connect(_viveProEyeReadThread.get(), &QThread::started, [] { setThreadName("ViveProEyeReadThread"); });
             _viveProEyeReadThread->start(QThread::HighPriority);
         }
     }


### PR DESCRIPTION
this will hopefully help with debugging.  in VS, when you hit a breakpoint or pause execution (or crash), in the Thread dropdown, more threads will have descriptive names now.  there's still a lot of unnamed ones...I think some are from the QThreadPool, and evidently you can't name them because there's no way to name a thread multiple times (when they get reused).  a bunch are seemingly from web processes...and there's a bunch that I'm not sure what they do...

Test plan:
- no real functional change, make sure server and client both still work