### PR TITLE
Small optimisations and tidying related to MyAvatar

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -556,8 +556,6 @@ Menu::Menu() {
         });
 
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::FixGaze, 0, false);
-    addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::ToggleHipsFollowing, 0, false,
-        avatar.get(), SLOT(setToggleHips(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::AnimDebugDrawBaseOfSupport, 0, false,
         avatar.get(), SLOT(setEnableDebugDrawBaseOfSupport(bool)));
     addCheckableActionToQMenuAndActionHash(avatarDebugMenu, MenuOption::AnimDebugDrawDefaultPose, 0, false,

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -211,7 +211,6 @@ namespace MenuOption {
     const QString ThirdPerson = "Third Person Legacy";
     const QString ThreePointCalibration = "3 Point Calibration";
     const QString ThrottleFPSIfNotFocus = "Throttle FPS If Not Focus"; // FIXME - this value duplicated in Basic2DWindowOpenGLDisplayPlugin.cpp
-    const QString ToggleHipsFollowing = "Toggle Hips Following";
     const QString ToolWindow = "Tool Window";
     const QString TransmitterDrive = "Transmitter Drive";
     const QString TurnWithHead = "Turn using Head";

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1392,18 +1392,6 @@ float loadSetting(Settings& settings, const QString& name, float defaultValue) {
     return value;
 }
 
-void MyAvatar::setToggleHips(bool followHead) {
-    _follow.setToggleHipsFollowing(followHead);
-}
-
-void MyAvatar::FollowHelper::setToggleHipsFollowing(bool followHead) {
-    _toggleHipsFollowing = followHead;
-}
-
-bool MyAvatar::FollowHelper::getToggleHipsFollowing() const {
-    return _toggleHipsFollowing;
-}
-
 void MyAvatar::setEnableDebugDrawBaseOfSupport(bool isEnabled) {
     _enableDebugDrawBaseOfSupport = isEnabled;
 }
@@ -2030,7 +2018,6 @@ void MyAvatar::loadData() {
         allowAvatarLeaningPreferenceStrings[static_cast<uint>(AllowAvatarLeaningPreference::Default)])));
 
     setEnableMeshVisible(Menu::getInstance()->isOptionChecked(MenuOption::MeshVisible));
-    _follow.setToggleHipsFollowing (Menu::getInstance()->isOptionChecked(MenuOption::ToggleHipsFollowing));
     setEnableDebugDrawBaseOfSupport(Menu::getInstance()->isOptionChecked(MenuOption::AnimDebugDrawBaseOfSupport));
     setEnableDebugDrawDefaultPose(Menu::getInstance()->isOptionChecked(MenuOption::AnimDebugDrawDefaultPose));
     setEnableDebugDrawAnimPose(Menu::getInstance()->isOptionChecked(MenuOption::AnimDebugDrawAnimPose));
@@ -5514,7 +5501,7 @@ void MyAvatar::setSitStandStateChange(bool stateChanged) {
 }
 
 // Determine if the user's real-world sit/stand state has changed.
-float MyAvatar::getSitStandStateChange() const {
+bool MyAvatar::getSitStandStateChange() const {
     return _sitStandStateChange;
 }
 
@@ -5696,7 +5683,7 @@ bool MyAvatar::FollowHelper::shouldActivateHorizontal_userSitting(const MyAvatar
     bool stepDetected = false;
     if (forwardLeanAmount > MAX_FORWARD_LEAN) {
         stepDetected = true;
-    } else if (forwardLeanAmount < 0 && forwardLeanAmount < -MAX_BACKWARD_LEAN) {
+    } else if (forwardLeanAmount < -MAX_BACKWARD_LEAN) {
         stepDetected = true;
     } else {
         stepDetected = fabs(lateralLeanAmount) > MAX_LATERAL_LEAN;

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1392,6 +1392,12 @@ float loadSetting(Settings& settings, const QString& name, float defaultValue) {
     return value;
 }
 
+void MyAvatar::setToggleHips(bool followHead) {
+    Q_UNUSED(followHead);
+    qCDebug(interfaceapp) << "MyAvatar.setToggleHips is deprecated; it no longer does anything; it will soon be removed from the API; "
+                             "please update your script";
+}
+
 void MyAvatar::setEnableDebugDrawBaseOfSupport(bool isEnabled) {
     _enableDebugDrawBaseOfSupport = isEnabled;
 }

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -1800,7 +1800,7 @@ public:
     void setAnalogPlusSprintSpeed(float value);
     float getAnalogPlusSprintSpeed() const;
     void setSitStandStateChange(bool stateChanged);
-    float getSitStandStateChange() const;
+    bool getSitStandStateChange() const;
     void updateSitStandState(float newHeightReading, float dt);
 
     QVector<QString> getScriptUrls();
@@ -2180,13 +2180,6 @@ public slots:
      * @function MyAvatar.updateMotionBehaviorFromMenu
      */
     Q_INVOKABLE void updateMotionBehaviorFromMenu();
-
-    /**jsdoc
-     * @function MyAvatar.setToggleHips
-     * @param {boolean} enabled - Enabled.
-     * @deprecated This function is deprecated and will be removed.
-     */
-    void setToggleHips(bool followHead);
 
     /**jsdoc
      * Displays the base of support area debug graphics if in HMD mode. If your head goes outside this area your avatar's hips 
@@ -2907,8 +2900,6 @@ private:
         void setForceActivateVertical(bool val);
         bool getForceActivateHorizontal() const;
         void setForceActivateHorizontal(bool val);
-        bool getToggleHipsFollowing() const;
-        void setToggleHipsFollowing(bool followHead);
         std::atomic<bool> _forceActivateRotation { false };
         std::atomic<bool> _forceActivateVertical { false };
         std::atomic<bool> _forceActivateHorizontal { false };

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -2182,6 +2182,13 @@ public slots:
     Q_INVOKABLE void updateMotionBehaviorFromMenu();
 
     /**jsdoc
+     * @function MyAvatar.setToggleHips
+     * @param {boolean} enabled - Enabled.
+     * @deprecated This function is deprecated and will be removed.
+     */
+    void setToggleHips(bool followHead);
+
+    /**jsdoc
      * Displays the base of support area debug graphics if in HMD mode. If your head goes outside this area your avatar's hips 
      * are moved to counterbalance your avatar, and if your head moves too far then your avatar's position is moved (i.e., a 
      * step happens).

--- a/interface/src/ui/PreferencesDialog.cpp
+++ b/interface/src/ui/PreferencesDialog.cpp
@@ -364,7 +364,7 @@ void setupPreferences() {
         auto preference = new SpinnerSliderPreference(VR_MOVEMENT, "Camera Sensitivity", getter, setter);
         preference->setMin(0.01f);
         preference->setMax(5.0f);
-        preference->setStep(0.1);
+        preference->setStep(0.1f);
         preference->setDecimals(2);
         preferences->addPreference(preference);
     }

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1444,9 +1444,7 @@ int Avatar::getJointIndex(const QString& name) const {
     }
 
     withValidJointIndicesCache([&]() {
-        if (_modelJointIndicesCache.contains(name)) {
-            result = _modelJointIndicesCache.value(name) - 1;
-        }
+        result = _modelJointIndicesCache.value(name, result + 1) - 1;
     });
     return result;
 }

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -1938,6 +1938,10 @@ void AvatarData::clearJointsData() {
 }
 
 int AvatarData::getFauxJointIndex(const QString& name) const {
+    static constexpr QChar fauxJointFirstChar('_');// The first character of all the faux joint names.
+    if (!name.startsWith(fauxJointFirstChar)) {
+        return -1;
+    };
     if (name == "_SENSOR_TO_WORLD_MATRIX") {
         return SENSOR_TO_WORLD_MATRIX_INDEX;
     }


### PR DESCRIPTION
This PR consists of small optimisations and tidying of things that were noticed in passing, related to `MyAvatar`.  No behaviour should change.

1. Removed the "Toggle Hips Following" option from the Developer menu.  It had no effect on any code.
2. The deprecated `MyAvatar.setToggleHips` script function, which had no effect on any code, now ouptuts a log warning indicating that it's deprecated.
3. In `CharacterController::applyMotor`, prevented unnecessary calls to `btVector3::rotate()` when the motor has no rotation.  This change also improves readability through the use of clearly-named lambdas.
4. In `AvatarData::getFauxJointIndex`, prevented unnecessary string comparisons when the named joint is a real joint rather than a faux one.
5. In `Avatar::getJointIndex`, removed an unnecessary call to `QHash<QString, int>::contains()`, by supplying a default index for `QHash<QString, int>::value()`.
6. Removed unnecessary condition "`forwardLeanAmount < 0`" in `MyAvatar::FollowHelper::shouldActivateHorizontal_userSitting`.
7. Corrected the return type of `MyAvatar::getSitStandStateChange` from float to bool.
8. Added a missing 'f' suffix to a float literal in PreferencesDialog.cpp (fixes warning C4305: "'argument': truncation from 'double' to 'float'").