### PR TITLE
Add messaging mixer rate limiting per node functionality.

### DIFF
--- a/assignment-client/src/messages/MessagesMixer.cpp
+++ b/assignment-client/src/messages/MessagesMixer.cpp
@@ -103,8 +103,9 @@ void MessagesMixer::sendStatsPacket() {
 }
 
 void MessagesMixer::run() {
-    // wait until we have the domain-server settings, otherwise we bail
-    DomainHandler& domainHandler = DependencyManager::get<NodeList>()->getDomainHandler();
+    auto nodeList = DependencyManager::get<NodeList>();
+    nodeList->addSetOfNodeTypesToNodeInterestSet({ NodeType::Agent, NodeType::EntityScriptServer });
+    DomainHandler& domainHandler = nodeList->getDomainHandler();
     connect(&domainHandler, &DomainHandler::settingsReceived, this, &MessagesMixer::domainSettingsRequestComplete);
 
     ThreadedAssignment::commonInit(MESSAGES_MIXER_LOGGING_NAME, NodeType::MessagesMixer);
@@ -114,7 +115,6 @@ void MessagesMixer::run() {
 
 void MessagesMixer::domainSettingsRequestComplete() {
     auto nodeList = DependencyManager::get<NodeList>();
-    nodeList->addSetOfNodeTypesToNodeInterestSet({ NodeType::Agent, NodeType::EntityScriptServer });
 
     // parse the settings to pull out the values we need
     parseDomainServerSettings(nodeList->getDomainHandler().getSettingsObject());

--- a/assignment-client/src/messages/MessagesMixer.cpp
+++ b/assignment-client/src/messages/MessagesMixer.cpp
@@ -132,6 +132,10 @@ void MessagesMixer::processMaxMessagesContainer() {
 }
 
 void MessagesMixer::startMaxMessagesProcessor() {
+    if (_maxMessagesTimer) {
+        stopMaxMessagesProcessor();
+    }
+
     _maxMessagesTimer = new QTimer();
     connect(_maxMessagesTimer, &QTimer::timeout, this, &MessagesMixer::processMaxMessagesContainer);
     _maxMessagesTimer->start(MESSAGES_MIXER_RATE_LIMITER_INTERVAL); // Clear the container every second.

--- a/assignment-client/src/messages/MessagesMixer.cpp
+++ b/assignment-client/src/messages/MessagesMixer.cpp
@@ -53,7 +53,7 @@ void MessagesMixer::handleMessages(QSharedPointer<ReceivedMessage> receivedMessa
     auto itr = _allSubscribers.find(senderUUID);
     if (itr == _allSubscribers.end()) {
         _allSubscribers[senderUUID] = 1;
-    } else if (*itr >= _maxMessagesPerSecond) {  // this syntax might be wrong I forget
+    } else if (*itr >= _maxMessagesPerSecond) {
         return;
     } else {
         *itr += 1;

--- a/assignment-client/src/messages/MessagesMixer.cpp
+++ b/assignment-client/src/messages/MessagesMixer.cpp
@@ -49,13 +49,15 @@ void MessagesMixer::handleMessages(QSharedPointer<ReceivedMessage> receivedMessa
     MessagesClient::decodeMessagesPacket(receivedMessage, channel, isText, message, data, senderID);
 
     auto nodeList = DependencyManager::get<NodeList>();
-    if (_allSubscribers.value(senderUUID) >= _maxMessagesPerSecond) {
-        // We will reject all messages that go over this limit for that second. 
-        // FIXME: We will add logging options to offer analytics on this later.
-        return;
-    }
 
-    _allSubscribers[senderUUID] += 1;
+    auto itr = _allSubscribers.find(senderUUID);
+    if (itr == _allSubscribers.end()) {
+        _allSubscribers[senderUUID] = 1;
+    } else if (*itr >= _maxMessagesPerSecond) {  // this syntax might be wrong I forget
+        return;
+    } else {
+        *itr += 1;
+    }
 
     nodeList->eachMatchingNode(
         [&](const SharedNodePointer& node)->bool {

--- a/assignment-client/src/messages/MessagesMixer.cpp
+++ b/assignment-client/src/messages/MessagesMixer.cpp
@@ -73,8 +73,6 @@ void MessagesMixer::handleMessagesSubscribe(QSharedPointer<ReceivedMessage> mess
     QString channel = QString::fromUtf8(message->getMessage());
 
     _channelSubscribers[channel] << senderUUID;
-
-    _allSubscribers[senderUUID] = 0;
 }
 
 void MessagesMixer::handleMessagesUnsubscribe(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode) {
@@ -83,18 +81,6 @@ void MessagesMixer::handleMessagesUnsubscribe(QSharedPointer<ReceivedMessage> me
 
     if (_channelSubscribers.contains(channel)) {
         _channelSubscribers[channel].remove(senderUUID);
-    }
-
-    bool isSenderSubscribed = false;
-    QList<QSet<QUuid>> allChannels = _channelSubscribers.values();
-    foreach (const QSet<QUuid> channel, allChannels) { 
-        if (channel.contains(senderUUID)) {
-            isSenderSubscribed = true;
-        }
-    }
-
-    if (!isSenderSubscribed && _allSubscribers.contains(senderUUID)) {
-        _allSubscribers.remove(senderUUID);
     }
 }
 

--- a/assignment-client/src/messages/MessagesMixer.h
+++ b/assignment-client/src/messages/MessagesMixer.h
@@ -32,9 +32,21 @@ private slots:
     void handleMessages(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void handleMessagesSubscribe(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
     void handleMessagesUnsubscribe(QSharedPointer<ReceivedMessage> message, SharedNodePointer senderNode);
+    void parseDomainServerSettings(const QJsonObject& domainSettings);
+    void domainSettingsRequestComplete();
+
+    void startMaxMessagesProcessor();
+    void stopMaxMessagesProcessor();
+    void processMaxMessagesContainer();
 
 private:
-    QHash<QString,QSet<QUuid>> _channelSubscribers;
+    QHash<QString, QSet<QUuid>> _channelSubscribers;
+    QHash<QUuid, int> _allSubscribers;
+
+    const int DEFAULT_NODE_MESSAGES_PER_SECOND = 1000;
+    int _maxMessagesPerSecond{ 0 };
+
+    QTimer* maxMessagesPerSecondTimer;
 };
 
 #endif // hifi_MessagesMixer_h

--- a/assignment-client/src/messages/MessagesMixer.h
+++ b/assignment-client/src/messages/MessagesMixer.h
@@ -46,7 +46,7 @@ private:
     const int DEFAULT_NODE_MESSAGES_PER_SECOND = 1000;
     int _maxMessagesPerSecond { 0 };
 
-    QTimer* _maxMessagesTimer;
+    QTimer* _maxMessagesTimer { nullptr };
 };
 
 #endif // hifi_MessagesMixer_h

--- a/assignment-client/src/messages/MessagesMixer.h
+++ b/assignment-client/src/messages/MessagesMixer.h
@@ -44,9 +44,9 @@ private:
     QHash<QUuid, int> _allSubscribers;
 
     const int DEFAULT_NODE_MESSAGES_PER_SECOND = 1000;
-    int _maxMessagesPerSecond{ 0 };
+    int _maxMessagesPerSecond { 0 };
 
-    QTimer* maxMessagesPerSecondTimer;
+    QTimer* _maxMessagesTimer;
 };
 
 #endif // hifi_MessagesMixer_h

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -1489,6 +1489,24 @@
       ]
     },
     {
+      "name": "messages_mixer",
+      "label": "Messages Mixer",
+      "assignment-types": [
+        4
+      ],
+      "settings": [
+        {
+          "name": "max_node_messages_per_second",
+          "type": "int",
+          "label": "Per-Node Send Messages",
+          "help": "Desired maximum send messages (in messages per second) per node",
+          "placeholder": 1000,
+          "default": 1000,
+          "advanced": true
+        }
+      ]
+    },
+    {
       "name": "entity_server_settings",
       "label": "Entities",
       "assignment-types": [

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -1498,8 +1498,8 @@
         {
           "name": "max_node_messages_per_second",
           "type": "int",
-          "label": "Per-Node Send Messages",
-          "help": "Desired maximum send messages (in messages per second) per node",
+          "label": "Maximum Message Rate",
+          "help": "Maximum message send rate (messages per second) per node",
           "placeholder": 1000,
           "default": 1000,
           "advanced": true


### PR DESCRIPTION
This PR will stop sending messages for nodes that surpass a certain amount of messages within one second. Currently the default is 1000 messages per second meaning you'd have to send an average of 1 message per millisecond to hit the limit, so under normal usage without knowledge of this setting... you will be unlikely to have this be an issue.

Future to-do: figure out a way to log messages in a performant way about the node going over the limit (spamming). 

Question: Does the repeated log entry thing work with this so if 1000 messages piled up in a second, only a chunk of them will actually see the light? Is that pretty performant...?

To test:

1. Go to your domain server settings, scroll to the `Messaging Mixer` area and set `Per-Node Send Messages` to something low like 2.
2. Connect to that domain with two clients (or two different people.)
3. Very quickly press enter, hit a letter or two on your keyboard, press enter again. (Try to spam the chat as much as possible in as short a time as possible to hit the limit.)
4. Notice how the first few messages come through to the other client but no others are seen until a second passes.
5. Raise the limit to 500 and notice how all spammed messages come through.