### PR TITLE
Domain chat muted by default

### DIFF
--- a/scripts/communityScripts/chat/FloofChat.js
+++ b/scripts/communityScripts/chat/FloofChat.js
@@ -61,8 +61,8 @@ var settingsRoot = "FloofChat";
 var vircadiaGotoUrl = "https://metaverse.vircadia.com/interim/d-goto/app/goto.json";
 var gotoJSONUrl = Settings.getValue(settingsRoot + "/gotoJSONUrl", vircadiaGotoUrl);
 
-var muted = Settings.getValue(settingsRoot + "/muted", {"Local": false, "Domain": false, "Grid": true});
-var mutedAudio = Settings.getValue(settingsRoot + "/mutedAudio", {"Local": false, "Domain": false, "Grid": true});
+var muted = Settings.getValue(settingsRoot + "/muted", {"Local": false, "Domain": true, "Grid": true});
+var mutedAudio = Settings.getValue(settingsRoot + "/mutedAudio", {"Local": false, "Domain": true, "Grid": true});
 var notificationSound = SoundCache.getSound(Script.resolvePath("resources/bubblepop.wav"));
 
 var ws;


### PR DESCRIPTION
This helps to prevent chat spam when a large amount of people are in a domain. Further improvements and overhauls will be done to the chat on this feature and many others when a new chat client is created.