### PR TITLE
Fix avatar parts rotating

### DIFF
--- a/libraries/entities-renderer/src/RenderableEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableEntityItem.h
@@ -132,7 +132,7 @@ protected:
     RenderLayer _renderLayer { RenderLayer::WORLD };
     PrimitiveMode _primitiveMode { PrimitiveMode::SOLID };
     QVector<QUuid> _renderWithZones;
-    BillboardMode _billboardMode;
+    BillboardMode _billboardMode { BillboardMode::NONE };
     bool _cauterized { false };
     bool _moving { false };
     Transform _renderTransform;

--- a/libraries/render-utils/src/MeshPartPayload.h
+++ b/libraries/render-utils/src/MeshPartPayload.h
@@ -92,7 +92,7 @@ private:
     bool _cauterized { false };
     bool _cullWithParent { false };
     QVector<QUuid> _renderWithZones;
-    BillboardMode _billboardMode;
+    BillboardMode _billboardMode { BillboardMode::NONE };
     uint64_t _created;
 
     Transform _localTransform;


### PR DESCRIPTION
Possible fix for "Avatar pieces rotate in an incorrect offset sometimes", https://github.com/vircadia/vircadia/issues/1026 .

The easiest way I found of reproducing the problem was to clear cache and start up in a heavy domain while rotting avatar with keyboard and/or right-mouse-press-and-drag. Then, if the problem didn't occur, teleport to another heavy domain and immediately quit Interface. Then start up again there. ... and so on.