### PR TITLE
Hash Windows and Mac machine fingerprints.

### DIFF
--- a/libraries/networking/src/FingerprintUtils.cpp
+++ b/libraries/networking/src/FingerprintUtils.cpp
@@ -32,6 +32,18 @@
 #include <IOKit/storage/IOMedia.h>
 #endif //Q_OS_MAC
 
+// Number of iterations to apply to the hash, for stretching.
+// The number is arbitrary and has the only purpose of slowing down brute-force
+// attempts. The number here should be low enough not to cause any trouble for
+// low-end hardware.
+//
+// Changing this results in different hardware IDs being computed.
+static const int HASH_ITERATIONS = 65535;
+
+// Salt string for the hardware ID, makes our IDs unique to our project.
+// Changing this results in different hardware IDs being computed.
+static const QByteArray HASH_SALT{"Vircadia"};
+
 static const QString FALLBACK_FINGERPRINT_KEY = "fallbackFingerprint";
 
 QUuid FingerprintUtils::_machineFingerprint { QUuid() };
@@ -129,10 +141,10 @@ QString FingerprintUtils::getMachineFingerprintString() {
 #endif //Q_OS_WIN
 
     // Makes this hash unique to us
-    hash.addData("Vircadia");
+    hash.addData(HASH_SALT);
 
     // Stretching
-    for (int i=0; i < 65535; i++) {
+    for (int i = 0; i < HASH_ITERATIONS; i++) {
         hash.addData(hash.result());
     }
 


### PR DESCRIPTION
Now all the fingerprints are hashed. This has the following benefits:

* It doesn't expose raw system IDs. The actual ID is hashed with a value unique to Vircadia, so that it won't match any other identifier. This slightly improves privacy, since it won't be possible to match the fingerprint with any other service.

* It should be more future-proof. Apple doesn't promise that the platform ID will have any particular format. The hashing means it doesn't matter if it stops being a valid UUID at some point.

Testing of this is needed on Windows and OSX.

Testing procedure:

1. Connect to a domain with a previous client. Note the machine fingerprint being mentioned in the logs, eg:
`Mar 25 19:34:43 hub.daleglass.net domain-server[795]: [03/25 19:34:43] [DEBUG] [default] Allowed connection from node "00000000-0000-0000-0000-111122223333" on 0.0.0.0:52289 with MAC "00:AA:BB:CC:DD:EE" and machine fingerprint QUuid("{11112222-3333-4444-5555-666677778888}") user ""`
2. Connect to the domain again with this PR's client. The machine fingerprint should have changed compared to the older client.
3. Disconnect and connect to the domain again. The machine fingerprint should be the same between multiple runs.

Merging this PR will mean all Windows and OSX fingerprints will be invalidated and replaced with new ones. Therefore anybody using them for access control will need to update their configuration.

**Note:** Using fingerprints to grant access is a bad idea since impersonation isn't difficult. I only recommend using fingerprints for restricting access.
