### PR TITLE
Add virtual destructor to TreeNodeBase

### DIFF
--- a/libraries/script-engine/src/ScriptsModel.h
+++ b/libraries/script-engine/src/ScriptsModel.h
@@ -35,6 +35,7 @@ public:
     void setParent(TreeNodeFolder* parent) { _parent = parent; }
     TreeNodeType getType() { return _type; }
     const QString& getName() { return _name; };
+    virtual ~TreeNodeBase() = default;
 
 private:
     TreeNodeFolder* _parent;


### PR DESCRIPTION
Fixes #1131, possibly solves a crash on exit.

See https://www.geeksforgeeks.org/virtual-destructor/ for an explanation of why this is necessary.

Testing:

Testing is only properly possible with #1127 applied, but since the change is so simple this should be entirely harmless in any case. 
