### PR TITLE
Add missing override keywords.

### DIFF
--- a/libraries/entities-renderer/src/RenderableTextEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableTextEntityItem.h
@@ -44,7 +44,7 @@ protected:
     void onRemoveFromSceneTyped(const TypedEntityPointer& entity) override;
 
 private:
-    virtual bool needsRenderUpdate() const;
+    virtual bool needsRenderUpdate() const override;
     virtual void doRenderUpdateSynchronousTyped(const ScenePointer& scene, Transaction& transaction, const TypedEntityPointer& entity) override;
     virtual void doRenderUpdateAsynchronousTyped(const TypedEntityPointer& entity) override;
     virtual void doRender(RenderArgs* args) override;

--- a/libraries/networking/src/PacketReceiver.h
+++ b/libraries/networking/src/PacketReceiver.h
@@ -85,9 +85,9 @@ private:
     class UnsourcedListenerReference : public ListenerReference {
     public:
         inline UnsourcedListenerReference(T* target, void (T::*slot)(QSharedPointer<ReceivedMessage>));
-        virtual bool invokeDirectly(const QSharedPointer<ReceivedMessage>& receivedMessagePointer, const QSharedPointer<Node>& sourceNode);
-        virtual bool isSourced() const { return false; }
-        virtual QObject* getObject() const { return _target; }
+        virtual bool invokeDirectly(const QSharedPointer<ReceivedMessage>& receivedMessagePointer, const QSharedPointer<Node>& sourceNode) override;
+        virtual bool isSourced() const override { return false; }
+        virtual QObject* getObject() const override { return _target; }
 
     private:
         QPointer<T> _target;
@@ -98,9 +98,9 @@ private:
     class SourcedListenerReference : public ListenerReference {
     public:
         inline SourcedListenerReference(T* target, void (T::*slot)(QSharedPointer<ReceivedMessage>, QSharedPointer<Node>));
-        virtual bool invokeDirectly(const QSharedPointer<ReceivedMessage>& receivedMessagePointer, const QSharedPointer<Node>& sourceNode);
-        virtual bool isSourced() const { return true; }
-        virtual QObject* getObject() const { return _target; }
+        virtual bool invokeDirectly(const QSharedPointer<ReceivedMessage>& receivedMessagePointer, const QSharedPointer<Node>& sourceNode) override;
+        virtual bool isSourced() const override { return true; }
+        virtual QObject* getObject() const override { return _target; }
 
     private:
         QPointer<T> _target;


### PR DESCRIPTION
Fixes warnings like:
```
/libraries/entities-renderer/src/RenderableTextEntityItem.h:47:18: warning: ‘virtual bool render::entities::TextEntityRenderer::needsRenderUpdate() const’ can be marked override [-Wsuggest-override]
   47 |     virtual bool needsRenderUpdate() const;
      |                  ^~~~~~~~~~~~~~~~~
```