### PR TITLE
Log authentication events in the domain server

### DIFF
--- a/domain-server/src/DomainServer.h
+++ b/domain-server/src/DomainServer.h
@@ -43,6 +43,7 @@
 
 Q_DECLARE_LOGGING_CATEGORY(domain_server)
 Q_DECLARE_LOGGING_CATEGORY(domain_server_ice)
+Q_DECLARE_LOGGING_CATEGORY(domain_server_auth)
 
 typedef QSharedPointer<Assignment> SharedAssignmentPointer;
 typedef QMultiHash<QUuid, WalletTransaction*> TransactionHash;
@@ -232,6 +233,8 @@ private:
                                     std::initializer_list<QString> requiredData = { },
                                     std::initializer_list<QString> optionalData = { },
                                     bool requireAccessToken = true);
+
+    QString operationToString(const QNetworkAccessManager::Operation &op);
 
     SubnetList _acSubnetWhitelist;
 

--- a/libraries/embedded-webserver/src/HTTPConnection.h
+++ b/libraries/embedded-webserver/src/HTTPConnection.h
@@ -78,6 +78,9 @@ public:
     /// Returns a pointer to the underlying socket, to which WebSocket message bodies should be written.
     QTcpSocket* socket() const { return _socket; }
 
+    /// Returns the IP address on the other side of the connection
+    const QHostAddress &peerAddress() const { return _address; }
+
     /// Returns the request operation.
     QNetworkAccessManager::Operation requestOperation() const { return _requestOperation; }
 


### PR DESCRIPTION
The domain server currently doesn't log any information regarding the access to the management interface. This PR fixes that.

It adds access logging in the `vircadia.domain_server.auth` logging category. Example output:

"OPEN ACCESS" here means the server has no password set, and anyone can have unauthenticated access:
```
[04/03 15:57:59] [WARNING] [vircadia.domain_server.auth] "127.0.0.1" - OPEN ACCESS - "GET"   QUrl("/nodes.json")
[04/03 15:57:59] [WARNING] [vircadia.domain_server.auth] "127.0.0.1" - OPEN ACCESS - "GET"   QUrl("/assignments.json")
```

Basic auth was required but none was provided:
```
[04/03 17:33:54] [WARNING] [vircadia.domain_server.auth] "127.0.0.1" - Basic auth required - "GET"   QUrl("/")
```

Auth was provided for 'admin', but either the username or the password was wrong:
```
[04/03 17:33:54] [WARNING] [vircadia.domain_server.auth] "127.0.0.1" - Basic auth failed for "admin" - "GET"   QUrl("/assignments.json")
```

Successful access as user admin:
```
[04/03 17:35:26] [INFO] [vircadia.domain_server.auth] "127.0.0.1" - basic: "admin" - "GET"   QUrl("/")
[04/03 17:35:26] [INFO] [vircadia.domain_server.auth] "127.0.0.1" - basic: "admin" - "GET"   QUrl("/css/bootstrap.min.css")
```


The logging can be quite verbose, so it was given its own category, `vircadia.domain_server.auth`. This can be used in the `QT_LOGGING_RULES` environment variable to control the log output:

`QT_LOGGING_RULES="vircadia.domain_server.auth.info=false"` - Don't log successful accesses
`QT_LOGGING_RULES="vircadia.domain_server.auth.warning=false"` - Don't log failed accesses
`QT_LOGGING_RULES="vircadia.domain_server.auth=false"` - Don't log anything regarding authentication

Testing plan:
* Build
* Run `domain-server/domain-server`. Assignment clients aren't required.
* Connect to `http://localhost:40100` and experiment with authentication. Results should be as above.

This fixes #1151 

