### PR TITLE
Obtain script backtrace when a log event is generated in C++ code

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -255,6 +255,7 @@
 #include "AboutUtil.h"
 #include "ExternalResource.h"
 #include <ThreadHelpers.h>
+#include "ScriptEngineLoggingAgent.h"
 
 #if defined(Q_OS_WIN)
 #include <VersionHelpers.h>
@@ -7652,6 +7653,9 @@ void Application::registerScriptEngineWithApplicationServices(const ScriptEngine
     connect(scriptEngine.data(), &ScriptEngine::infoMessage, scriptEngines, &ScriptEngines::onInfoMessage);
     connect(scriptEngine.data(), &ScriptEngine::clearDebugWindow, scriptEngines, &ScriptEngines::onClearDebugWindow);
 
+
+    ScriptEngineLoggingAgent *scriptLogger = new ScriptEngineLoggingAgent(scriptEngine.data());
+    scriptEngine->setAgent(scriptLogger);
 }
 
 bool Application::canAcceptURL(const QString& urlString) const {

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -78,6 +78,7 @@
 #include "ScriptEngines.h"
 #include "StackTestScriptingInterface.h"
 #include "ModelScriptingInterface.h"
+#include "ScriptEngineLoggingAgent.h"
 
 #include <Profile.h>
 

--- a/libraries/script-engine/src/ScriptEngineLoggingAgent.cpp
+++ b/libraries/script-engine/src/ScriptEngineLoggingAgent.cpp
@@ -1,0 +1,52 @@
+//
+//  ScriptEngineLoggingAgent.cpp
+//  script-engine/src
+//
+//  Created by Dale Glass on 04/04/2021.
+//  Copyright 2021 Vircadia Contributors
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "ScriptEngineLoggingAgent.h"
+#include "ScriptContextHelper.h"
+#include <QObject>
+#include <QScriptEngine>
+#include <QDebug>
+#include <QLoggingCategory>
+#include <QScriptContextInfo>
+
+Q_LOGGING_CATEGORY(script_logger, "vircadia.script-engine.logging-agent")
+
+
+ScriptEngineLoggingAgent::ScriptEngineLoggingAgent(QScriptEngine *engine) : QScriptEngineAgent(engine) {
+
+}
+
+void ScriptEngineLoggingAgent::functionEntry(qint64 scriptId) {
+    if ( scriptId != -1) {
+        // We only care about non-native functions
+        return;
+    }
+
+    QStringList backtrace;
+    QScriptContext *ctx = engine()->currentContext();
+    while( ctx ) {
+        QScriptContextInfo ctx_info(ctx);
+        backtrace.append( QString("%1:%2 %3").arg(ctx_info.fileName()).arg(ctx_info.lineNumber()).arg(ctx_info.functionName()) );
+        ctx = ctx->parentContext();
+    }
+
+    ScriptContextHelper::push( backtrace );
+}
+
+void ScriptEngineLoggingAgent::functionExit(qint64 scriptId, const QScriptValue &returnValue) {
+    if ( scriptId != -1) {
+        // We only care about non-native functions
+        return;
+    }
+
+    ScriptContextHelper::pop();
+}
+

--- a/libraries/script-engine/src/ScriptEngineLoggingAgent.h
+++ b/libraries/script-engine/src/ScriptEngineLoggingAgent.h
@@ -1,0 +1,33 @@
+//
+//  ScriptEngineLoggingAgent.h
+//  script-engine/src
+//
+//  Created by Dale Glass on 04/04/2021.
+//  Copyright 2021 Vircadia Contributors
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef vircadia_ScriptEngineLoggingAgent_h
+#define vircadia_ScriptEngineLoggingAgent_h
+
+#include <QObject>
+#include <QStringList>
+#include <QScriptEngineAgent>
+#include <QThreadStorage>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(script_logger)
+
+
+
+class ScriptEngineLoggingAgent : public QScriptEngineAgent {
+public:
+    ScriptEngineLoggingAgent(QScriptEngine *engine);
+    virtual void functionEntry(qint64 scriptId) override;
+    virtual void functionExit(qint64 scriptId, const QScriptValue &returnValue) override;
+
+};
+
+#endif

--- a/libraries/shared/src/LogHandler.cpp
+++ b/libraries/shared/src/LogHandler.cpp
@@ -28,6 +28,7 @@
 #include <QtCore/QMutexLocker>
 #include <QtCore/QThread>
 #include <QtCore/QTimer>
+#include "ScriptContextHelper.h"
 
 QMutex LogHandler::_mutex(QMutex::Recursive);
 
@@ -209,6 +210,15 @@ QString LogHandler::printMessage(LogMsgType type, const QMessageLogContext& cont
             fprintf(stdout, "[Previous message was repeated %i times]\n", _repeatCount);
         }
 
+        if (strcmp(context.category, "vircadia.script-engine.logging-agent") != 0 ) {
+            QStringList context = ScriptContextHelper::get();
+            if ( !context.isEmpty()) {
+                fprintf(stdout, "Script context:\n");
+                for( auto line : context) {
+                    fprintf(stdout, "\t%s\n", line.toStdString().c_str());
+                }
+            }
+        }
         fprintf(stdout, "%s%s%s", color, qPrintable(logMessage), resetColor);
         _repeatCount = 0;
     } else {

--- a/libraries/shared/src/ScriptContextHelper.cpp
+++ b/libraries/shared/src/ScriptContextHelper.cpp
@@ -1,0 +1,45 @@
+//
+//  ScriptContextHelper.cpp
+//  shared/src
+//
+//  Created by Dale Glass on 04/04/2021.
+//  Copyright 2021 Vircadia Contributors
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#include "ScriptContextHelper.h"
+
+QThreadStorage<QList<QStringList>> ScriptContextHelper::_context;
+
+void  ScriptContextHelper::push(QStringList context) {
+    QList<QStringList> data = _context.localData();
+
+    data.append(context);
+
+    _context.setLocalData(data);
+}
+
+QStringList ScriptContextHelper::get() {
+    QList<QStringList> data = _context.localData();
+
+    if ( data.isEmpty() ) {
+        return QStringList();
+    } else {
+        return data.last();
+    }
+
+    //return _context.localData();
+}
+
+void ScriptContextHelper::pop() {
+    QList<QStringList> data = _context.localData();
+    
+    if (!data.isEmpty()) {
+        data.removeLast();
+    }
+
+    _context.setLocalData(data);
+}
+

--- a/libraries/shared/src/ScriptContextHelper.h
+++ b/libraries/shared/src/ScriptContextHelper.h
@@ -1,0 +1,31 @@
+//
+//  ScriptContextHelper.h
+//  shared/src
+//
+//  Created by Dale Glass on 04/04/2021.
+//  Copyright 2021 Vircadia Contributors
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+#ifndef vircadia_ScriptContextHelper_h
+#define vircadia_ScriptContextHelper_h
+
+#include <QObject>
+#include <QStringList>
+#include <QThreadStorage>
+#include <QList>
+
+
+class ScriptContextHelper {
+public:
+    static void push(QStringList context);
+    static QStringList get();
+    static void pop();
+
+private:
+    static QThreadStorage<QList<QStringList>> _context;
+};
+
+#endif


### PR DESCRIPTION
This is a very, very early prototype and doesn't work. Here's the overall idea:

When a C++ function logs something, such as:

```
[04/04 23:16:38] [WARNING] [hifi.scriptengine] Script.include() ignoring file path -- outside of standard libraries:  "" "/home/dale/git/vircadia/build-logging/interface/scripts"
```

We want to figure out where that came from. Which script resulted in this function being called? And this works to some extent:
```
Script context:
	:-1 include
	file:///home/dale/git/vircadia/build-logging/interface/scripts/defaultScripts.js:153 runDefaultsTogether
	file:///home/dale/git/vircadia/build-logging/interface/scripts/defaultScripts.js:185 
[04/04 23:16:38] [WARNING] [hifi.scriptengine] Script.include() ignoring file path -- outside of standard libraries:  "" "/home/dale/git/vircadia/build-logging/interface/scripts"
```

The problem is that a problem can be found at any arbitrary depth, not just in whatever QScriptEngine calls directly. So I figured out a way around that. Qt has the `QScriptEngineAgent`, which allows us invoke code at interesting points, such as script function calls, including calls to native code.

So the idea is:

1. On every native function call from ScriptEngine,  ScriptEngineLoggingAgent::functionEntry is called.
2. We generate a backtrace.
3. We give this to ScriptContextHelper, which remembers backtraces per-thread.
4. Execution continues, native function runs
5. Possibly more native code runs
6. Code logs an event. Execution eventually ends up in LogHandler.
7. LogHandler checks ScriptContextHelper, prints the backtrace if there's any.
8. Eventually the native code finishes running
9. ScriptEngineLoggingAgent::functionExit is called
10. ScriptContextHelper wipes the current backtrace.


Unfortunately it doesn't quite work. Problems:

* There's probably something thread-related horribly wrong somewhere
* functionEntry seems to be called multiple times per event, hence the stack
* Trying to generate a backtrace sometimes results in functionEntry calling itself through the Qt code.
* I tried constructing a backtrace by hand, hoping that avoiding examining objects and arguments and just printing names would be safe, but it doesn't seem to help.


```
#15 0x00007ffff51720a6 in ScriptEngineLoggingAgent::functionEntry(long long) (this=0x16e8a1a0, scriptId=-1) at /home/dale/git/vircadia/vircadia-master/libraries/script-engine/src/ScriptEngineLoggingAgent.cpp:37
#16 0x00007ffff017e81c in QTJSC::NativeFuncWrapper::operator()(QTJSC::ExecState*, QTJSC::JSObject*, QTJSC::JSValue, QTJSC::ArgList const&) const (this=0x7ffd9dffd810, exec=0x7ffda45308d8, jsobj=0x7ffda44e7f40, thisValue=..., argList=...) at ../3rdparty/javascriptcore/JavaScriptCore/runtime/CallData.cpp:44
#17 0x00007ffff01b284a in QTJSC::callDefaultValueFunction (propertyName=<optimized out>, object=0x7ffda44e7f00, exec=0x7ffda45308d8) at ../3rdparty/javascriptcore/JavaScriptCore/runtime/JSValue.h:814
#18 QTJSC::JSObject::defaultValue(QTJSC::ExecState*, QTJSC::PreferredPrimitiveType) const (this=0x7ffda44e7f00, exec=0x7ffda45308d8, hint=<optimized out>) at ../3rdparty/javascriptcore/JavaScriptCore/runtime/JSObject.cpp:274
#19 0x00007ffff01b2164 in QTJSC::JSObject::toPrimitive(QTJSC::ExecState*, QTJSC::PreferredPrimitiveType) const (preferredType=QTJSC::PreferString, exec=0x7ffda45308d8, this=<optimized out>) at ../3rdparty/javascriptcore/JavaScriptCore/runtime/JSObject.h:597
#20 QTJSC::JSObject::toString(QTJSC::ExecState*) const (this=<optimized out>, exec=0x7ffda45308d8) at ../3rdparty/javascriptcore/JavaScriptCore/runtime/JSObject.cpp:478
#21 0x00007ffff022f8d2 in QTJSC::JSValue::toString(QTJSC::ExecState*) const (exec=exec@entry=0x7ffda45308d8, this=<optimized out>, this=<optimized out>) at ../3rdparty/javascriptcore/JavaScriptCore/runtime/JSString.h:545
#22 0x00007ffff023ded3 in QScriptEnginePrivate::toString(QTJSC::ExecState*, QTJSC::JSValue) (exec=0x7ffda45308d8, value=...) at api/qscriptengine_p.h:1068
#23 0x00007ffff0238805 in QScriptEnginePrivate::convertValue(QTJSC::ExecState*, QTJSC::JSValue, int, void*) (exec=0x7ffda45308d8, value=..., type=-1644177040, ptr=0x7ffd9dffdb30) at api/qscriptengine.cpp:3246
#24 0x00007ffff025d831 in QScript::delegateQtMethod<QScript::QtMethodIndexReturner>(QTJSC::ExecState*, QTJSC::ArgList const&, QMetaObject const*, int, bool, QScript::QtMethodIndexReturner&, QMetaMethod::MethodType)
    (exec=exec@entry=0x7ffda45308d8, scriptArgs=..., meta=<optimized out>, initialIndex=initialIndex@entry=59, maybeOverloaded=maybeOverloaded@entry=true, delegate=<optimized out>, callType=<optimized out>) at bridge/qscriptqobject.cpp:583
#25 0x00007ffff025f8a9 in QScript::QtFunction::specificIndex(QScriptContext const*) const (this=0x7ffda44c72c0, context=0x7ffda45308d8) at bridge/qscriptqobject.cpp:1048
#26 0x00007ffff0227193 in QScriptContextInfoPrivate::QScriptContextInfoPrivate(QScriptContext const*) (this=0x7ffd60192ea0, context=0x7ffda45308d8) at api/qscriptcontextinfo.cpp:218
#27 0x00007ffff0227412 in QScriptContextInfo::QScriptContextInfo(QScriptContext const*) (this=0x7ffd9dffdea0, context=0x7ffda45308d8) at api/qscriptcontextinfo.cpp:252
#28 0x00007ffff51720a6 in ScriptEngineLoggingAgent::functionEntry(long long) (this=0x16e8a1a0, scriptId=-1) at /home/dale/git/vircadia/vircadia-master/libraries/script-engine/src/ScriptEngineLoggingAgent.cpp:37
```


So far this is extremely half-baked and guaranteed to run out of stack space right on start due to that last problem. Some help here would be extremely appreciated.