### PR TITLE
Implement VIRCADIA_MEMORY_DEBUGGING for Windows

### DIFF
--- a/cmake/macros/MemoryDebugger.cmake
+++ b/cmake/macros/MemoryDebugger.cmake
@@ -17,25 +17,34 @@ if ("$ENV{VIRCADIA_MEMORY_DEBUGGING}")
 endif ()
 
 if (VIRCADIA_MEMORY_DEBUGGING)
-  if (UNIX)
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        # for clang on Linux
-        SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=address -fsanitize=leak -fsanitize-recover=address")
-        SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=undefined -fsanitize=address -fsanitize=leak -fsanitize-recover=address")
-        SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=undefined -fsanitize=address -fsanitize=leak -fsanitize-recover=address")
-    else ()
-        # for gcc on Linux
-        # For some reason, using -fstack-protector results in this error:
-        # usr/bin/ld: ../../libraries/audio/libaudio.so: undefined reference to `FIR_1x4_AVX512(float*, float*, float*, float*, float*, float (*) [64], int)'
-        # The '-DSTACK_PROTECTOR' argument below disables the usage of this function in the code. This should be fine as it only works on the latest Intel hardware,
-        # and is an optimization that should make no functional difference.
-
-        SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined -fsanitize=address -fsanitize=leak -U_FORTIFY_SOURCE -DSTACK_PROTECTOR -fstack-protector-strong -fno-omit-frame-pointer")
-        SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=undefined -fsanitize=address -fsanitize=leak ")
-        SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=undefined -fsanitize=address -fsanitize=leak")
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=undefined -fsanitize=address -fsanitize-recover=address")
+    SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=undefined -fsanitize=address -fsanitize-recover=address")
+    SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=undefined -fsanitize=address -fsanitize-recover=address")
+    if (UNIX)
+      # Only supported on Linux and OSX
+      # https://clang.llvm.org/docs/LeakSanitizer.html
+      SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=leak")
+      SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=leak")
+      SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=leak")
     endif()
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    # for gcc
+    # For some reason, using -fstack-protector results in this error:
+    # usr/bin/ld: ../../libraries/audio/libaudio.so: undefined reference to `FIR_1x4_AVX512(float*, float*, float*, float*, float*, float (*) [64], int)'
+    # The '-DSTACK_PROTECTOR' argument below disables the usage of this function in the code. This should be fine as it only works on the latest Intel hardware,
+    # and is an optimization that should make no functional difference.
+
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined -fsanitize=address -fsanitize=leak -U_FORTIFY_SOURCE -DSTACK_PROTECTOR -fstack-protector-strong -fno-omit-frame-pointer")
+    SET(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=undefined -fsanitize=address -fsanitize=leak ")
+    SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=undefined -fsanitize=address -fsanitize=leak")
+  elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    # https://docs.microsoft.com/en-us/cpp/sanitizers/asan?view=msvc-160
+    # Supported experimentally starting from VS2019 v16.4, and officially from v16.9.
+    # UBSan and leak detection don't seem to be implemented yet.
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fsanitize=address /Zi")
   else()
-    message(FATAL_ERROR "Memory debugging is not supported on this platform." )
+    message(FATAL_ERROR "Memory debugging is not supported on this compiler.")
   endif()
 endif ()
 endmacro(SETUP_MEMORY_DEBUGGER)


### PR DESCRIPTION
Only supported starting from VS2019 v16.9.

Only the address sanitizer is supported, as MS has not implemented any others yet.

Testing plan:
* Ensure Visual Studio is VS 2019, v16.9.
* Set the environment variable  `VIRCADIA_MEMORY_DEBUGGING=1`
* Run CMake, compile
* Verify that there is no compile failure
* Verify that `/fsanitize=address` is passed to the compiler (if possible)
* Run the program. Check if there are any messages on the output from the sanitizer. The "Developer/Crash/Double Free" menu option should trigger it if nothing shows up.

It should also be possible to build on Windows using Clang, which supports more functionality. MSVC only has the address sanitizer, while Clang also detects undefined behavior.
