### PR TITLE
Fix mismatched if in CMake warning

### DIFF
--- a/libraries/gpu-gl/CMakeLists.txt
+++ b/libraries/gpu-gl/CMakeLists.txt
@@ -3,7 +3,7 @@ setup_hifi_library(Concurrent)
 link_hifi_libraries(shared gl gpu gpu-gl-common shaders)
 if (UNIX AND NOT VIRCADIA_THREAD_DEBUGGING)
     target_link_libraries(${TARGET_NAME} pthread)
-endif(UNIX)
+endif(UNIX AND NOT VIRCADIA_THREAD_DEBUGGING)
 GroupSources("src")
 
 set(OpenGL_GL_PREFERENCE "LEGACY")


### PR DESCRIPTION
This should have no actual effect, just a warning fix. Fixes:

```
CMake Warning (dev) in libraries/gpu-gl/CMakeLists.txt:
  A logical block opening on the line

    /home/dale/git/vircadia/vircadia-master/libraries/gpu-gl/CMakeLists.txt:4 (if)

  closes on the line

    /home/dale/git/vircadia/vircadia-master/libraries/gpu-gl/CMakeLists.txt:6 (endif)

  with mis-matching arguments.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

This one snuck into PR #1149
