### PR TITLE
UI for setting metaverse server on login

### DIFF
--- a/interface/resources/qml/LoginDialog/LinkAccountBody.qml
+++ b/interface/resources/qml/LoginDialog/LinkAccountBody.qml
@@ -131,8 +131,9 @@ Item {
         if (!isLoggingInToDomain) {
             var savedUsername = Settings.getValue("keepMeLoggedIn/savedUsername", "");
             emailField.text = keepMeLoggedInCheckbox.checked ? savedUsername === "Unknown user" ? "" : savedUsername : "";
-            
+
             var metaverseServer = Settings.getValue("private/selectedMetaverseURL", "");
+            console.log("Saved metaverse server:", metaverseServer);
             metaverseServerField.text = metaverseServer;
         } else {
             // ####### TODO
@@ -384,7 +385,7 @@ Item {
                 font.pixelSize: linkAccountBody.textFieldFontSize
                 styleRenderType: Text.QtRendering
                 anchors {
-                    top: loginDialogTextContainer.bottom
+                    top: passwordField.bottom
                     topMargin: 1.5 * hifi.dimensions.contentSpacing.y
                 }
                 placeholderText: "Metaverse Server (optional)"
@@ -403,6 +404,7 @@ Item {
                         case Qt.Key_Return:
                             event.accepted = true;
                             if (!isLoggingInToDomain) {
+                                console.log("Setting metaverse server to", metaverseServerField.text);
                                 Settings.setValue("private/selectedMetaverseURL", metaverseServerField.text);
                             }
                             linkAccountBody.login();
@@ -426,9 +428,9 @@ Item {
                 color: hifi.colors.white;
                 visible: !isLoggingInToDomain
                 anchors {
-                    top: passwordField.bottom;
+                    top: metaverseServerField.bottom;
                     topMargin: hifi.dimensions.contentSpacing.y;
-                    left: passwordField.left;
+                    left: metaverseServerField.left;
                 }
                 onCheckedChanged: {
                     Settings.setValue("keepMeLoggedIn", checked);
@@ -749,4 +751,4 @@ Item {
                 break;
         }
     }
-metaverseServerField
+}

--- a/interface/resources/qml/LoginDialog/LinkAccountBody.qml
+++ b/interface/resources/qml/LoginDialog/LinkAccountBody.qml
@@ -74,6 +74,19 @@ Item {
     }
 
     function login() {
+        // make sure the metaverse server is set so we don't send your password to the wrong place!
+        if (!isLoggingInToDomain) {
+            Settings.setValue("private/selectedMetaverseURL", metaverseServerField.text);
+        }
+        
+        if (keepMeLoggedInCheckbox.checked) {
+            if (!isLoggingInToDomain) {
+                Settings.setValue("keepMeLoggedIn/savedUsername", emailField.text);
+            } else {
+                // ####### TODO
+            }
+        }
+
         if (!isLoggingInToDomain) {
             loginDialog.login(emailField.text, passwordField.text);
         } else {
@@ -242,13 +255,6 @@ Item {
                         case Qt.Key_Enter:
                         case Qt.Key_Return:
                             event.accepted = true;
-                            if (keepMeLoggedInCheckbox.checked) {
-                                if (!isLoggingInToDomain) {
-                                    Settings.setValue("keepMeLoggedIn/savedUsername", emailField.text);
-                                } else {
-                                    // ####### TODO
-                                }
-                            }
                             linkAccountBody.login();
                             break;
                     }
@@ -285,13 +291,7 @@ Item {
                         case Qt.Key_Enter:
                         case Qt.Key_Return:
                             event.accepted = true;
-                            if (keepMeLoggedInCheckbox.checked) {
-                                if (!isLoggingInToDomain) {
-                                    Settings.setValue("keepMeLoggedIn/savedUsername", emailField.text);
-                                } else {
-                                    // ####### TODO
-                                }
-                            }
+                            
                             linkAccountBody.login();
                             break;
                     }
@@ -369,15 +369,48 @@ Item {
                         case Qt.Key_Enter:
                         case Qt.Key_Return:
                             event.accepted = true;
-                            if (keepMeLoggedInCheckbox.checked) {
-                                if (!isLoggingInToDomain) {
-                                    Settings.setValue("keepMeLoggedIn/savedUsername", emailField.text);
-                                } else {
-                                    // ####### TODO
-                                }
+                            linkAccountBody.login();
+                            break;
+                    }
+                }
+            }
+            HifiControlsUit.TextField {
+                id: metaverseServerField
+                width: root.bannerWidth
+                height: linkAccountBody.textFieldHeight
+                font.pixelSize: linkAccountBody.textFieldFontSize
+                styleRenderType: Text.QtRendering
+                anchors {
+                    top: loginDialogTextContainer.bottom
+                    topMargin: 1.5 * hifi.dimensions.contentSpacing.y
+                }
+                placeholderText: "Metaverse Server (optional)"
+                activeFocusOnPress: true
+                visible: !isLoggingInToDomain
+                Keys.onPressed: {
+                    switch (event.key) {
+                        case Qt.Key_Tab:
+                            event.accepted = true;
+                            emailField.focus = true;
+                            break;
+                        case Qt.Key_Backtab:
+                            event.accepted = true;
+                            passwordField.focus = true;
+                            break;
+                        case Qt.Key_Enter:
+                        case Qt.Key_Return:
+                            event.accepted = true;
+                            if (!isLoggingInToDomain) {
+                                Settings.setValue("private/selectedMetaverseURL", metaverseServerField.text);
                             }
                             linkAccountBody.login();
                             break;
+                    }
+                }
+                onFocusChanged: {
+                    root.text = "";
+                    if (focus) {
+                        root.isPassword = false;
                     }
                 }
             }
@@ -714,4 +747,4 @@ Item {
                 break;
         }
     }
-}
+metaverseServerField

--- a/interface/resources/qml/LoginDialog/LinkAccountBody.qml
+++ b/interface/resources/qml/LoginDialog/LinkAccountBody.qml
@@ -131,6 +131,9 @@ Item {
         if (!isLoggingInToDomain) {
             var savedUsername = Settings.getValue("keepMeLoggedIn/savedUsername", "");
             emailField.text = keepMeLoggedInCheckbox.checked ? savedUsername === "Unknown user" ? "" : savedUsername : "";
+            
+            var metaverseServer = Settings.getValue("private/selectedMetaverseURL", "");
+            metaverseServerField.text = metaverseServer;
         } else {
             // ####### TODO
         }
@@ -160,7 +163,7 @@ Item {
         Item {
             id: loginContainer
             width: displayNameField.width
-            height: errorContainer.height + loginDialogTextContainer.height + displayNameField.height + emailField.height + passwordField.height + 5.5 * hifi.dimensions.contentSpacing.y +
+            height: errorContainer.height + loginDialogTextContainer.height + displayNameField.height + emailField.height + passwordField.height + metaverseServerField.height + 5.5 * hifi.dimensions.contentSpacing.y +
                 keepMeLoggedInCheckbox.height + loginButton.height + cantAccessTextMetrics.height + continueButton.height
             anchors {
                 top: parent.top
@@ -250,7 +253,7 @@ Item {
                             break;
                         case Qt.Key_Backtab:
                             event.accepted = true;
-                            passwordField.focus = true;
+                            metaverseServerField.focus = true;
                             break;
                         case Qt.Key_Enter:
                         case Qt.Key_Return:
@@ -360,7 +363,7 @@ Item {
                     switch (event.key) {
                         case Qt.Key_Tab:
                             event.accepted = true;
-                            displayNameField.focus = true;
+                            metaverseServerField.focus = true;
                             break;
                         case Qt.Key_Backtab:
                             event.accepted = true;
@@ -386,12 +389,11 @@ Item {
                 }
                 placeholderText: "Metaverse Server (optional)"
                 activeFocusOnPress: true
-                visible: !isLoggingInToDomain
                 Keys.onPressed: {
                     switch (event.key) {
                         case Qt.Key_Tab:
                             event.accepted = true;
-                            emailField.focus = true;
+                            displayNameField.focus = true;
                             break;
                         case Qt.Key_Backtab:
                             event.accepted = true;


### PR DESCRIPTION
I tried hosting my own private metaverse server so I wouldn't have to make a centralized account, and it worked great... there's just one problem:

The official client can't connect to it!

This fixes that, sort of. It lets you set HIFI_METAVERSE_SERVER (like the domain server already has) and also HIFI_AUTHABLE_HOSTNAMES (a comma-separated list) to set which domains get your credentials passed to them.