### PR TITLE
Fix minitablet goto

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1011,7 +1011,7 @@ const bool DEFAULT_HMD_TABLET_BECOMES_TOOLBAR = false;
 const bool DEFAULT_PREFER_STYLUS_OVER_LASER = false;
 const bool DEFAULT_PREFER_AVATAR_FINGER_OVER_STYLUS = false;
 const QString DEFAULT_CURSOR_NAME = "DEFAULT";
-const bool DEFAULT_MINI_TABLET_ENABLED = true;
+const bool DEFAULT_MINI_TABLET_ENABLED = false;
 const bool DEFAULT_AWAY_STATE_WHEN_FOCUS_LOST_IN_VR_ENABLED = true;
 
 QSharedPointer<OffscreenUi> getOffscreenUI() {

--- a/scripts/system/miniTablet.js
+++ b/scripts/system/miniTablet.js
@@ -563,7 +563,7 @@
 
             // Tablet targets.
             isGoto = false,
-            TABLET_ADDRESS_DIALOG = "hifi/tablet/TabletAddressDialog.qml",
+            TABLET_EXPLORE_APP_UI = Script.resolvePath("../communityScripts/explore/explore.html"),
 
             // Trigger values.
             leftTriggerOn = 0,
@@ -907,7 +907,7 @@
             var miniTabletProperties;
 
             if (isGoto) {
-                tablet.loadQMLSource(TABLET_ADDRESS_DIALOG);
+                tablet.gotoWebScreen(TABLET_EXPLORE_APP_UI);
             } else {
                 tablet.gotoHomeScreen();
             }


### PR DESCRIPTION
- Replace old Goto in mini tablet with Explore app.
- Default to mini tablet disabled in Settings > General.