### PR TITLE
Fix non-consecutive header level increases in build docs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -2,50 +2,50 @@
 
 *Last Updated on March 8, 2021*
 
-### OS Specific Build Guides
+## OS Specific Build Guides
 
 * [Build Windows](BUILD_WIN.md) - complete instructions for Windows.
 * [Build Linux](BUILD_LINUX.md) - additional instructions for Linux.
 * [Build OSX](BUILD_OSX.md) - additional instructions for OS X.
 * [Build Android](BUILD_ANDROID.md) - additional instructions for Android.
 
-### Dependencies
-- [git](https://git-scm.com/downloads): >= 1.6  
+## Dependencies
+- [git](https://git-scm.com/downloads): >= 1.6
 - [CMake](https://cmake.org/download/):  3.9 (or greater up to 3.18.x)
 - [Python](https://www.python.org/downloads/): 3.6 or higher
 - [Node.JS](https://nodejs.org/en/): >= 12.13.1 LTS
     - Used to build the Screen Sharing executable.
 
-### CMake External Project Dependencies
+## CMake External Project Dependencies
 
 These dependencies need not be installed manually. They are automatically downloaded on the platforms where they are required.
-- [Bullet Physics Engine](https://github.com/bulletphysics/bullet3/releases):  2.83  
-- [glm](https://glm.g-truc.net/0.9.8/index.html):  0.9.8  
-- [Oculus SDK](https://developer.oculus.com/downloads/):   1.11 (Windows) / 0.5 (Mac)  
-- [OpenVR](https://github.com/ValveSoftware/openvr):   1.11.11 (Windows, Linux)  
-- [Polyvox](http://www.volumesoffun.com/):   0.2.1  
-- [QuaZip](https://sourceforge.net/projects/quazip/files/quazip/):   0.7.3  
-- [SDL2](https://www.libsdl.org/download-2.0.php):   2.0.3  
-- [Intel Threading Building Blocks](https://www.threadingbuildingblocks.org/):   4.3  
-- [vcpkg](https://github.com/hifi-archive/vcpkg):  
-- [VHACD](https://github.com/virneo/v-hacd)  
-- [zlib](http://www.zlib.net/):   1.28 (Win32 only)  
-- [nvtt](https://github.com/hifi-archive/nvidia-texture-tools):   2.1.1 (customized)  
+- [Bullet Physics Engine](https://github.com/bulletphysics/bullet3/releases):  2.83
+- [glm](https://glm.g-truc.net/0.9.8/index.html):  0.9.8
+- [Oculus SDK](https://developer.oculus.com/downloads/):   1.11 (Windows) / 0.5 (Mac)
+- [OpenVR](https://github.com/ValveSoftware/openvr):   1.11.11 (Windows, Linux)
+- [Polyvox](http://www.volumesoffun.com/):   0.2.1
+- [QuaZip](https://sourceforge.net/projects/quazip/files/quazip/):   0.7.3
+- [SDL2](https://www.libsdl.org/download-2.0.php):   2.0.3
+- [Intel Threading Building Blocks](https://www.threadingbuildingblocks.org/):   4.3
+- [vcpkg](https://github.com/hifi-archive/vcpkg):
+- [VHACD](https://github.com/virneo/v-hacd)
+- [zlib](http://www.zlib.net/):   1.28 (Win32 only)
+- [nvtt](https://github.com/hifi-archive/nvidia-texture-tools):   2.1.1 (customized)
 
 The above dependencies will be downloaded, built, linked and included automatically by CMake where we require them. The CMakeLists files that handle grabbing each of the following external dependencies can be found in the [cmake/externals folder](cmake/externals). The resulting downloads, source files and binaries will be placed in the `build/ext` folder in each of the subfolders for each external project.
 
 These are not placed in your normal build tree when doing an out of source build so that they do not need to be re-downloaded and re-compiled every time the CMake build folder is cleared. Should you want to force a re-download and re-compile of a specific external, you can simply remove that directory from the appropriate subfolder in `build/ext`. Should you want to force a re-download and re-compile of all externals, just remove the `build/ext` folder.
 
-#### CMake
+### CMake
 
 Vircadia uses CMake to generate build files and project files for your platform.
 
-#### Qt
+### Qt
 
 CMake will download Qt 5.15.2 using vcpkg.
 
-To override this - i.e., use an installed Qt configuration - you need to set a QT_CMAKE_PREFIX_PATH environment variable pointing to your Qt **lib/cmake** folder.  
-This can either be entered directly into your shell session before you build or in your shell profile (e.g.: ~/.bash_profile, ~/.bashrc, ~/.zshrc - this depends on your shell and environment).  The path it needs to be set to will depend on where and how Qt5 was installed. 
+To override this - i.e., use an installed Qt configuration - you need to set a QT_CMAKE_PREFIX_PATH environment variable pointing to your Qt **lib/cmake** folder.
+This can either be entered directly into your shell session before you build or in your shell profile (e.g.: ~/.bash_profile, ~/.bashrc, ~/.zshrc - this depends on your shell and environment).  The path it needs to be set to will depend on where and how Qt5 was installed.
 
 For example, under Linux:
 ```bash
@@ -66,12 +66,12 @@ For example, under OSX:
 Note: You only need the following components checked under Qt 5.15.2 (select the "Custom Installation" option):
 "MSVC 2019 64-bit", "Qt WebEngine", and "Qt Script (Deprecated)".
 
-Note: Installing the sources is optional but recommended if you have room for them (~3GB). You may also want the Qt debug 
+Note: Installing the sources is optional but recommended if you have room for them (~3GB). You may also want the Qt debug
 information files (~7GB).
 
 Note: Installing Qt Creator is optional but recommended if you will be editing QML files.
 
-#### VCPKG
+### VCPKG
 
 Vircadia uses vcpkg to download and build dependencies.
 You do not need to install vcpkg.
@@ -92,9 +92,9 @@ set HIFI_VCPKG_BASE=/path/to/directory
 
 Where `/path/to/directory` is the path to a directory where you wish the build files to get stored.
 
-#### Generating Build Files
+### Generating Build Files
 
-##### Possible Environment Variables
+#### Possible Environment Variables
 
 ```text
 // The URL to post the dump to.
@@ -133,7 +133,7 @@ USE_STABLE_GLOBAL_SERVICES=1
 BUILD_GLOBAL_SERVICES=STABLE
 ```
 
-##### Generate Files
+#### Generate Files
 
 Create a build directory in the root of your checkout and then run the CMake build from there. This will keep the rest of the directory clean.
 
@@ -145,7 +145,7 @@ cmake ..
 
 If CMake gives you the same error message repeatedly after the build fails, try removing `CMakeCache.txt`.
 
-##### Generating a release/debug only vcpkg build
+#### Generating a release/debug only vcpkg build
 
 In order to generate a release or debug only vcpkg package, you could use the use the `VCPKG_BUILD_TYPE` define in your CMake generate command. Building a release only vcpkg can drastically decrease the total build time.
 
@@ -157,7 +157,7 @@ For debug only vcpkg:
 
 `cmake .. -DVCPKG_BUILD_TYPE=debug`
 
-#### Variables
+### Variables
 
 Any variables that need to be set for CMake to find dependencies can be set as ENV variables in your shell profile, or passed directly to CMake with a `-D` flag appended to the `cmake ..` command.
 
@@ -167,7 +167,7 @@ For example, to pass the QT_CMAKE_PREFIX_PATH variable (if not using the vcpkg'e
 cmake .. -DQT_CMAKE_PREFIX_PATH=/usr/local/qt/5.12.3/lib/cmake
 ```
 
-#### Finding Dependencies
+### Finding Dependencies
 
 The following applies for dependencies we do not grab via CMake ExternalProject (OpenSSL is an example), or for dependencies you have opted not to grab as a CMake ExternalProject (via -DUSE_LOCAL_$NAME=0). The list of dependencies we grab by default as external projects can be found in [the CMake External Project Dependencies section](#cmake-external-project-dependencies).
 
@@ -179,9 +179,9 @@ In the examples below the variable $NAME would be replaced by the name of the de
 * $NAME_ROOT_DIR - set this variable in your ENV
 * HIFI_LIB_DIR - set this variable in your ENV to your Vircadia lib folder, should contain a folder '$name'
 
-### Optional Components
+## Optional Components
 
-#### Build Options
+### Build Options
 
 The following build options can be used when running CMake
 
@@ -192,12 +192,12 @@ The following build options can be used when running CMake
 * CLIENT_ONLY // Will package only the Interface
 * SERVER_ONLY // Will package only the Server
 
-#### Developer Build Options
+### Developer Build Options
 
 * USE_GLES
 * DISABLE_UI
 
-#### Devices
+### Devices
 
 You can support external input/output devices such as Leap Motion, MIDI, and more by adding each individual SDK in the visible building path. Refer to the readme file available in each device folder in [interface/external/](interface/external) for the detailed explanation of the requirements to use the device.
- 
+

--- a/BUILD_OSX.md
+++ b/BUILD_OSX.md
@@ -4,7 +4,7 @@
 
 Please read the [general build guide](BUILD.md) for information on dependencies required for all platforms. Only macOS specific instructions are found in this document.
 
-### Homebrew
+## Homebrew
 
 [Homebrew](https://brew.sh/) is an excellent package manager for macOS. It makes install of some Vircadia dependencies very simple.
 
@@ -12,14 +12,14 @@ Please read the [general build guide](BUILD.md) for information on dependencies 
 brew install cmake openssl npm
 ```
 
-Note: cmake versions > 3.18.x have known problems building Vircadia, so alternatively you can download cmake 3.18.4 (or earlier versions) from [Github](https://github.com/Kitware/CMake/releases).   
+Note: cmake versions > 3.18.x have known problems building Vircadia, so alternatively you can download cmake 3.18.4 (or earlier versions) from [Github](https://github.com/Kitware/CMake/releases).
 
-### Python 3
+## Python 3
 
 Download an install Python 3.6.6 or higher from [here](https://www.python.org/downloads/).
 Execute the `Update Shell Profile.command` script that is provided with the installer.
 
-### OSX SDK
+## OSX SDK
 
 You will need version `10.12` of the OSX SDK for building, otherwise you may have crashing or other unintended issues due to the deprecation of OpenGL on OSX. You can get that SDK from [here](https://github.com/phracker/MacOSX-SDKs). You must copy it in to your Xcode SDK directory, e.g.
 
@@ -27,14 +27,14 @@ You will need version `10.12` of the OSX SDK for building, otherwise you may hav
 cp -rp ~/Downloads/MacOSX10.12.sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/
 ```
 
-### OpenSSL
+## OpenSSL
 
 Assuming you've installed OpenSSL using the homebrew instructions above, you'll need to set OPENSSL_ROOT_DIR so CMake can find your installations.
 For OpenSSL installed via homebrew, set OPENSSL_ROOT_DIR via
     `export OPENSSL_ROOT_DIR=/usr/local/opt/openssl`
     or by appending `-DOPENSSL_ROOT_DIR=/usr/local/opt/openssl` to `cmake`
 
-### Xcode
+## Xcode
 
 You can ask CMake to generate Xcode project files instead of Unix Makefiles using the `-G Xcode` parameter after CMake. You will need to select the Xcode installation in the terminal first if you have not done so already.
 
@@ -50,14 +50,14 @@ After running CMake, you will have the make files or Xcode project file necessar
 
 If the build completes successfully, you will have built targets for all components located in the `build/${target_name}/Debug` directories.
 
-### make
+## make
 
 If you build with make rather than Xcode, you can append `-j4` for assigning more threads. The number indicates the number of threads, e.g. 4.
 
 To package the installation, you can simply run `make package` afterwards.
 
-### FAQ
+## FAQ
 
 1. **Problem:** Running the scheme `interface.app` from Xcode causes a crash for Interface related to `libgl`
-    1. **Cause:** The target `gl` generates a binary called `libgl`. A macOS `libGL.framework` item gets loaded instead by Xcode. 
+    1. **Cause:** The target `gl` generates a binary called `libgl`. A macOS `libGL.framework` item gets loaded instead by Xcode.
     1. **Solution:** In the Xcode target settings for `libgl`, set the version to 1.0.0

--- a/BUILD_WIN.md
+++ b/BUILD_WIN.md
@@ -2,14 +2,14 @@
 
 *Last Updated on 15 Apr 2021*
 
-This is a stand-alone guide for creating your first Vircadia build for Windows 64-bit.  
+This is a stand-alone guide for creating your first Vircadia build for Windows 64-bit.
 
 Note: We are now using Visual Studio 2019 and Qt 5.15.2.
-If you are upgrading from previous versions, do a clean uninstall of those versions before going through this guide.  
+If you are upgrading from previous versions, do a clean uninstall of those versions before going through this guide.
 
 **Note: The prerequisites will require about 10 GB of space on your drive. You will also need a system with at least 8GB of main memory.**
 
-### Step 1. Visual Studio & Python 3.x
+## Step 1. Visual Studio & Python 3.x
 
 If you don't have Community or Professional edition of Visual Studio 2019, download [Visual Studio Community 2019](https://visualstudio.microsoft.com/vs/). If you have Visual Studio 2017, you need to download Visual Studio 2019.
 
@@ -17,7 +17,7 @@ When selecting components, check "Desktop development with C++".
 
 If you do not already have a Python 3.x development environment installed and want to install it with Visual Studio, check "Python Development". If you already have Visual Studio installed and need to add Python, open the "Add or remove programs" control panel and find the "Microsoft Visual Studio Installer". Select it and click "Modify". In the installer, select "Modify" again, then check "Python Development" and allow the installer to apply the changes.
 
-#### Visual Studio 2019
+### Visual Studio 2019
 
 On the right on the Summary toolbar, select the following components.
 
@@ -25,11 +25,11 @@ On the right on the Summary toolbar, select the following components.
 * MSVC v141 - VS 2017 C++ x64/x86 build tools
 * MSVC v140 - VS 2015 C++ build tools (v14.00)
 
-### Step 1a. Alternate Python
+## Step 1a. Alternate Python
 
 If you do not wish to use the Python installation bundled with Visual Studio, you can download the installer from [here](https://www.python.org/downloads/). Ensure that you get version 3.6.6 or higher.
 
-### Step 2. Python Dependencies
+## Step 2. Python Dependencies
 
 In an administrator command-line that can access Python's pip you will need to run the following command:
 
@@ -37,18 +37,18 @@ In an administrator command-line that can access Python's pip you will need to r
 
 If you do not use an administrator command-line, you will get errors.
 
-### Step 3. Installing CMake
+## Step 3. Installing CMake
 
 Download and install the latest version of CMake 3.15.
  * Note that earlier versions of CMake will work, but there is a specific bug related to the interaction of Visual Studio 2019 and CMake versions prior to 3.15 that will cause Visual Studio to rebuild far more than it needs to on every build
 
 Download the file named win64-x64 Installer from the [CMake Website](https://cmake.org/download/). You can access the installer on this [3.15 Version page](https://cmake.org/files/v3.15/). During installation, make sure to check "Add CMake to system PATH for all users" when prompted.
 
-### Step 4. Node.JS and NPM
+## Step 4. Node.JS and NPM
 
 Install version 10.15.0 LTS (or greater) of [Node.JS and NPM](<https://nodejs.org/en/download/>).
 
-### Step 5. (Optional) Install Qt
+## Step 5. (Optional) Install Qt
 
 If you would like to compile Qt instead of using the precompiled package provided during CMake, you can do so now. Install version 5.12.3 of [Qt](<https://www.qt.io/download-open-source>), as well as the following packages:
 * Qt 5.15.2
@@ -67,7 +67,7 @@ To create this variable:
 * Set "Variable name" to `QT_CMAKE_PREFIX_PATH`
 * Set "Variable value" to `%QT_INSTALL_DIR%\5.15.2\msvc2019_64\lib\cmake`, where `%QT_INSTALL_DIR%` is the directory you specified for Qt's installation. The default is `C:\Qt`.
 
-### Step 6. Create VCPKG environment variable
+## Step 6. Create VCPKG environment variable
 In the next step, you will use CMake to build Vircadia. By default, the CMake process builds dependency files in Windows' `%TEMP%` directory, which is periodically cleared by the operating system. To prevent you from having to re-build the dependencies in the event that Windows clears that directory, we recommend that you create a `HIFI_VCPKG_BASE` environment variable linked to a directory somewhere on your machine. That directory will contain all dependency files until you manually remove them.
 
 To create this variable:
@@ -86,19 +86,19 @@ To create this variable:
 * Set "Variable name" to `HIFI_VCPKG_BOOTSTRAP`
 * Set "Variable value" to `1`
 
-### Step 7. Running CMake to Generate Build Files
+## Step 7. Running CMake to Generate Build Files
 
-Run Command Prompt from Start and run the following commands:  
-`cd "%VIRCADIA_DIR%"`  
-`mkdir build`  
-`cd build`  
+Run Command Prompt from Start and run the following commands:
+`cd "%VIRCADIA_DIR%"`
+`mkdir build`
+`cd build`
 
-#### Visual Studio 2019
+### Visual Studio 2019
 Run `cmake .. -G "Visual Studio 16 2019" -A x64`.
 
 Where `%VIRCADIA_DIR%` is the directory for the Vircadia repository.
 
-### Step 8. Making a Build
+## Step 8. Making a Build
 
 Open `%VIRCADIA_DIR%\build\vircadia.sln` using Visual Studio.
 
@@ -106,7 +106,7 @@ Change the Solution Configuration (menu ribbon under the menu bar, next to the g
 
 Run from the menu bar `Build > Build Solution`.
 
-### Step 9. Testing Interface
+## Step 9. Testing Interface
 
 Create another environment variable (see Step #3)
 * Set "Variable name": `_NO_DEBUG_HEAP`
@@ -120,18 +120,18 @@ Now, you should have a full build of Vircadia and be able to run the Interface u
 
 Note: You can also run Interface by launching it from command line or File Explorer from `%VIRCADIA_DIR%\build\interface\Release\interface.exe`
 
-## Troubleshooting
+# Troubleshooting
 
-For any problems after Step #7, first try this:  
-* Delete your locally cloned copy of the Vircadia repository  
-* Restart your computer  
-* Redownload the [repository](https://github.com/vircadia/vircadia)  
-* Restart directions from Step #7  
+For any problems after Step #7, first try this:
+* Delete your locally cloned copy of the Vircadia repository
+* Restart your computer
+* Redownload the [repository](https://github.com/vircadia/vircadia)
+* Restart directions from Step #7
 
-#### CMake gives you the same error message repeatedly after the build fails
+## CMake gives you the same error message repeatedly after the build fails
 
 Remove `CMakeCache.txt` found in the `%VIRCADIA_DIR%\build` directory.
 
-#### CMake can't find OpenSSL
+## CMake can't find OpenSSL
 
 Remove `CMakeCache.txt` found in the `%VIRCADIA_DIR%\build` directory.  Verify that your HIFI_VCPKG_BASE environment variable is set and pointing to the correct location. Verify that the file `${HIFI_VCPKG_BASE}/installed/x64-windows/include/openssl/ssl.h` exists.


### PR DESCRIPTION
This PR fixes the non-consecutive header level increases in the build docs since that doesn't work in Sphinx and throws warnings.