### PR TITLE
Include Vircadia Web app as a Git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vircadia-web"]
 	path = vircadia-web
-	url = https://github.com/vircadia/vircadia-web.git
+	url = ./vircadia-web.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vircadia-web"]
 	path = vircadia-web
-	url = ./vircadia-web.git
+	url = ../vircadia-web.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vircadia-web"]
+	path = vircadia-web
+	url = https://github.com/vircadia/vircadia-web.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,12 @@ GroupSources("scripts")
 GroupSources("unpublishedScripts")
 unset(JS_SRC)
 
+file(GLOB_RECURSE WEB_APP_SRC vircadia-web/*.*)
+list(FILTER WEB_APP_SRC EXCLUDE REGEX "vircadia-web/(dist|node_modules|public)/*" )
+add_custom_target(vircadia-web SOURCES ${WEB_APP_SRC})
+GroupSources("vircadia-web")
+unset(WEB_APP_SRC)
+
 set_packaging_parameters()
 
 # Locate the required Qt build on the filesystem

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ add_custom_target(cmake SOURCES ${CMAKE_SRC})
 GroupSources("cmake")
 unset(CMAKE_SRC)
 
-file(GLOB_RECURSE JS_SRC scripts/*.js unpublishedScripts/*.js)
+file(GLOB_RECURSE JS_SRC scripts/*.* unpublishedScripts/*.*)
 add_custom_target(js SOURCES ${JS_SRC})
 GroupSources("scripts")
 GroupSources("unpublishedScripts")


### PR DESCRIPTION
The Vircadia Web app is included in the Vircadia repository as a Git submodule. In particular, this enables code searches to include both Vircadia and Vircadia Web app files.

Additionally:
- Vircadia Web app files are listed in the IDE tree.
- HTML, CSS, and other files in the JavaScript directories are included in the IDE tree in addition to JavaScript files.

Note: The Vircadia Web app is NOT included in PR or release builds.
