### PR TITLE
drop remaining references to QScriptEngineDebugger

### DIFF
--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -50,8 +50,6 @@
 #include "SettingHandle.h"
 #include "Profile.h"
 
-class QScriptEngineDebugger;
-
 static const QString NO_SCRIPT("");
 
 static const int SCRIPT_FPS = 60;
@@ -166,8 +164,6 @@ public:
     /// the current script contents and calling run(). Callers will likely want to register the script with external
     /// services before calling this.
     void runInThread();
-
-    void runDebuggable();
 
     /// run the script in the callers thread, exit when stop() is called.
     void run();
@@ -667,8 +663,6 @@ public:
     // this is used by code in ScriptEngines.cpp during the "reload all" operation
     bool isStopping() const { return _isStopping; }
 
-    bool isDebuggable() const { return _debuggable; }
-
     void disconnectNonEssentialSignals();
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -982,8 +976,6 @@ protected:
     EntityScriptContentAvailableMap _contentAvailableQueue;
 
     bool _isThreaded { false };
-    QScriptEngineDebugger* _debugger { nullptr };
-    bool _debuggable { false };
     qint64 _lastUpdate;
 
     QString _fileNameString;

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -26,7 +26,6 @@
 #define __LOC__ __FILE__ "(" __STR1__(__LINE__) ") : Warning Msg: "
 
 static const QString DESKTOP_LOCATION = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
-static const bool HIFI_SCRIPT_DEBUGGABLES { true };
 static const QString SETTINGS_KEY { "RunningScripts" };
 static const QUrl DEFAULT_SCRIPTS_LOCATION { "file:///~//defaultScripts.js" };
 
@@ -589,17 +588,7 @@ void ScriptEngines::launchScriptEngine(ScriptEnginePointer scriptEngine) {
 
     // register our application services and set it off on its own thread
     runScriptInitializers(scriptEngine);
-
-    // FIXME disabling 'shift key' debugging for now.  If you start up the application with
-    // the shift key held down, it triggers a deadlock because of script interfaces running
-    // on the main thread
-    auto const wantDebug = scriptEngine->isDebuggable(); //  || (qApp->queryKeyboardModifiers() & Qt::ShiftModifier);
-
-    if (HIFI_SCRIPT_DEBUGGABLES && wantDebug) {
-        scriptEngine->runDebuggable();
-    } else {
-        scriptEngine->runInThread();
-    }
+    scriptEngine->runInThread();
 }
 
 void ScriptEngines::onScriptFinished(const QString& rawScriptURL, ScriptEnginePointer engine) {


### PR DESCRIPTION
This PR drops all remaining references to QScriptEngineDebugger.

It appears that this *used* to be available by holding down [Shift] while launching Vircadia but this feature was disabled due to launching deadlocks.  This appears to currently still be available by sticking #debug at the end of a scripting URL.

I have verified that this compiles and links but have not attempted to run or verify that scripts are running properly.