### PR TITLE
Add "gren" configuration for easy changelog generation

### DIFF
--- a/.grenrc.js
+++ b/.grenrc.js
@@ -1,0 +1,42 @@
+//
+//  .grenrc.js
+//
+//  Created by Kalila L. on May 25, 2021
+//  Copyright 2021 Vircadia contributors.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+//  This configuration is for generating a changelog with gren for a GitHub repository.
+//
+//  gren changelog -G
+//
+
+module.exports = {
+    "dataSource": "prs",
+    "prefix": "",
+    "ignoreLabels": [
+        "enhancement",
+        "bugfix",
+        "CR Approved",
+        "QA Approved",
+        "allow-build-upload",
+        "bug",
+        "confirmed",
+        "do not merge",
+        "duplicate",
+        "good first issue",
+        "help wanted",
+        "hifi migration",
+        "high risk",
+        "rebuild",
+        "merge right before snip"
+    ],
+    "onlyMilestones": true,
+    "groupBy": {
+        "Enhancements": ["enhancement"],
+        "Bug Fixes": ["bugfix"],
+        "Docs": ["docs"]
+    },
+    "changelogFilename": "CHANGELOG.md"
+}


### PR DESCRIPTION
You can read more about it here: https://github.com/github-tools/github-release-notes

I am going to add this to our other repositories as well so that I can generate changelogs for release notes from each pull request.

You can see an example of how the output ends up looking here: https://github.com/vircadia/vircadia-docs-sphinx/pull/154/files?short_path=880352b#diff-880352b5c67c6cde1551356bcfb4055537afbeef3be4cfa51cf4e1a11e983e2f