### PR TITLE
Add ability for 'handleLookupString' to have spaces.

### DIFF
--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4004,7 +4004,7 @@ void Application::handleSandboxStatus(QNetworkReply* reply) {
     parser.parse(arguments());
     if (parser.isSet(urlOption)) {
         QUrl url = QUrl(parser.value(urlOption));
-        if (url.scheme() == URL_SCHEME_HIFIAPP) {
+        if (url.scheme() == URL_SCHEME_VIRCADIAAPP) {
             Setting::Handle<QVariant>("startUpApp").set(url.path());
         } else {
             addressLookupString = url.toString();
@@ -7285,7 +7285,7 @@ void Application::clearDomainOctreeDetails(bool clearAll) {
 
 void Application::domainURLChanged(QUrl domainURL) {
     // disable physics until we have enough information about our new location to not cause craziness.
-    setIsServerlessMode(domainURL.scheme() != URL_SCHEME_HIFI);
+    setIsServerlessMode(domainURL.scheme() != URL_SCHEME_VIRCADIA);
     if (isServerlessMode()) {
         loadServerlessDomain(domainURL);
     }
@@ -7294,7 +7294,7 @@ void Application::domainURLChanged(QUrl domainURL) {
 
 void Application::goToErrorDomainURL(QUrl errorDomainURL) {
     // disable physics until we have enough information about our new location to not cause craziness.
-    setIsServerlessMode(errorDomainURL.scheme() != URL_SCHEME_HIFI);
+    setIsServerlessMode(errorDomainURL.scheme() != URL_SCHEME_VIRCADIA);
     if (isServerlessMode()) {
         loadErrorDomain(errorDomainURL);
     }
@@ -7658,7 +7658,7 @@ bool Application::canAcceptURL(const QString& urlString) const {
     QUrl url(urlString);
     if (url.query().contains(WEB_VIEW_TAG)) {
         return false;
-    } else if (urlString.startsWith(URL_SCHEME_HIFI)) {
+    } else if (urlString.startsWith(URL_SCHEME_VIRCADIA)) {
         return true;
     }
     QString lowerPath = url.path().toLower();
@@ -7673,7 +7673,7 @@ bool Application::canAcceptURL(const QString& urlString) const {
 bool Application::acceptURL(const QString& urlString, bool defaultUpload) {
     QUrl url(urlString);
 
-    if (url.scheme() == URL_SCHEME_HIFI) {
+    if (url.scheme() == URL_SCHEME_VIRCADIA) {
         // this is a hifi URL - have the AddressManager handle it
         QMetaObject::invokeMethod(DependencyManager::get<AddressManager>().data(), "handleLookupString",
                                   Qt::AutoConnection, Q_ARG(const QString&, urlString));

--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -265,7 +265,7 @@ int main(int argc, const char* argv[]) {
         if (socket.waitForConnected(LOCAL_SERVER_TIMEOUT_MS)) {
             if (parser.isSet(urlOption)) {
                 QUrl url = QUrl(parser.value(urlOption));
-                if (url.isValid() && (url.scheme() == URL_SCHEME_HIFI || url.scheme() == URL_SCHEME_HIFIAPP
+                if (url.isValid() && (url.scheme() == URL_SCHEME_VIRCADIA || url.scheme() == URL_SCHEME_VIRCADIAAPP
                         || url.scheme() == HIFI_URL_SCHEME_HTTP || url.scheme() == HIFI_URL_SCHEME_HTTPS
                         || url.scheme() == HIFI_URL_SCHEME_FILE)) {
                     qDebug() << "Writing URL to local socket";

--- a/interface/src/scripting/WindowScriptingInterface.cpp
+++ b/interface/src/scripting/WindowScriptingInterface.cpp
@@ -139,9 +139,9 @@ void WindowScriptingInterface::disconnectedFromDomain() {
 void WindowScriptingInterface::openUrl(const QUrl& url) {
     if (!url.isEmpty()) {
         auto scheme = url.scheme();
-        if (scheme == URL_SCHEME_HIFI) {
+        if (scheme == URL_SCHEME_VIRCADIA) {
             DependencyManager::get<AddressManager>()->handleLookupString(url.toString());
-        } else if (scheme == URL_SCHEME_HIFIAPP) {
+        } else if (scheme == URL_SCHEME_VIRCADIAAPP) {
             DependencyManager::get<QmlCommerce>()->openSystemApp(url.path());
         } else {
 #if defined(Q_OS_ANDROID)

--- a/libraries/networking/src/AddressManager.cpp
+++ b/libraries/networking/src/AddressManager.cpp
@@ -359,7 +359,6 @@ bool AddressManager::handleUrl(const QUrl& lookupUrlIn, LookupTrigger trigger, c
                 _previousAPILookup = lookupUrl;
 
                 // Let's convert this to a QString for processing in case there are spaces in it.
-
                 if (lookupUrlString.contains(URL_SCHEME_VIRCADIA + "://", Qt::CaseInsensitive)) {
                     lookupUrlString = lookupUrlString.replace((URL_SCHEME_VIRCADIA + "://"), "");
                 } else if (lookupUrlString.contains(URL_SCHEME_VIRCADIA + ":/", Qt::CaseInsensitive)) {
@@ -377,7 +376,7 @@ bool AddressManager::handleUrl(const QUrl& lookupUrlIn, LookupTrigger trigger, c
                     lookupUrlString.replace(lookupUrlStringPath, "");
                 }
 
-                if (!lookupUrlString.isNull() && !lookupUrlString.isEmpty()) {
+                if (!lookupUrlString.isEmpty()) {
                     attemptPlaceNameLookup(lookupUrlString, lookupUrlStringPath, trigger);
                 }
             }
@@ -633,8 +632,6 @@ void AddressManager::handleAPIError(QNetworkReply* errorReply) {
 
 void AddressManager::attemptPlaceNameLookup(const QString& lookupString, const QString& overridePath, LookupTrigger trigger) {
     // assume this is a place name and see if we can get any info on it
-    //QString placeName = QUrl::toPercentEncoding(lookupString);
-
     QVariantMap requestParams;
 
     // if the user asked for a specific path with this lookup then keep it with the request so we can use it later

--- a/libraries/networking/src/AddressManager.h
+++ b/libraries/networking/src/AddressManager.h
@@ -4,6 +4,7 @@
 //
 //  Created by Stephen Birarda on 2014-09-10.
 //  Copyright 2014 High Fidelity, Inc.
+//  Copyright 2021 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -35,7 +36,7 @@ const QString GET_PLACE = "/api/v1/places/%1";
  * The <code>location</code> API provides facilities related to your current location in the metaverse.
  *
  * <h3>Getter/Setter</h3>
- * <p>You can get and set your current metaverse address by directly reading a string value from and writing a string value to 
+ * <p>You can get and set your current metaverse address by directly reading a string value from and writing a string value to
  * the <code>location</code> object. This is an alternative to using the <code>location.href</code> property or other object
  * functions.</p>
  *
@@ -53,12 +54,12 @@ const QString GET_PLACE = "/api/v1/places/%1";
  *     <code>localhost</code>, or an IP address). Is blank if you're in a serverless domain.
  *     <em>Read-only.</em>
  * @property {string} href - Your current metaverse address (e.g., <code>"hifi://domainname/15,-10,26/0,0,0,1"</code>)
- *     regardless of whether or not you're connected to the domain. Starts with <code>"file:///"</code> if you're in a 
+ *     regardless of whether or not you're connected to the domain. Starts with <code>"file:///"</code> if you're in a
  *     serverless domain.
  *     <em>Read-only.</em>
  * @property {boolean} isConnected - <code>true</code> if you're connected to the domain in your current <code>href</code>
  *     metaverse address, otherwise <code>false</code>.
- * @property {string} pathname - The location and orientation in your current <code>href</code> metaverse address 
+ * @property {string} pathname - The location and orientation in your current <code>href</code> metaverse address
  *     (e.g., <code>"/15,-10,26/0,0,0,1"</code>).
  *     <em>Read-only.</em>
  * @property {string} placename - The place name in your current <code>href</code> metaverse address
@@ -77,7 +78,7 @@ const QString GET_PLACE = "/api/v1/places/%1";
  * @hifi-client-entity
  * @hifi-avatar
  *
- * @deprecated This API is deprecated and will be removed. Use the {@link location} or {@link Window|Window.location} APIs 
+ * @deprecated This API is deprecated and will be removed. Use the {@link location} or {@link Window|Window.location} APIs
  * instead.
  *
  * @property {Uuid} domainID - A UUID uniquely identifying the domain you're visiting. Is {@link Uuid(0)|Uuid.NULL} if you're not
@@ -248,9 +249,9 @@ public slots:
     /*@jsdoc
      * Takes you to a specified metaverse address.
      * @function location.handleLookupString
-     * @param {string} address - The address to go to: a <code>"hifi://"</code> address, an IP address (e.g., 
-     *     <code>"127.0.0.1"</code> or <code>"localhost"</code>), a <code>file:///</code> address, a domain name, a named path 
-     *     on a domain (starts with <code>"/"</code>), a position or position and orientation, or a user (starts with 
+     * @param {string} address - The address to go to: a <code>"hifi://"</code> address, an IP address (e.g.,
+     *     <code>"127.0.0.1"</code> or <code>"localhost"</code>), a <code>file:///</code> address, a domain name, a named path
+     *     on a domain (starts with <code>"/"</code>), a position or position and orientation, or a user (starts with
      *     <code>"@"</code>).
      * @param {boolean} [fromSuggestions=false] - Set to <code>true</code> if the address is obtained from the "Goto" dialog.
      *     Helps ensure that user's location history is correctly maintained.
@@ -258,7 +259,7 @@ public slots:
     void handleLookupString(const QString& lookupString, bool fromSuggestions = false);
 
     /*@jsdoc
-     * Takes you to a position and orientation resulting from a lookup for a named path in the domain (set in the domain 
+     * Takes you to a position and orientation resulting from a lookup for a named path in the domain (set in the domain
      * server's settings).
      * @function location.goToViewpointForPath
      * @param {string} path - The position and orientation corresponding to the named path.
@@ -292,7 +293,7 @@ public slots:
      *     location history is correctly maintained.
      */
     void goToLocalSandbox(QString path = "", LookupTrigger trigger = LookupTrigger::StartupFromSettings) {
-        handleUrl(SANDBOX_HIFI_ADDRESS + path, trigger); 
+        handleUrl(SANDBOX_HIFI_ADDRESS + path, trigger);
     }
 
     /*@jsdoc
@@ -307,7 +308,7 @@ public slots:
      * Takes you to the specified user's location.
      * @function location.goToUser
      * @param {string} username - The user's username.
-     * @param {boolean} [matchOrientation=true] - If <code>true</code> then go to a location just in front of the user and turn 
+     * @param {boolean} [matchOrientation=true] - If <code>true</code> then go to a location just in front of the user and turn
      *     to face them, otherwise go to the user's exact location and orientation.
      */
     void goToUser(const QString& username, bool shouldMatchOrientation = true);
@@ -348,7 +349,7 @@ public slots:
     void copyAddress();
 
     /*@jsdoc
-     * Copies your current metaverse location and orientation (i.e., <code>location.pathname</code> property value) to the OS 
+     * Copies your current metaverse location and orientation (i.e., <code>location.pathname</code> property value) to the OS
      * clipboard.
      * @function location.copyPath
      */
@@ -374,7 +375,7 @@ signals:
     void lookupResultsFinished();
 
     /*@jsdoc
-     * Triggered when looking up the details of a metaverse user or location to go to has completed and the domain or user is 
+     * Triggered when looking up the details of a metaverse user or location to go to has completed and the domain or user is
      * offline.
      * @function location.lookupResultIsOffline
      * @returns {Signal}
@@ -415,9 +416,9 @@ signals:
      * @function location.locationChangeRequired
      * @param {Vec3} position - The position to go to.
      * @param {boolean} hasOrientationChange - If <code>true</code> then a new <code>orientation</code> has been requested.
-     * @param {Quat} orientation - The orientation to change to. Is {@link Quat(0)|Quat.IDENTITY} if 
+     * @param {Quat} orientation - The orientation to change to. Is {@link Quat(0)|Quat.IDENTITY} if
      *     <code>hasOrientationChange</code> is <code>false</code>.
-     * @param {boolean} shouldFaceLocation - If <code>true</code> then the request is to go to a position near that specified 
+     * @param {boolean} shouldFaceLocation - If <code>true</code> then the request is to go to a position near that specified
      *     and orient your avatar to face it. For example when you visit someone from the "People" dialog.
      * @returns {Signal}
      * @example <caption>Report location change requests.</caption>
@@ -468,7 +469,7 @@ signals:
      * Triggered when there's a change in whether or not there's a previous location that can be navigated to using
      * {@link location.goBack|goBack}. (Reflects changes in the state of the "Goto" dialog's back arrow.)
      * @function location.goBackPossible
-     * @param {boolean} isPossible - <code>true</code> if there's a previous location to navigate to, otherwise 
+     * @param {boolean} isPossible - <code>true</code> if there's a previous location to navigate to, otherwise
      *     <code>false</code>.
      * @returns {Signal}
      * @example <caption>Report when ability to navigate back changes.</caption>
@@ -511,7 +512,7 @@ private:
 
     const JSONCallbackParameters& apiCallbackParameters();
 
-    bool handleUrl(const QUrl& lookupUrl, LookupTrigger trigger = UserInput);
+    bool handleUrl(const QUrl& lookupUrl, LookupTrigger trigger = UserInput, const QString& lookupUrlInString = "");
 
     bool handleNetworkAddress(const QString& lookupString, LookupTrigger trigger, bool& hostChanged);
     void handlePath(const QString& path, LookupTrigger trigger, bool wasPathOnly = false);

--- a/libraries/networking/src/DomainHandler.cpp
+++ b/libraries/networking/src/DomainHandler.cpp
@@ -184,7 +184,7 @@ void DomainHandler::setSockAddr(const HifiSockAddr& sockAddr, const QString& hos
 
     // some callers may pass a hostname, this is not to be used for lookup but for DTLS certificate verification
     _domainURL = QUrl();
-    _domainURL.setScheme(URL_SCHEME_HIFI);
+    _domainURL.setScheme(URL_SCHEME_VIRCADIA);
     _domainURL.setHost(hostname);
     _domainURL.setPort(_sockAddr.getPort());
 }
@@ -199,7 +199,7 @@ void DomainHandler::setUUID(const QUuid& uuid) {
 void DomainHandler::setURLAndID(QUrl domainURL, QUuid domainID) {
     _pendingDomainID = domainID;
 
-    if (domainURL.scheme() != URL_SCHEME_HIFI) {
+    if (domainURL.scheme() != URL_SCHEME_VIRCADIA) {
         _sockAddr.clear();
 
         // if this is a file URL we need to see if it has a ~ for us to expand
@@ -215,7 +215,7 @@ void DomainHandler::setURLAndID(QUrl domainURL, QUuid domainID) {
 
     // if it's in the error state, reset and try again.
     if (_domainURL != domainURL 
-        || (_sockAddr.getPort() != domainPort && domainURL.scheme() == URL_SCHEME_HIFI)
+        || (_sockAddr.getPort() != domainPort && domainURL.scheme() == URL_SCHEME_VIRCADIA)
         || isServerless() // For reloading content in serverless domain.
         || _isInErrorState) {
         // re-set the domain info so that auth information is reloaded
@@ -230,7 +230,7 @@ void DomainHandler::setURLAndID(QUrl domainURL, QUuid domainID) {
             qCDebug(networking) << "Updated domain hostname to" << domainURL.host();
 
             if (!domainURL.host().isEmpty()) {
-                if (domainURL.scheme() == URL_SCHEME_HIFI) {
+                if (domainURL.scheme() == URL_SCHEME_VIRCADIA) {
                     // re-set the sock addr to null and fire off a lookup of the IP address for this domain-server's hostname
                     qCDebug(networking, "Looking up DS hostname %s.", domainURL.host().toLocal8Bit().constData());
                     QHostInfo::lookupHost(domainURL.host(), this, SLOT(completedHostnameLookup(const QHostInfo&)));
@@ -303,7 +303,7 @@ void DomainHandler::setIceServerHostnameAndID(const QString& iceServerHostname, 
 void DomainHandler::activateICELocalSocket() {
     DependencyManager::get<NodeList>()->flagTimeForConnectionStep(LimitedNodeList::ConnectionStep::SetDomainSocket);
     _sockAddr = _icePeer.getLocalSocket();
-    _domainURL.setScheme(URL_SCHEME_HIFI);
+    _domainURL.setScheme(URL_SCHEME_VIRCADIA);
     _domainURL.setHost(_sockAddr.getAddress().toString());
     emit domainURLChanged(_domainURL);
     emit completedSocketDiscovery();
@@ -312,7 +312,7 @@ void DomainHandler::activateICELocalSocket() {
 void DomainHandler::activateICEPublicSocket() {
     DependencyManager::get<NodeList>()->flagTimeForConnectionStep(LimitedNodeList::ConnectionStep::SetDomainSocket);
     _sockAddr = _icePeer.getPublicSocket();
-    _domainURL.setScheme(URL_SCHEME_HIFI);
+    _domainURL.setScheme(URL_SCHEME_VIRCADIA);
     _domainURL.setHost(_sockAddr.getAddress().toString());
     emit domainURLChanged(_domainURL);
     emit completedSocketDiscovery();
@@ -369,7 +369,7 @@ void DomainHandler::setIsConnected(bool isConnected) {
             // FIXME: Reinstate the requestDomainSettings() call here in version 2021.2.0 instead of having it in 
             // NodeList::processDomainServerList().
             /*
-            if (_domainURL.scheme() == URL_SCHEME_HIFI && !_domainURL.host().isEmpty()) {
+            if (_domainURL.scheme() == URL_SCHEME_VIRCADIA && !_domainURL.host().isEmpty()) {
                 // we've connected to new domain - time to ask it for global settings
                 requestDomainSettings();
             }

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -137,7 +137,7 @@ public:
     void setCanConnectWithoutAvatarEntities(bool canConnect);
     bool canConnectWithoutAvatarEntities();
 
-    bool isServerless() const { return _domainURL.scheme() != URL_SCHEME_HIFI; }
+    bool isServerless() const { return _domainURL.scheme() != URL_SCHEME_VIRCADIA; }
     bool getInterstitialModeEnabled() const;
     void setInterstitialModeEnabled(bool enableInterstitialMode);
 

--- a/libraries/networking/src/NetworkingConstants.h
+++ b/libraries/networking/src/NetworkingConstants.h
@@ -83,8 +83,8 @@ namespace NetworkingConstants {
 }
 
 const QString HIFI_URL_SCHEME_ABOUT = "about";
-const QString URL_SCHEME_HIFI = "hifi";
-const QString URL_SCHEME_HIFIAPP = "hifiapp";
+const QString URL_SCHEME_VIRCADIA = "hifi";
+const QString URL_SCHEME_VIRCADIAAPP = "hifiapp";
 const QString URL_SCHEME_DATA = "data";
 const QString URL_SCHEME_QRC = "qrc";
 const QString HIFI_URL_SCHEME_FILE = "file";

--- a/libraries/networking/src/NetworkingConstants.h
+++ b/libraries/networking/src/NetworkingConstants.h
@@ -25,7 +25,7 @@ namespace NetworkingConstants {
     // You can avoid changing that and still effectively use a connected domain on staging
     // if you manually generate a personal access token for the domains scope
     // at https://staging.highfidelity.com/user/tokens/new?for_domain_server=true
-    
+
     const QString WEB_ENGINE_VERSION = "Chrome/83.0.4103.122";
 
     // For now we only have one Metaverse server.
@@ -35,21 +35,21 @@ namespace NetworkingConstants {
     // Web Engine requests to this parent domain have an account authorization header added
     const QString AUTH_HOSTNAME_BASE = "vircadia.com";
     const QStringList IS_AUTHABLE_HOSTNAME = { "vircadia.com", "vircadia.io" };
-    
+
     // Use a custom User-Agent to avoid ModSecurity filtering, e.g. by hosting providers.
     const QByteArray VIRCADIA_USER_AGENT = "Mozilla/5.0 (VircadiaInterface)";
-    
+
     const QString WEB_ENGINE_USER_AGENT = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) " + WEB_ENGINE_VERSION + " Mobile Safari/537.36";
     const QString MOBILE_USER_AGENT = "Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) " + WEB_ENGINE_VERSION + " Mobile Safari/537.36";
-    
+
     // WebEntity Defaults
     const QString WEB_ENTITY_DEFAULT_SOURCE_URL = "https://vircadia.com/";
     const QString WEB_ENTITY_DEFAULT_USER_AGENT = WEB_ENGINE_USER_AGENT;
-    
+
     // Builds URLs
     const QUrl BUILDS_XML_URL("https://highfidelity.com/builds.xml");
     const QUrl MASTER_BUILDS_XML_URL("https://highfidelity.com/dev-builds.xml");
-    
+
     const QString DEFAULT_AVATAR_COLLISION_SOUND_URL = "https://hifi-public.s3.amazonaws.com/sounds/Collisions-otherorganic/Body_Hits_Impact.wav";
 
     // CDN URLs
@@ -71,12 +71,12 @@ namespace NetworkingConstants {
     const unsigned short STUN_SERVER_DEFAULT_PORT = 19302;
 #endif
 
-    const QUrl HELP_DOCS_URL { "https://docs.vircadia.dev" };
-    const QUrl HELP_FORUM_URL { "https://forums.vircadia.dev" };
+    const QUrl HELP_DOCS_URL { "https://docs.vircadia.com" };
+    const QUrl HELP_FORUM_URL { "https://forum.vircadia.com" };
     const QUrl HELP_SCRIPTING_REFERENCE_URL{ "https://apidocs.vircadia.dev/" };
-    const QUrl HELP_RELEASE_NOTES_URL{ "https://docs.vircadia.dev/release-notes.html" };
+    const QUrl HELP_RELEASE_NOTES_URL{ "https://docs.vircadia.com/release-notes.html" };
     const QUrl HELP_BUG_REPORT_URL{ "https://github.com/vircadia/vircadia/issues" };
-    
+
     const QString DEFAULT_VIRCADIA_ADDRESS = "file:///~/serverless/tutorial.json";
     const QString DEFAULT_HOME_ADDRESS = "file:///~/serverless/tutorial.json";
     const QString REDIRECT_HIFI_ADDRESS = "file:///~/serverless/redirect.json";

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -824,7 +824,7 @@ void NodeList::processDomainServerList(QSharedPointer<ReceivedMessage> message) 
     // FIXME: Remove this call to requestDomainSettings() and reinstate the one in DomainHandler::setIsConnected(), in version 
     // 2021.2.0. (New protocol version implies a domain server upgrade.)
     if (!_domainHandler.isConnected() 
-            && _domainHandler.getScheme() == URL_SCHEME_HIFI && !_domainHandler.getHostname().isEmpty()) {
+            && _domainHandler.getScheme() == URL_SCHEME_VIRCADIA && !_domainHandler.getHostname().isEmpty()) {
         // We're about to connect but we need the domain settings (in particular, the node permissions) in order to adjust the
         // canRezAvatarEntities permission above before using the permissions in determining whether or not to connect without
         // avatar entities rezzing below.

--- a/libraries/script-engine/src/ScriptEngine.cpp
+++ b/libraries/script-engine/src/ScriptEngine.cpp
@@ -2405,7 +2405,7 @@ void ScriptEngine::entityScriptContentAvailable(const EntityItemID& entityID, co
         QString currentDomain = DependencyManager::get<AddressManager>()->getDomainURL().host();
         
         QString domainSafeIP = nodeList->getDomainHandler().getHostname();
-        QString domainSafeURL = URL_SCHEME_HIFI + "://" + currentDomain;
+        QString domainSafeURL = URL_SCHEME_VIRCADIA + "://" + currentDomain;
         for (const auto& str : safeURLPrefixes) {
             if (domainSafeURL.startsWith(str) || domainSafeIP.startsWith(str)) {
                 qCDebug(scriptengine) << whitelistPrefix << "Whitelist Bypassed, entire domain is whitelisted. Current Domain Host: " 


### PR DESCRIPTION
To test... 

Open the console with Ctrl + Alt + J.

1. Using the `AddressManager.handleLookupString` API, try every type of possible path/URL. Especially try a placename with spaces in it.
2. Try all attempts with and without "hifi://".

Closes #1242