### PR TITLE
Fix typo in WebSocket~onMessageCallback API documention.

### DIFF
--- a/libraries/script-engine/src/WebSocketClass.cpp
+++ b/libraries/script-engine/src/WebSocketClass.cpp
@@ -159,7 +159,7 @@ void WebSocketClass::handleOnError(QAbstractSocket::SocketError error) {
 }
 
 /*@jsdoc
- * Triggered when a message is received.
+ * Called when a message is received.
  * @callback WebSocket~onMessageCallback
  * @param {WebSocket.MessageData} message - The message received.
  */


### PR DESCRIPTION
All other callbacks are documented as "Called ...". ("Triggered ..." is for signals.)