### PR TITLE
Update WebRTC Windows package

### DIFF
--- a/cmake/ports/webrtc/CONTROL
+++ b/cmake/ports/webrtc/CONTROL
@@ -1,3 +1,3 @@
 Source: webrtc
-Version: 20190626
+Version: 20210105
 Description: WebRTC

--- a/cmake/ports/webrtc/README.md
+++ b/cmake/ports/webrtc/README.md
@@ -1,0 +1,215 @@
+# WebRTC
+
+WebRTC Information:
+- https://webrtc.org/
+- https://webrtc.googlesource.com/src
+- https://webrtc.googlesource.com/src/+/refs/heads/master/docs/native-code/index.md
+  - https://webrtc.googlesource.com/src/+/refs/heads/master/docs/native-code/development/prerequisite-sw/index.md
+  - https://webrtc.googlesource.com/src/+/refs/heads/master/docs/native-code/development/index.md
+- https://www.chromium.org/developers/calendar
+- https://github.com/microsoft/winrtc
+- https://docs.microsoft.com/en-us/winrtc/getting-started
+- https://groups.google.com/g/discuss-webrtc \
+  See "PSA" posts for release information.
+- https://bugs.chromium.org/p/webrtc/issues/list
+- https://stackoverflow.com/questions/27809193/webrtc-not-building-for-windows
+- https://github.com/aisouard/libwebrtc/issues/57
+
+## Windows - M84
+
+WebRTC's M84 release is currently used because it corresponded to Microsoft's latest WinRTC release at the time of develeopment,
+and WinRTC is a source of potentially useful patches.
+
+The following notes document how the M84-based Windows VCPKG was created, using Visual Studio 2019.
+
+### Set Up depot_tools
+
+Install Google's depot_tools.
+- Download depot_tools.zip.
+- Extract somewhere.
+- Add the extracted directory to the start of the system `PATH` environment variable.
+
+Configure depot_tools.
+- Set an environment variable `DEPOT_TOOLS_WIN_TOOLCHAIN=0`
+- Set an environment variable `GYP_MSVS_VERSION=2019`
+
+Initialize depot_tools.
+- VS2019 developer command prompt in the directory where the source tree will be created.  
+- `gclient`
+
+### Get the Code
+
+Fetch the code into a *\src* subdirectory. This may take some time!
+- `fetch --nohooks webrtc`
+
+Switch to the M84 branch.
+- `cd src`
+- `git checkout branch-heads/4147`
+
+Fetch all the subrepositories.  
+- `gclient sync -D -r branch-heads/4147`
+
+### Patch the Code
+
+#### Modify compiler switches
+- Edit *build\config\win\BUILD.gn*:
+  - Change all `/MT` to `/MD`, and `/MTd` to `/MDd`.
+  - Change all `cflags = [ "/MDd" ]` to `[ "/MDd", "-D_ITERATOR_DEBUG_LEVEL=2", "-D_HAS_ITERATOR_DEBUGGING=1" ]`.
+- Edit *build\config\compiler\BUILD.gn*:\
+  Change:
+  ```
+    if (is_win) {
+      if (is_clang) {
+        cflags = [ "/Z7" ]  # Debug information in the .obj files.
+      } else {
+        cflags = [ "/Zi" ]  # Produce PDB file, no edit and continue.
+      }
+  ```
+  to:
+  ```
+    if (is_win) {
+      if (is_clang) {
+        cflags = [ "/Z7", "/std:c++17", "/Zc:__cplusplus" ]  # Debug information in the .obj files.
+      } else {
+        cflags = [ "/Zi", "/std:c++17", "/Zc:__cplusplus" ]  # Produce PDB file, no edit and continue.
+      }
+  ```
+
+#### H265 Codec Fixes  
+https://bugs.webrtc.org/9213#c13
+- Edit the following files:
+  - *modules\video_coding\codecs\h264\h264_color_space.h*
+  - *modules\video_coding\codecs\h264\h264_decoder_impl.h*
+  - *modules\video_coding\codecs\h264\h264_encoder_impl.h*
+  In each, comment out the following lines:
+  ```
+  #if defined(WEBRTC_WIN) && !defined(__clang__)
+  #error "See: bugs.webrtc.org/9213#c13."
+  #endif
+  ```
+- Edit *third_party\ffmpeg\libavcodec\fft_template.c*:\
+  Comment out all of `ff_fft_init` except the fail clause at the end.
+- Edit *third_party\ffmpeg\libavcodec\pcm.c*:\
+  Comment out last line, containing `PCM Archimedes VIDC`.
+- Edit *third_party\ffmpeg\libavutil\x86\imgutils_init.c*:\
+  Add the following method to the end of the file:
+  ```
+  void avpriv_emms_asm(void) {}  // Fix missing symbol in FFMPEG.
+  ```
+
+#### Exclude BoringSSL
+A separate OpenSSL VCPKG is used for building Vircadia.
+The following patches are needed even though SSL is excluded in the `gn gen` build commands.
+- Rename *third_party\boringssl* to *third_party\boringssl-NO*.
+- Edit *third_party\libsrtp\BUILD.gn:\
+  Change:
+  ```
+  public_deps = [
+    "//third_party/boringssl:boringssl",
+  ]
+  ```
+  To:
+  ```
+  public_deps = [
+    # "//third_party/boringssl:boringssl",
+  ]
+  ```
+
+- Edit *third_party\usrsctp\BUILD.gn*:\
+  Change:
+  ```
+  deps = [ "//third_party/boringssl" ]
+  ```
+  To:
+  ```
+  deps = [
+    # "//third_party/boringssl"
+  ]
+  ```
+- Edit *base\BUILD.gn*:\
+  In the code under:
+  ```
+  # Use the base implementation of hash functions when building for
+  # NaCl. Otherwise, use boringssl.
+  ```
+  Change:
+  ```
+  if (is_nacl) {
+  ```
+  To:
+  ```
+  # if (is_nacl) {
+  if (true) {
+  ```
+- Edit *rtc_base\BUILD.gn*:\
+  Change:  
+  ```
+  if (rtc_build_ssl) {
+    deps += [ "//third_party/boringssl" ]
+  } else {
+  ```
+  To:  
+  ```
+  if (rtc_build_ssl) {
+    # deps += [ "//third_party/boringssl" ]
+  } else {
+  ```
+
+### Set Up OpenSSL
+
+Do one of the following to provide OpenSSL for building against:
+a. If you have built Vircadia, find the **HIFI_VCPKG_BASE** subdirectory used in your build and make note of the path to and 
+including the *installed\x64-windows\include* directory (which includes an *openssl* directory).
+a. Follow https://github.com/vircadia/vcpkg to install *vcpkg* and then *openssl*. Make note of the path to and including the 
+*packages\openssl-windows_x64-windows\include* directory (which includes an *openssl* directory).
+
+Copy the *\<path\>\openssl* directory to the following locations (i.e., add as *openssl* subdirectories):
+- *third_party\libsrtp\crypto\include*
+- *third_party\usrsctp\usrsctplib\usrsctplib*
+
+Also use the path in the `gn gen` commands, below, making sure to escape `\`s as `\\`s.
+
+### Build and Package
+
+Use a VS2019 developer command prompt in the *src* directory.
+
+Create a release build of the WebRTC library:
+- `gn gen --ide=vs2019 out\Release --filters=//:webrtc "--args=is_debug=false is_clang=false use_custom_libcxx=false libcxx_is_shared=true symbol_level=2 use_lld=false rtc_include_tests=false rtc_build_tools=false rtc_build_examples=false proprietary_codecs=true rtc_use_h264=true enable_libaom=false rtc_enable_protobuf=false rtc_build_ssl=false rtc_ssl_root=\"<path>\""`
+- `ninja -C out\Release`
+
+Create a debug build of the WebRTC library:
+- `gn gen --ide=vs2019 out\Debug --filters=//:webrtc "--args=is_debug=true is_clang=false use_custom_libcxx=false libcxx_is_shared=true enable_iterator_debugging=true use_lld=false rtc_include_tests=false rtc_build_tools=false rtc_build_examples=false proprietary_codecs=true rtc_use_h264=true enable_libaom=false rtc_enable_protobuf=false rtc_build_ssl=false rtc_ssl_root=\"<path>\""`
+- `ninja -C out\Debug`
+
+Create VCPKG file:
+- Assemble files in VCPKG directory structure: Use the *copy-VCPKG-files-win.cmd* batch file per instructions in it.  
+`cd ..`\
+`copy-VCPKG-files-win`
+- Zip up the VCPKG *webrtc* directory created by the batch file.  
+`cd vcpkg`\
+`7z a -tzip webrtc-m84-yyyymmdd-windows.zip webrtc`
+- Calculate the SHA512 of the zip file. E.g., using a Windows PowerShell command window:\
+  `Get-FileHash <filename> -Algorithm SHA512 | Format-List`
+- Convert the SHA512 to lower case. E.g., using Microsoft Word, select the SHA512 text and use Shift-F3 to change the case.
+- Host the zip file on the Web.
+- Update *CONTROL* and *portfile.cmake* with version number (revision date), zip file Web URL, and SHA512.
+
+### Tidying up
+
+Disable the depot_tools:
+- Rename the *depot_tools* directory so that these tools don't interfere with the rest of your development environment for 
+  other work.
+
+
+## Linux - M81
+
+The original, High Fidelity-provided WebRTC VCPKG library is used for AEC (audio echo cancellation) only.
+
+**TODO:** Update to M84 and include WebRTC components per Windows WebRTC.
+
+
+## MacOS - M78
+
+The original, High Fidelity-provided WebRTC VCPKG library is used for AEC (audio echo cancellation) only.
+
+**TODO:** Update to M84 and include WebRTC components per Windows WebRTC.

--- a/cmake/ports/webrtc/copy-VCPKG-file-win.cmd
+++ b/cmake/ports/webrtc/copy-VCPKG-file-win.cmd
@@ -1,0 +1,36 @@
+rem Copy this file to a directory above the WebRTC \src directory and run it from there in a command window.
+set WEBRTC_SRC_DIR=src
+set RELEASE_LIB_DIR=%WEBRTC_SRC_DIR%\out\Release\obj
+set DEBUG_LIB_DIR=%WEBRTC_SRC_DIR%\out\Debug\obj
+set VCPKG_TGT_DIR=vcpkg
+
+if exist %VCPKG_TGT_DIR% rd /s /q %VCPKG_TGT_DIR%
+mkdir %VCPKG_TGT_DIR%
+
+rem License and .lib files
+mkdir %VCPKG_TGT_DIR%\webrtc\share\webrtc\
+copy %WEBRTC_SRC_DIR%\LICENSE %VCPKG_TGT_DIR%\webrtc\share\webrtc\copyright
+xcopy /v %RELEASE_LIB_DIR%\webrtc.lib %VCPKG_TGT_DIR%\webrtc\lib\
+xcopy /v %DEBUG_LIB_DIR%\webrtc.lib %VCPKG_TGT_DIR%\webrtc\debug\lib\
+
+rem Header files
+mkdir %VCPKG_TGT_DIR%\webrtc\include\webrtc\
+copy %WEBRTC_SRC_DIR%\common_types.h %VCPKG_TGT_DIR%\webrtc\include\webrtc
+xcopy /v /s /i %WEBRTC_SRC_DIR%\api\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\api
+xcopy /v /s /i %WEBRTC_SRC_DIR%\audio\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\audio
+xcopy /v /s /i %WEBRTC_SRC_DIR%\base\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\base
+xcopy /v /s /i %WEBRTC_SRC_DIR%\call\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\call
+xcopy /v /s /i %WEBRTC_SRC_DIR%\common_audio\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\common_audio
+xcopy /v /s /i %WEBRTC_SRC_DIR%\common_video\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\common_video
+xcopy /v /s /i %WEBRTC_SRC_DIR%\logging\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\logging
+xcopy /v /s /i %WEBRTC_SRC_DIR%\media\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\media
+xcopy /v /s /i %WEBRTC_SRC_DIR%\modules\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\modules
+xcopy /v /s /i %WEBRTC_SRC_DIR%\p2p\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\p2p
+xcopy /v /s /i %WEBRTC_SRC_DIR%\pc\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\pc
+xcopy /v /s /i %WEBRTC_SRC_DIR%\rtc_base\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\rtc_base
+xcopy /v /s /i %WEBRTC_SRC_DIR%\rtc_tools\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\rtc_tools
+xcopy /v /s /i %WEBRTC_SRC_DIR%\stats\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\stats
+xcopy /v /s /i %WEBRTC_SRC_DIR%\system_wrappers\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\system_wrappers
+xcopy /v /s /i %WEBRTC_SRC_DIR%\third_party\abseil-cpp\absl\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\absl
+xcopy /v /s /i %WEBRTC_SRC_DIR%\third_party\libyuv\include\libyuv\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\libyuv
+xcopy /v /s /i %WEBRTC_SRC_DIR%\video\*.h %VCPKG_TGT_DIR%\webrtc\include\webrtc\video

--- a/cmake/ports/webrtc/portfile.cmake
+++ b/cmake/ports/webrtc/portfile.cmake
@@ -1,5 +1,5 @@
 include(vcpkg_common_functions)
-set(WEBRTC_VERSION 20190626)
+set(WEBRTC_VERSION 20210105)
 set(MASTER_COPY_SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src)
 
 file(READ "${VCPKG_ROOT_DIR}/_env/EXTERNAL_BUILD_ASSETS.txt" EXTERNAL_BUILD_ASSETS)
@@ -9,9 +9,9 @@ if (ANDROID)
 elseif (WIN32)
     vcpkg_download_distfile(
         WEBRTC_SOURCE_ARCHIVE
-        URLS "${EXTERNAL_BUILD_ASSETS}/seth/webrtc-20190626-windows.zip"
-        SHA512 c0848eddb1579b3bb0496b8785e24f30470f3c477145035fd729264a326a467b9467ae9f426aa5d72d168ad9e9bf2c279150744832736bdf39064d24b04de1a3
-        FILENAME webrtc-20190626-windows.zip
+        URLS "${EXTERNAL_BUILD_ASSETS}/dependencies/vcpkg/webrtc-m84-20210105-windows.zip"
+        SHA512 12847f7e9df2e0539a6b017db88012a8978b1aa37ff2e8dbf019eb7438055395fdda3a74dc669b0a30330973a83bc57e86eca6f59b1c9eff8e2145a7ea4a532a
+        FILENAME webrtc-m84-20210105-windows.zip
     )
 elseif (APPLE)
     vcpkg_download_distfile(

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -1176,7 +1176,9 @@ void AudioClient::configureWebrtc() {
     config.high_pass_filter.enabled = false;
     config.echo_canceller.enabled = true;
     config.echo_canceller.mobile_mode = false;
+#if defined(WEBRTC_LEGACY)
     config.echo_canceller.use_legacy_aec = false;
+#endif
     config.noise_suppression.enabled = false;
     config.noise_suppression.level = webrtc::AudioProcessing::Config::NoiseSuppression::kModerate;
     config.voice_detection.enabled = false;

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -58,6 +58,7 @@
 #include "HifiAudioDeviceInfo.h"
 
 #if defined(WEBRTC_AUDIO)
+#  define WEBRTC_APM_DEBUG_DUMP 0
 #  include <modules/audio_processing/include/audio_processing.h>
 #  include "modules/audio_processing/audio_processing_impl.h"
 #endif

--- a/libraries/shared/src/shared/WebRTC.h
+++ b/libraries/shared/src/shared/WebRTC.h
@@ -22,6 +22,7 @@
 #if defined(Q_OS_MAC)
 #  define WEBRTC_AUDIO 1
 #  define WEBRTC_POSIX 1
+#  define WEBRTC_LEGACY 1
 #elif defined(Q_OS_WIN)
 #  define WEBRTC_AUDIO 1
 #  define WEBRTC_DATA_CHANNEL 1
@@ -32,9 +33,11 @@
 // I don't yet have a working libwebrtc for android
 // #  define WEBRTC_AUDIO 1
 // #  define WEBRTC_POSIX 1
+// #  define WEBRTC_LEGACY 1
 #elif defined(Q_OS_LINUX)
 #  define WEBRTC_AUDIO 1
 #  define WEBRTC_POSIX 1
+#  define WEBRTC_LEGACY 1
 #endif
 
 #endif // hifi_WebRTC_h


### PR DESCRIPTION
- Updates the WebRTC version used on Windows from version M81 to M84.
- Adds WebRTC data channel to the WebRTC VCPKG. *

`*` In current `master`, the audio component of WebRTC is used for echo cancellation.

### Testing	

Check that the following audio features continue to work on Windows:
- [x] Echo cancellation
- [x] Noise reduction
- [x] Manual nose reduction

Check that other OSes continue to work:
- [x] Linux server
- [x] Linux client
- [x] MacOS client

(Resubmission of PR https://github.com/vircadia/vircadia/pull/1221.)