### PR TITLE
Update Doxygen group tags to use /// format

### DIFF
--- a/libraries/script-engine/src/AbstractScriptingServicesInterface.h
+++ b/libraries/script-engine/src/AbstractScriptingServicesInterface.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_AbstractScriptingServicesInterface_h
 #define hifi_AbstractScriptingServicesInterface_h
 
@@ -25,4 +26,5 @@ public:
 
 
 #endif // hifi_AbstractScriptingServicesInterface_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/ArrayBufferClass.h
+++ b/libraries/script-engine/src/ArrayBufferClass.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_ArrayBufferClass_h
 #define hifi_ArrayBufferClass_h
 
@@ -61,4 +62,5 @@ private:
 };
 
 #endif // hifi_ArrayBufferClass_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/ArrayBufferPrototype.h
+++ b/libraries/script-engine/src/ArrayBufferPrototype.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_ArrayBufferPrototype_h
 #define hifi_ArrayBufferPrototype_h
 
@@ -34,4 +35,5 @@ private:
 };
 
 #endif // hifi_ArrayBufferPrototype_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/ArrayBufferViewClass.h
+++ b/libraries/script-engine/src/ArrayBufferViewClass.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_ArrayBufferViewClass_h
 #define hifi_ArrayBufferViewClass_h
 
@@ -53,4 +54,5 @@ protected:
 };
 
 #endif // hifi_ArrayBufferViewClass_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/AssetScriptingInterface.h
+++ b/libraries/script-engine/src/AssetScriptingInterface.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #pragma once
 
 #ifndef hifi_AssetScriptingInterface_h
@@ -547,4 +548,5 @@ protected:
 };
 
 #endif // hifi_AssetScriptingInterface_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/AudioScriptingInterface.h
+++ b/libraries/script-engine/src/AudioScriptingInterface.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_AudioScriptingInterface_h
 #define hifi_AudioScriptingInterface_h
 
@@ -293,4 +294,5 @@ private:
 void registerAudioMetaTypes(QScriptEngine* engine);
 
 #endif // hifi_AudioScriptingInterface_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/BatchLoader.h
+++ b/libraries/script-engine/src/BatchLoader.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_BatchLoader_h
 #define hifi_BatchLoader_h
 
@@ -58,4 +59,5 @@ private:
 };
 
 #endif // hifi_BatchLoader_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/ConsoleScriptingInterface.h
+++ b/libraries/script-engine/src/ConsoleScriptingInterface.h
@@ -14,9 +14,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #pragma once
 #ifndef hifi_ConsoleScriptingInterface_h
 #define hifi_ConsoleScriptingInterface_h
@@ -222,4 +223,5 @@ private:
 };
 
 #endif // hifi_ConsoleScriptingInterface_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/DataViewClass.h
+++ b/libraries/script-engine/src/DataViewClass.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_DataViewClass_h
 #define hifi_DataViewClass_h
 
@@ -37,4 +38,5 @@ private:
 
 
 #endif // hifi_DataViewClass_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/DataViewPrototype.h
+++ b/libraries/script-engine/src/DataViewPrototype.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_DataViewPrototype_h
 #define hifi_DataViewPrototype_h
 
@@ -69,4 +70,5 @@ private:
 };
 
 #endif // hifi_DataViewPrototype_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/EventTypes.h
+++ b/libraries/script-engine/src/EventTypes.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_EventTypes_h
 #define hifi_EventTypes_h
 
@@ -19,4 +20,5 @@
 void registerEventTypes(QScriptEngine* engine);
 
 #endif // hifi_EventTypes_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/FileScriptingInterface.h
+++ b/libraries/script-engine/src/FileScriptingInterface.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_FileScriptingInterface_h
 #define hifi_FileScriptingInterface_h
 
@@ -116,4 +117,5 @@ private:
 };
 
 #endif // hifi_FileScriptingInterface_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/KeyEvent.h
+++ b/libraries/script-engine/src/KeyEvent.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_KeyEvent_h
 #define hifi_KeyEvent_h
 
@@ -42,4 +43,5 @@ public:
 Q_DECLARE_METATYPE(KeyEvent)
 
 #endif // hifi_KeyEvent_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/MIDIEvent.h
+++ b/libraries/script-engine/src/MIDIEvent.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_MIDIEvent_h
 #define hifi_MIDIEvent_h
 
@@ -33,4 +34,5 @@ QScriptValue midiEventToScriptValue(QScriptEngine* engine, const MIDIEvent& even
 void midiEventFromScriptValue(const QScriptValue &object, MIDIEvent& event);
 
 #endif // hifi_MIDIEvent_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/Mat4.h
+++ b/libraries/script-engine/src/Mat4.h
@@ -10,9 +10,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_Mat4_h
 #define hifi_Mat4_h
 
@@ -322,4 +323,5 @@ public slots:
 };
 
 #endif // hifi_Mat4_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/MenuItemProperties.h
+++ b/libraries/script-engine/src/MenuItemProperties.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_MenuItemProperties_h
 #define hifi_MenuItemProperties_h
 
@@ -59,4 +60,5 @@ void registerMenuItemProperties(QScriptEngine* engine);
 
 
 #endif // hifi_MenuItemProperties_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/ModelScriptingInterface.h
+++ b/libraries/script-engine/src/ModelScriptingInterface.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_ModelScriptingInterface_h
 #define hifi_ModelScriptingInterface_h
 
@@ -100,4 +101,5 @@ private:
 };
 
 #endif // hifi_ModelScriptingInterface_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/MouseEvent.h
+++ b/libraries/script-engine/src/MouseEvent.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_MouseEvent_h
 #define hifi_MouseEvent_h
 
@@ -45,4 +46,5 @@ public:
 Q_DECLARE_METATYPE(MouseEvent)
 
 #endif // hifi_MouseEvent_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/Quat.h
+++ b/libraries/script-engine/src/Quat.h
@@ -10,9 +10,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_Quat_h
 #define hifi_Quat_h
 
@@ -471,4 +472,5 @@ private:
 };
 
 #endif // hifi_Quat_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/RecordingScriptingInterface.h
+++ b/libraries/script-engine/src/RecordingScriptingInterface.h
@@ -5,9 +5,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_RecordingScriptingInterface_h
 #define hifi_RecordingScriptingInterface_h
 
@@ -372,4 +373,5 @@ private:
 };
 
 #endif // hifi_RecordingScriptingInterface_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/SceneScriptingInterface.h
+++ b/libraries/script-engine/src/SceneScriptingInterface.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_SceneScriptingInterface_h
 #define hifi_SceneScriptingInterface_h
 
@@ -72,4 +73,5 @@ protected:
 };
 
 #endif // hifi_SceneScriptingInterface_h 
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/ScriptAudioInjector.h
+++ b/libraries/script-engine/src/ScriptAudioInjector.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_ScriptAudioInjector_h
 #define hifi_ScriptAudioInjector_h
 
@@ -151,4 +152,5 @@ QScriptValue injectorToScriptValue(QScriptEngine* engine, ScriptAudioInjector* c
 void injectorFromScriptValue(const QScriptValue& object, ScriptAudioInjector*& out);
 
 #endif // hifi_ScriptAudioInjector_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/ScriptCache.h
+++ b/libraries/script-engine/src/ScriptCache.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_ScriptCache_h
 #define hifi_ScriptCache_h
 
@@ -67,4 +68,5 @@ private:
 };
 
 #endif // hifi_ScriptCache_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -9,9 +9,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_ScriptEngine_h
 #define hifi_ScriptEngine_h
 
@@ -1015,4 +1016,5 @@ ScriptEnginePointer scriptEngineFactory(ScriptEngine::Context context,
                                         const QString& fileNameString);
 
 #endif // hifi_ScriptEngine_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/ScriptEngineLogging.h
+++ b/libraries/script-engine/src/ScriptEngineLogging.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_ScriptEngineLogging_h
 #define hifi_ScriptEngineLogging_h
 
@@ -21,4 +22,5 @@ Q_DECLARE_LOGGING_CATEGORY(scriptengine_module)
 Q_DECLARE_LOGGING_CATEGORY(scriptengine_script)
 
 #endif // hifi_ScriptEngineLogging_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/ScriptEngines.h
+++ b/libraries/script-engine/src/ScriptEngines.h
@@ -5,9 +5,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_ScriptEngines_h
 #define hifi_ScriptEngines_h
 
@@ -364,4 +365,5 @@ QString expandScriptPath(const QString& rawPath);
 QUrl expandScriptUrl(const QUrl& rawScriptURL);
 
 #endif // hifi_ScriptEngine_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/ScriptGatekeeper.h
+++ b/libraries/script-engine/src/ScriptGatekeeper.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef vircadia_ScriptGatekeeper_h
 #define vircadia_ScriptGatekeeper_h
 
@@ -30,4 +31,5 @@ private:
 };
 
 #endif // vircadia_ScriptGatekeeper_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/ScriptUUID.h
+++ b/libraries/script-engine/src/ScriptUUID.h
@@ -10,9 +10,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_ScriptUUID_h
 #define hifi_ScriptUUID_h
 
@@ -128,4 +129,5 @@ private:
 };
 
 #endif // hifi_ScriptUUID_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/ScriptsModel.h
+++ b/libraries/script-engine/src/ScriptsModel.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_ScriptsModel_h
 #define hifi_ScriptsModel_h
 
@@ -194,4 +195,5 @@ private:
 };
 
 #endif // hifi_ScriptsModel_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/ScriptsModelFilter.h
+++ b/libraries/script-engine/src/ScriptsModelFilter.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_ScriptsModelFilter_h
 #define hifi_ScriptsModelFilter_h
 
@@ -84,4 +85,5 @@ protected:
 };
 
 #endif // hifi_ScriptsModelFilter_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/SpatialEvent.h
+++ b/libraries/script-engine/src/SpatialEvent.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_SpatialEvent_h
 #define hifi_SpatialEvent_h
 
@@ -37,4 +38,5 @@ public:
 Q_DECLARE_METATYPE(SpatialEvent)
 
 #endif // hifi_SpatialEvent_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/StackTestScriptingInterface.h
+++ b/libraries/script-engine/src/StackTestScriptingInterface.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #pragma once
 
 #ifndef hifi_StackTestScriptingInterface_h
@@ -31,4 +32,5 @@ public:
 };
 
 #endif // hifi_StackTestScriptingInterface_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/TouchEvent.h
+++ b/libraries/script-engine/src/TouchEvent.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_TouchEvent_h
 #define hifi_TouchEvent_h
 
@@ -63,4 +64,5 @@ private:
 Q_DECLARE_METATYPE(TouchEvent)
 
 #endif // hifi_TouchEvent_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/TypedArrayPrototype.h
+++ b/libraries/script-engine/src/TypedArrayPrototype.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_TypedArrayPrototype_h
 #define hifi_TypedArrayPrototype_h
 
@@ -34,4 +35,5 @@ private:
 };
 
 #endif // hifi_TypedArrayPrototype_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/TypedArrays.h
+++ b/libraries/script-engine/src/TypedArrays.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_TypedArrays_h
 #define hifi_TypedArrays_h
 
@@ -149,4 +150,5 @@ public:
 };
 
 #endif // hifi_TypedArrays_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/UsersScriptingInterface.h
+++ b/libraries/script-engine/src/UsersScriptingInterface.h
@@ -9,9 +9,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #pragma once
 
 #ifndef hifi_UsersScriptingInterface_h
@@ -265,4 +266,5 @@ private:
 
 
 #endif // hifi_UsersScriptingInterface_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/Vec3.h
+++ b/libraries/script-engine/src/Vec3.h
@@ -10,9 +10,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #pragma once
 #ifndef hifi_Vec3_h
 #define hifi_Vec3_h
@@ -420,4 +421,5 @@ private:
 };
 
 #endif // hifi_Vec3_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/WebSocketClass.h
+++ b/libraries/script-engine/src/WebSocketClass.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_WebSocketClass_h
 #define hifi_WebSocketClass_h
 
@@ -257,4 +258,5 @@ QScriptValue wscReadyStateToScriptValue(QScriptEngine* engine, const WebSocketCl
 void wscReadyStateFromScriptValue(const QScriptValue& object, WebSocketClass::ReadyState& readyState);
 
 #endif // hifi_WebSocketClass_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/WebSocketServerClass.h
+++ b/libraries/script-engine/src/WebSocketServerClass.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_WebSocketServerClass_h
 #define hifi_WebSocketServerClass_h
 
@@ -121,4 +122,5 @@ signals:
 };
 
 #endif // hifi_WebSocketServerClass_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/WheelEvent.h
+++ b/libraries/script-engine/src/WheelEvent.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_WheelEvent_h
 #define hifi_WheelEvent_h
 
@@ -45,4 +46,5 @@ public:
 Q_DECLARE_METATYPE(WheelEvent)
 
 #endif // hifi_WheelEvent_h
-/** @}*/
+
+/// @}

--- a/libraries/script-engine/src/XMLHttpRequestClass.h
+++ b/libraries/script-engine/src/XMLHttpRequestClass.h
@@ -8,9 +8,10 @@
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
-/** @addtogroup ScriptEngine
- *  @{
-*/
+
+/// @addtogroup ScriptEngine
+/// @{
+
 #ifndef hifi_XMLHttpRequestClass_h
 #define hifi_XMLHttpRequestClass_h
 
@@ -377,4 +378,5 @@ private slots:
 };
 
 #endif // hifi_XMLHttpRequestClass_h
-/** @}*/
+
+/// @}

--- a/tools/doxygen/README.md
+++ b/tools/doxygen/README.md
@@ -7,8 +7,6 @@
 
 **Doxygen** &ge; 1.9.1 - https://www.doxygen.nl/
 
-Make a `/build/doxygen/` directory.
-
 If you want to run Doxygen from a command prompt, add the Doxygen install's `/bin` directory to your system PATH.
 
 


### PR DESCRIPTION
This makes these consistent with other Doxygen tags.

The ScriptEngine documentation, such as it is, should be generated the same as before.