### PR TITLE
Fix CMake GifCreator name warning

### DIFF
--- a/cmake/modules/FindGifCreator.cmake
+++ b/cmake/modules/FindGifCreator.cmake
@@ -21,6 +21,6 @@ hifi_library_search_hints("GIFCREATOR")
 find_path(GIFCREATOR_INCLUDE_DIRS "GifCreator/GifCreator.h" HINTS ${GIFCREATOR_SEARCH_DIRS})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(GIFCREATOR DEFAULT_MSG GIFCREATOR_INCLUDE_DIRS)
+find_package_handle_standard_args(GifCreator DEFAULT_MSG GIFCREATOR_INCLUDE_DIRS)
 
 mark_as_advanced(GIFCREATOR_INCLUDE_DIRS GIFCREATOR_SEARCH_DIRS)


### PR DESCRIPTION
This fixes this:

```
CMake Warning (dev) at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:426 (message):
  The package name passed to `find_package_handle_standard_args` (GIFCREATOR)
  does not match the name of the calling package (GifCreator).  This can lead
  to problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake/modules/FindGifCreator.cmake:24 (find_package_handle_standard_args)
  /home/dale/vircadia-files/vcpkg/2a0d2829/scripts/buildsystems/vcpkg.cmake:262 (_find_package)
  interface/CMakeLists.txt:487 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```