### PR TITLE
Don't use LeapMotion by default.

### DIFF
--- a/plugins/hifiLeapMotion/CMakeLists.txt
+++ b/plugins/hifiLeapMotion/CMakeLists.txt
@@ -6,7 +6,12 @@
 #  See the accompanying file LICENSE or http:#www.apache.org/licenses/LICENSE-2.0.html
 #
 
-find_package(LEAPMOTION)
+if (USE_LEAPMOTION)
+    find_package(LEAPMOTION)
+else()
+    message(STATUS "Use of Leap Motion SDK not enabled. Run cmake with -DUSE_LEAPMOTION=1 to use it.")
+endif()
+
 if (LEAPMOTION_FOUND) 
     set(TARGET_NAME hifiLeapMotion)
     setup_hifi_plugin(Qml)


### PR DESCRIPTION
It doesn't have many users, and causes an annoying 'LEAPMOTIONConfig.cmake' not found error if the SDK isn't installed.

We now require running cmake with -DUSE_LEAPMOTION=1 to enable using it.

This replaces:
```
CMake Warning at /home/dale/vircadia-files/vcpkg/2a0d2829/scripts/buildsystems/vcpkg.cmake:262 (_find_package):
  By not providing "FindLEAPMOTION.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "LEAPMOTION", but CMake did not find one.

  Could not find a package configuration file provided by "LEAPMOTION" with
  any of the following names:

    LEAPMOTIONConfig.cmake
    leapmotion-config.cmake

  Add the installation prefix of "LEAPMOTION" to CMAKE_PREFIX_PATH or set
  "LEAPMOTION_DIR" to a directory containing one of the above files.  If
  "LEAPMOTION" provides a separate development package or SDK, be sure it has
  been installed.
Call Stack (most recent call first):
  plugins/hifiLeapMotion/CMakeLists.txt:9 (find_package)
```

with:

```
-- Use of Leap Motion SDK not enabled. Run cmake with -DUSE_LEAPMOTION=1 to use it.
```


Testing:

* Test both `cmake` and `cmake -DUSE_LEAPMOTION=1`. 
* Setting the `USE_LEAPMOTION` setting is cached by cmake, so to disable it, the build directory needs to be wiped, or it can be set to 0 instead.
