### PR TITLE
Replace uses of endl on Qt classes with Qt::endl

### DIFF
--- a/android/apps/interface/src/main/cpp/native.cpp
+++ b/android/apps/interface/src/main/cpp/native.cpp
@@ -142,7 +142,7 @@ void unpackAndroidAssets() {
         if (!file.open(QIODevice::ReadWrite | QIODevice::Truncate)) {
             throw std::runtime_error("Can't write date stamp");
         }
-        QTextStream(&file) << "touch" << endl;
+        QTextStream(&file) << "touch" << Qt::endl;
         file.close();
     }
 }

--- a/libraries/controllers/src/controllers/UserInputMapper.cpp
+++ b/libraries/controllers/src/controllers/UserInputMapper.cpp
@@ -738,7 +738,7 @@ Mapping::Pointer UserInputMapper::newMapping(const QString& mappingName) {
 //        if (request->getResult() == ResourceRequest::Success) {
 //            result = parseMapping(QString(request->getData()));
 //        } else {
-//            qCWarning(controllers) << "Failed to load mapping url <" << jsonUrl << ">" << endl;
+//            qCWarning(controllers) << "Failed to load mapping url <" << jsonUrl << ">" << Qt::endl;
 //        }
 //        request->deleteLater();
 //    }
@@ -1177,13 +1177,13 @@ Mapping::Pointer UserInputMapper::parseMapping(const QString& json) {
     if (doc.isNull()) {
         qCDebug(controllers) << "Invalid JSON...\n";
         qCDebug(controllers) << error.errorString();
-        qCDebug(controllers) << "JSON was:\n" << json << endl;
+        qCDebug(controllers) << "JSON was:\n" << json << Qt::endl;
         return Mapping::Pointer();
     }
 
     if (!doc.isObject()) {
-        qWarning() << "Mapping json Document is not an object" << endl;
-        qCDebug(controllers) << "JSON was:\n" << json << endl;
+        qWarning() << "Mapping json Document is not an object" << Qt::endl;
+        qCDebug(controllers) << "JSON was:\n" << json << Qt::endl;
         return Mapping::Pointer();
     }
     return parseMapping(doc.object());

--- a/tools/ac-client/src/ACClientApp.cpp
+++ b/tools/ac-client/src/ACClientApp.cpp
@@ -49,7 +49,7 @@ ACClientApp::ACClientApp(int argc, char* argv[]) :
     parser.addOption(listenPortOption);
 
     if (!parser.parse(QCoreApplication::arguments())) {
-        qCritical() << parser.errorText() << endl;
+        qCritical() << parser.errorText() << Qt::endl;
         parser.showHelp();
         Q_UNREACHABLE();
     }

--- a/tools/atp-client/src/ATPClientApp.cpp
+++ b/tools/atp-client/src/ATPClientApp.cpp
@@ -59,7 +59,7 @@ ATPClientApp::ATPClientApp(int argc, char* argv[]) :
     parser.addOption(listenPortOption);
 
     if (!parser.parse(QCoreApplication::arguments())) {
-        qCritical() << parser.errorText() << endl;
+        qCritical() << parser.errorText() << Qt::endl;
         parser.showHelp();
         Q_UNREACHABLE();
     }

--- a/tools/ice-client/src/ICEClientApp.cpp
+++ b/tools/ice-client/src/ICEClientApp.cpp
@@ -45,7 +45,7 @@ ICEClientApp::ICEClientApp(int argc, char* argv[]) :
     parser.addOption(cacheSTUNOption);
 
     if (!parser.parse(QCoreApplication::arguments())) {
-        qCritical() << parser.errorText() << endl;
+        qCritical() << parser.errorText() << Qt::endl;
         parser.showHelp();
         Q_UNREACHABLE();
     }

--- a/tools/nitpick/src/TestCreator.cpp
+++ b/tools/nitpick/src/TestCreator.cpp
@@ -207,11 +207,11 @@ void TestCreator::appendTestResultsToFile(const TestResult& testResult, const QP
 
     // Create text file describing the failure
     QTextStream stream(&descriptionFile);
-    stream << "TestCreator in folder " << testResult._pathname.left(testResult._pathname.length() - 1) << endl; // remove trailing '/'
-    stream << "Expected image was    " << testResult._expectedImageFilename << endl;
-    stream << "Actual image was      " << testResult._actualImageFilename << endl;
-    stream << "Similarity index was  " << testResult._errorGlobal << endl;
-    stream << "Worst tile was  " << testResult._errorLocal << endl;
+    stream << "TestCreator in folder " << testResult._pathname.left(testResult._pathname.length() - 1) << Qt::endl; // remove trailing '/'
+    stream << "Expected image was    " << testResult._expectedImageFilename << Qt::endl;
+    stream << "Actual image was      " << testResult._actualImageFilename << Qt::endl;
+    stream << "Similarity index was  " << testResult._errorGlobal << Qt::endl;
+    stream << "Worst tile was  " << testResult._errorLocal << Qt::endl;
 
     descriptionFile.close();
 
@@ -415,7 +415,7 @@ void TestCreator::includeTest(QTextStream& textStream, const QString& testPathna
     QString partialPath = extractPathFromTestsDown(testPathname);
     QString partialPathWithoutTests = partialPath.right(partialPath.length() - 7);
 
-    textStream << "Script.include(testsRootPath + \"" << partialPathWithoutTests + "\");" << endl;
+    textStream << "Script.include(testsRootPath + \"" << partialPathWithoutTests + "\");" << Qt::endl;
 }
 
 void TestCreator::createTests(const QString& clientProfile) {
@@ -994,7 +994,7 @@ void TestCreator::createRecursiveScript(const QString& directory, bool interacti
 
     QTextStream textStream(&recursiveTestsFile);
 
-    textStream << "// This is an automatically generated file, created by nitpick" << endl;
+    textStream << "// This is an automatically generated file, created by nitpick" << Qt::endl;
 
     // Include 'nitpick.js'
     QString branch = nitpick->getSelectedBranch();
@@ -1002,31 +1002,31 @@ void TestCreator::createRecursiveScript(const QString& directory, bool interacti
 
     textStream << "PATH_TO_THE_REPO_PATH_UTILS_FILE = \"https://raw.githubusercontent.com/" + user + "/hifi_tests/" + branch +
         "/tests/utils/branchUtils.js\";"
-        << endl;
-    textStream << "Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);" << endl << endl;
+        << Qt::endl;
+    textStream << "Script.include(PATH_TO_THE_REPO_PATH_UTILS_FILE);" << Qt::endl << Qt::endl;
 
     // The 'depth' variable is used to signal when to start running the recursive scripts
-    textStream << "if (typeof depth === 'undefined') {" << endl; 
-    textStream << "   depth = 0;" << endl;
-    textStream << "   nitpick = createNitpick(Script.resolvePath(\".\"));" << endl;
-    textStream << "   testsRootPath = nitpick.getTestsRootPath();" << endl << endl;
-    textStream << "   nitpick.enableRecursive();" << endl;
-    textStream << "   nitpick.enableAuto();" << endl;
-    textStream << "} else {" << endl;
-    textStream << "   depth++" << endl;
-    textStream << "}" << endl << endl;
+    textStream << "if (typeof depth === 'undefined') {" << Qt::endl;
+    textStream << "   depth = 0;" << Qt::endl;
+    textStream << "   nitpick = createNitpick(Script.resolvePath(\".\"));" << Qt::endl;
+    textStream << "   testsRootPath = nitpick.getTestsRootPath();" << Qt::endl << Qt::endl;
+    textStream << "   nitpick.enableRecursive();" << Qt::endl;
+    textStream << "   nitpick.enableAuto();" << Qt::endl;
+    textStream << "} else {" << Qt::endl;
+    textStream << "   depth++" << Qt::endl;
+    textStream << "}" << Qt::endl << Qt::endl;
 
     // Now include the test scripts
     for (int i = 0; i < directories.length(); ++i) {
         includeTest(textStream, directories.at(i));
     }
 
-    textStream << endl;
-    textStream << "if (depth > 0) {" << endl;
-    textStream << "   depth--;" << endl;
-    textStream << "} else {" << endl;
-    textStream << "   nitpick.runRecursive();" << endl;
-    textStream << "}" << endl << endl;
+    textStream << Qt::endl;
+    textStream << "if (depth > 0) {" << Qt::endl;
+    textStream << "   depth--;" << Qt::endl;
+    textStream << "} else {" << Qt::endl;
+    textStream << "   nitpick.runRecursive();" << Qt::endl;
+    textStream << "}" << Qt::endl << Qt::endl;
 
     recursiveTestsFile.close();
 }

--- a/tools/skeleton-dump/src/SkeletonDumpApp.cpp
+++ b/tools/skeleton-dump/src/SkeletonDumpApp.cpp
@@ -29,7 +29,7 @@ SkeletonDumpApp::SkeletonDumpApp(int argc, char* argv[]) : QCoreApplication(argc
     parser.addOption(inputFilenameOption);
 
     if (!parser.parse(QCoreApplication::arguments())) {
-        qCritical() << parser.errorText() << endl;
+        qCritical() << parser.errorText() << Qt::endl;
         parser.showHelp();
         _returnCode = 1;
         return;

--- a/tools/vhacd-util/src/VHACDUtilApp.cpp
+++ b/tools/vhacd-util/src/VHACDUtilApp.cpp
@@ -188,7 +188,7 @@ VHACDUtilApp::VHACDUtilApp(int argc, char* argv[]) :
 
 
     if (!parser.parse(QCoreApplication::arguments())) {
-        qCritical() << parser.errorText() << endl;
+        qCritical() << parser.errorText() << Qt::endl;
         parser.showHelp();
         Q_UNREACHABLE();
     }


### PR DESCRIPTION
This fixes a whole bunch of these:

```
  In file included from /usr/include/qt5/QtCore/QTextStream:1,
                 from /home/dale/git/vircadia/vircadia-master/tools/nitpick/src/AWSInterface.h:18,
                 from /home/dale/git/vircadia/vircadia-master/tools/nitpick/src/TestCreator.h:21,
                 from /home/dale/git/vircadia/vircadia-master/tools/nitpick/src/TestCreator.cpp:10:
/usr/include/qt5/QtCore/qtextstream.h:293:75: note: declared here
  293 | Q_CORE_EXPORT QT_DEPRECATED_VERSION_X(5, 15, "Use Qt::endl") QTextStream &endl(QTextStream &s);
      |            ```
