### PR TITLE
Archive cmake logs, for debugging

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -25,6 +25,8 @@ env:
   # WIN32 specific variables
   PreferredToolArchitecture: X64
 
+  # Ensure XZ always runs with muticore support
+  XZ_OPT: -T0
 
 jobs:
   build:
@@ -140,6 +142,18 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DVCPKG_BUILD_TYPE=release $CMAKE_EXTRA
+    - name: Compress cmake logs
+      if: always()
+      shell: bash
+      run: |
+        find "$HOME/vircadia-files/vcpkg" -name '*log' -type f -print0 | tar --null --force-local -T - -c --xz -v -f "${{ runner.workspace }}/cmake-logs.tar.xz"
+    - name: Archive cmake logs
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: cmake-logs
+        path: ${{ runner.workspace }}/cmake-logs.tar.xz
+        if-no-files-found: error
     - name: Build Application
       if: matrix.build_type == 'full' || matrix.build_type == 'client'
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -146,7 +146,7 @@ jobs:
       if: always()
       shell: bash
       run: |
-        find "$HOME/vircadia-files/vcpkg" -name '*log' -type f -print0 | tar --null --force-local -T - -c --xz -v -f "${{ runner.workspace }}/cmake-logs.tar.xz"
+        find "$HOME/vircadia-files/vcpkg" -name '*log' -type f -print0 | gtar --null --force-local -T - -c --xz -v -f "${{ runner.workspace }}/cmake-logs.tar.xz"
     - name: Archive cmake logs
       if: always()
       uses: actions/upload-artifact@v2

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -146,7 +146,13 @@ jobs:
       if: always()
       shell: bash
       run: |
-        find "$HOME/vircadia-files/vcpkg" -name '*log' -type f -print0 | gtar --null --force-local -T - -c --xz -v -f "${{ runner.workspace }}/cmake-logs.tar.xz"
+        if [ "${{ matrix.os }}" == "macOS-latest" ]; then
+          TAR=gtar
+        else
+          TAR=tar
+        fi
+
+        find "$HOME/vircadia-files/vcpkg" -name '*log' -type f -print0 | $TAR --null --force-local -T - -c --xz -v -f "${{ runner.workspace }}/cmake-logs.tar.xz"
     - name: Archive cmake logs
       if: always()
       uses: actions/upload-artifact@v2

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -157,7 +157,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: cmake-logs
+        name: cmake-logs-${{ matrix.os }}-${{ github.event.number }}.tar.xz
         path: ${{ runner.workspace }}/cmake-logs-${{ matrix.os }}-${{ github.event.number }}.tar.xz
         if-no-files-found: error
     - name: Build Application

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -152,13 +152,13 @@ jobs:
           TAR=tar
         fi
 
-        find "$HOME/vircadia-files/vcpkg" -name '*log' -type f -print0 | $TAR --null --force-local -T - -c --xz -v -f "${{ runner.workspace }}/cmake-logs.tar.xz"
+        find "$HOME/vircadia-files/vcpkg" -name '*log' -type f -print0 | $TAR --null --force-local -T - -c --xz -v -f "${{ runner.workspace }}/cmake-logs-${{ matrix.os }}-${{ github.event.number }}.tar.xz"
     - name: Archive cmake logs
       if: always()
       uses: actions/upload-artifact@v2
       with:
         name: cmake-logs
-        path: ${{ runner.workspace }}/cmake-logs.tar.xz
+        path: ${{ runner.workspace }}/cmake-logs-${{ matrix.os }}-${{ github.event.number }}.tar.xz
         if-no-files-found: error
     - name: Build Application
       if: matrix.build_type == 'full' || matrix.build_type == 'client'


### PR DESCRIPTION
When CMake calls vcpkg, if something goes wrong in that part of the process, it points to a path with a log file.

On GHA this doesn't help much, as the log files aren't accessible. This PR creates an archive with everything that looks like a log under the vcpkg directory, so that it can be used for troubleshooting.

This should be particularly helpful for Mac OS builds, since not a lot of people have the hardware for it.