### PR TITLE
GitHub Actions do not clone submodules

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -101,8 +101,8 @@ jobs:
       working-directory: ${{runner.workspace}}
       run: rm -rf ./*
     - uses: actions/checkout@v1
-      with: 
-        submodules: true
+      with:
+        submodules: false
         fetch-depth: 1
     - name: Install dependencies
       if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -118,8 +118,8 @@ jobs:
       working-directory: ${{runner.workspace}}
       run: rm -rf ./*
     - uses: actions/checkout@v1
-      with: 
-        submodules: true
+      with:
+        submodules: false
         fetch-depth: 1
     - name: Install dependencies
       shell: bash


### PR DESCRIPTION
This PR disables cloning submodules in the GitHub Actions builds.
The vircadia-web submodule isn't used as far as I can tell and not only wastes resources but also makes it more annoying to test GitHub Actions in ones own repository.