### PR TITLE
Quiet Doxygen output

### DIFF
--- a/tools/doxygen/Doxyfile
+++ b/tools/doxygen/Doxyfile
@@ -794,7 +794,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES


### PR DESCRIPTION
Makes Doxygen output only warnings and errors - i.e., not all the files it's successfully processed.