### PR TITLE
Reduce stale-bot's aggressiveness.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,17 +1,16 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 120
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 60
+daysUntilClose: false
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
+  - confirmed
   - security
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
-  This issue has been automatically marked as stale because it has not had recent activity.
-  It will be closed if no further activity occurs.
-  Thank you for your contributions.
+  Hello! Is this still an issue?
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,12 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 120
+daysUntilStale: 180
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: false
-# Issues with these labels will never be considered stale
-exemptLabels:
-  - pinned
-  - confirmed
-  - security
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Stale bot will no longer close issues and the comment has been made more "human".

The days to stale has have been moved from 120 days to 180 days.