### PR TITLE
Fix "Ninja does not support toolset specification" on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ MESSAGE(STATUS "GLES_OPTION: ${GLES_OPTION}")
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/macros/TargetPython.cmake")
 target_python()
 
-if (WIN32 AND NOT HIFI_ANDROID)
+if (WIN32 AND NOT HIFI_ANDROID AND NOT (CMAKE_GENERATOR STREQUAL "Ninja"))
     # Force x64 toolset
     set(CMAKE_GENERATOR_TOOLSET "host=x64" CACHE STRING "64-bit toolset" FORCE)
 endif()


### PR DESCRIPTION
This fixes this:

```
1> [CMake] Writing cmake config to C:/Users/Builder/source/repos/vircadia/out/build/x64-Debug\vcpkg.cmake
1> [CMake] -- C:/Users/Builder/source/repos/vircadia/out/build/x64-Debug/qt.cmake included!
1> [CMake] CMake Error at C:\Users\Builder\Source\Repos\vircadia\CMakeLists.txt:121 (project):
1> [CMake]   Generator
1> [CMake] 
1> [CMake]     Ninja
1> [CMake] 
1> [CMake]   does not support toolset specification, but toolset
1> [CMake] 
1> [CMake]     host=x64
1> [CMake] 
1> [CMake]   was specified.
1> [CMake] 
1> [CMake] 
1> [CMake] -- Configuring incomplete, errors occurred!
```

It happens when trying to build by using VS Community's internal cmake support. It's Windows specific because the toolset setting happens within a Windows-specific branch.

This doesn't fix every problem with Ninja, so after this it still won't build with it. But it's a start.
