### PR TITLE
Replace deprecated QAbstractsocket::error with QAbstractSocket::error…

### DIFF
--- a/libraries/embedded-webserver/src/HTTPConnection.cpp
+++ b/libraries/embedded-webserver/src/HTTPConnection.cpp
@@ -124,9 +124,9 @@ HTTPConnection::HTTPConnection(QTcpSocket* socket, HTTPManager* parentManager) :
     _socket->setParent(this);
 
     // connect initial slots
-    connect(socket, SIGNAL(readyRead()), SLOT(readRequest()));
-    connect(socket, SIGNAL(error(QAbstractSocket::SocketError)), SLOT(deleteLater()));
-    connect(socket, SIGNAL(disconnected()), SLOT(deleteLater()));
+    connect(socket, &QAbstractSocket::readyRead, this, &HTTPConnection::readRequest);
+    connect(socket, &QAbstractSocket::errorOccurred, this, &HTTPConnection::deleteLater);
+    connect(socket, &QAbstractSocket::disconnected, this, &HTTPConnection::deleteLater);
 }
 
 HTTPConnection::~HTTPConnection() {

--- a/libraries/networking/src/LimitedNodeList.cpp
+++ b/libraries/networking/src/LimitedNodeList.cpp
@@ -1224,8 +1224,7 @@ void LimitedNodeList::updateLocalSocket() {
     QTcpSocket* localIPTestSocket = new QTcpSocket;
 
     connect(localIPTestSocket, &QTcpSocket::connected, this, &LimitedNodeList::connectedForLocalSocketTest);
-    connect(localIPTestSocket, static_cast<void(QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::error),
-        this, &LimitedNodeList::errorTestingLocalSocket);
+    connect(localIPTestSocket, &QTcpSocket::errorOccurred, this, &LimitedNodeList::errorTestingLocalSocket);
 
     // attempt to connect to our reliable host
     localIPTestSocket->connectToHost(RELIABLE_LOCAL_IP_CHECK_HOST, RELIABLE_LOCAL_IP_CHECK_PORT);


### PR DESCRIPTION
Fixes:

```
‘void QAbstractSocket::error(QAbstractSocket::SocketError)’ is deprecated: Use QAbstractSocket::errorOccurred(QAbstractSocket::SocketError) instead [-Wdeprecated-declarations]
```