### PR TITLE
Copy resources to interface's exe directory

### DIFF
--- a/interface/CMakeLists.txt
+++ b/interface/CMakeLists.txt
@@ -394,6 +394,9 @@ else()
     COMMAND "${CMAKE_COMMAND}" -E copy_if_different
       "${PROJECT_SOURCE_DIR}/resources/serverless/redirect.json"
       "${RESOURCES_DEV_DIR}/serverless/redirect.json"
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+      "${RESOURCES_RCC}"
+      "${INTERFACE_EXEC_DIR}/resources.rcc"
   )
 
   if (JSDOC_ENABLED)


### PR DESCRIPTION
This should have no effect on Unix, but fix the resource issue on Win32.

This fixes #1308 