### PR TITLE
make HUD bubble/shield button optional

### DIFF
--- a/scripts/system/bubble.js
+++ b/scripts/system/bubble.js
@@ -47,7 +47,7 @@
     }
 
     //create a menu item in "Setings" to toggle the bubble/shield HUD button 
-    var menuItemName = "HUD shield button";
+    var menuItemName = "HUD Shield Button";
     Menu.addMenuItem({
         menuName: "Settings",
         menuItemName: menuItemName,

--- a/scripts/system/bubble.js
+++ b/scripts/system/bubble.js
@@ -58,8 +58,8 @@
     AvatarInputs.showBubbleToolsChanged.connect(showBubbleToolsChanged);
 
     function onToggleHudShieldButton(menuItem) {
-        if (menuItem == menuItemName) {
-            AvatarInputs.setShowBubbleTools(Menu.isOptionChecked(menuItem))
+        if (menuItem === menuItemName) {
+            AvatarInputs.setShowBubbleTools(Menu.isOptionChecked(menuItem));
         };
     }
 

--- a/scripts/system/bubble.js
+++ b/scripts/system/bubble.js
@@ -46,6 +46,27 @@
         });
     }
 
+    //create a menu item in "Setings" to toggle the bubble/shield HUD button 
+    var menuItemName = "HUD shield button";
+    Menu.addMenuItem({
+        menuName: "Settings",
+        menuItemName: menuItemName,
+        isCheckable: true,
+        isChecked: AvatarInputs.showBubbleTools
+    });
+    Menu.menuItemEvent.connect(onToggleHudShieldButton);
+    AvatarInputs.showBubbleToolsChanged.connect(showBubbleToolsChanged);
+
+    function onToggleHudShieldButton(menuItem) {
+        if (menuItem == menuItemName) {
+            AvatarInputs.setShowBubbleTools(Menu.isOptionChecked(menuItem))
+        };
+    }
+
+    function showBubbleToolsChanged(show) {
+        Menu.setIsOptionChecked(menuItemName, show);
+    }
+
     // Make the bubble overlay visible, set its position, and play the sound
     function createOverlays() {
         var nowTimestamp = Date.now();
@@ -191,6 +212,9 @@
 
     // Cleanup the tablet button and overlays when script is stopped
     Script.scriptEnding.connect(function () {
+        Menu.menuItemEvent.disconnect(onToggleHudShieldButton);
+        AvatarInputs.showBubbleToolsChanged.disconnect(showBubbleToolsChanged);
+        Menu.removeMenuItem("Settings", menuItemName);
         button.clicked.disconnect(Users.toggleIgnoreRadius);
         if (tablet) {
             tablet.removeButton(button);


### PR DESCRIPTION
Adds an menu item in "Settings" to toggle the HUD shield/bubble button on or off.
Shield button remains available in the tablet or toolbar, it is called "HUD shield button" but suggestions are welcome

fixes https://github.com/vircadia/vircadia/issues/1210 but makes it optional.