### PR TITLE
Create app - "Reset Rotation" button

### DIFF
--- a/scripts/system/create/edit.js
+++ b/scripts/system/create/edit.js
@@ -2656,6 +2656,24 @@ var PropertiesTool = function (opts) {
                 } else {
                     audioFeedback.rejection();
                 }
+            } else if (data.action === "setRotationToZero") {
+                if (selectionManager.selections.length === 1 && SelectionManager.hasUnlockedSelection()) {
+                    selectionManager.saveProperties();
+                    var parentState = getParentState(selectionManager.selections[0]);
+                    if ((parentState === "PARENT_CHILDREN" || parentState === "CHILDREN") && selectionDisplay.getSpaceMode() === "local" ) {
+                        Entities.editEntity(selectionManager.selections[0], {
+                            localRotation: Quat.IDENTITY
+                        });                    
+                    } else {
+                        Entities.editEntity(selectionManager.selections[0], {
+                            rotation: Quat.IDENTITY
+                        });
+                    }
+                    pushCommandForSelections();
+                    selectionManager._update(false, this);
+                } else {
+                    audioFeedback.rejection();
+                }
             }
         } else if (data.type === "propertiesPageReady") {
             updateSelections(true);

--- a/scripts/system/create/entityProperties/html/js/entityProperties.js
+++ b/scripts/system/create/entityProperties/html/js/entityProperties.js
@@ -1384,7 +1384,7 @@ const GROUPS = [
                 type: "buttons",
                 buttons: [  { id: "copyRotation", label: "Copy Rotation", className: "secondary", onClick: copyRotationProperty },
                             { id: "pasteRotation", label: "Paste Rotation", className: "secondary", onClick: pasteRotationProperty },
-                            { id: "setRotationToZero", label: "Set Rotation to Zero", className: "secondary_red", onClick: setRotationToZeroProperty }],
+                            { id: "setRotationToZero", label: "Reset Rotation", className: "secondary_red", onClick: setRotationToZeroProperty }],
                 propertyID: "copyPasteRotation"
             },          
             {

--- a/scripts/system/create/entityProperties/html/js/entityProperties.js
+++ b/scripts/system/create/entityProperties/html/js/entityProperties.js
@@ -1383,7 +1383,8 @@ const GROUPS = [
             {
                 type: "buttons",
                 buttons: [  { id: "copyRotation", label: "Copy Rotation", className: "secondary", onClick: copyRotationProperty },
-                            { id: "pasteRotation", label: "Paste Rotation", className: "secondary", onClick: pasteRotationProperty } ],
+                            { id: "pasteRotation", label: "Paste Rotation", className: "secondary", onClick: pasteRotationProperty },
+                            { id: "setRotationToZero", label: "Set Rotation to Zero", className: "secondary_red", onClick: setRotationToZeroProperty }],
                 propertyID: "copyPasteRotation"
             },          
             {
@@ -1874,10 +1875,16 @@ function setCopyPastePositionAndRotationAvailability (selectionLength, islocked)
     
     if (selectionLength > 0 && !islocked) {
         $('#property-copyPastePosition-button-pastePosition').attr('disabled', false);
-        $('#property-copyPasteRotation-button-pasteRotation').attr('disabled', false);           
+        $('#property-copyPasteRotation-button-pasteRotation').attr('disabled', false);
+        if (selectionLength === 1) {
+            $('#property-copyPasteRotation-button-setRotationToZero').attr('disabled', false);
+        } else {
+            $('#property-copyPasteRotation-button-setRotationToZero').attr('disabled', true);
+        }
     } else {
         $('#property-copyPastePosition-button-pastePosition').attr('disabled', true);
-        $('#property-copyPasteRotation-button-pasteRotation').attr('disabled', true);            
+        $('#property-copyPasteRotation-button-pasteRotation').attr('disabled', true);
+        $('#property-copyPasteRotation-button-setRotationToZero').attr('disabled', true);
     }
 }
 
@@ -3273,7 +3280,12 @@ function pasteRotationProperty() {
         action: "pasteRotation"
     }));    
 }
-
+function setRotationToZeroProperty() {
+    EventBridge.emitWebEvent(JSON.stringify({
+        type: "action",
+        action: "setRotationToZero"
+    }));    
+}
 /**
  * USER DATA FUNCTIONS
  */

--- a/scripts/system/create/entityProperties/html/js/entityProperties.js
+++ b/scripts/system/create/entityProperties/html/js/entityProperties.js
@@ -1384,7 +1384,7 @@ const GROUPS = [
                 type: "buttons",
                 buttons: [  { id: "copyRotation", label: "Copy Rotation", className: "secondary", onClick: copyRotationProperty },
                             { id: "pasteRotation", label: "Paste Rotation", className: "secondary", onClick: pasteRotationProperty },
-                            { id: "setRotationToZero", label: "Reset Rotation", className: "secondary_red", onClick: setRotationToZeroProperty }],
+                            { id: "setRotationToZero", label: "Reset Rotation", className: "secondary_red red", onClick: setRotationToZeroProperty }],
                 propertyID: "copyPasteRotation"
             },          
             {

--- a/scripts/system/html/css/edit-style.css
+++ b/scripts/system/html/css/edit-style.css
@@ -479,7 +479,22 @@ input[type=button].secondary, button.hifi-edit-button.secondary {
     background: linear-gradient(#343434 20%, #000 100%);
     cursor: pointer;
 }
-
+input[type=button].secondary_red, button.hifi-edit-button.secondary_red {
+    font-family: Raleway-Bold;
+    font-size: 10px;
+    text-transform: uppercase;
+    vertical-align: top;
+    height: 18px;
+    min-width: 60px;
+    padding: 0 14px;
+    margin-right: 6px;
+    border-radius: 4px;
+    border: none;
+    color: #fff;
+    background-color: #94132e;
+    background: linear-gradient(#d42043 20%, #94132e 100%);
+    cursor: pointer;
+}
 input[type=button]:enabled:hover, button.hifi-edit-button:enabled:hover {
     background: linear-gradient(#000, #000);
     border: none;


### PR DESCRIPTION
This PR add a "Reset Rotation" to the properties tab
![image](https://user-images.githubusercontent.com/60075796/130000517-a10e8824-a44b-4339-8659-077393f19960.png)

By clicking on the button, the "rotation" or "localRotation" get reset to (0,0,0).
If the entity doesn't have a parent, it will reset the rotation.
If the entity have a parent, it will reset the "localRotation" if the mode is "Local" or the "rotation" if the mode is "World".
The button is only effective for a single selection, as the "Copy Rotation" and "Paste Rotation" buttons are.

-----

I hesitated to pull this code, thinking that it is a bit over-design. But since I find my-self starting to use it, then I think it can be useful to some people.
I will let you decide about the fate of this pull request. Personally, I will be fine with or without it.
