### PR TITLE
Fix avatar crash

### DIFF
--- a/libraries/physics/src/MultiSphereShape.cpp
+++ b/libraries/physics/src/MultiSphereShape.cpp
@@ -487,9 +487,6 @@ void MultiSphereShape::calculateDebugLines() {
                 }
             }
         }
-        if (radiuses.size() == 0) {
-            radiuses.push_back(0.0f);
-        }
         calculateChamferBox(_debugLines, radiuses, axes, _midPoint);
     } else if (_spheres.size() == 8) {
         std::vector<glm::vec3> axes;
@@ -512,6 +509,11 @@ void MultiSphereShape::connectEdges(std::vector<std::pair<glm::vec3, glm::vec3>>
 
 void MultiSphereShape::calculateChamferBox(std::vector<std::pair<glm::vec3, glm::vec3>>& outLines, const std::vector<float>& radiuses, const std::vector<glm::vec3>& axes, const glm::vec3& translation) {
     std::vector<std::pair<glm::vec3, glm::vec3>> sphereLines;
+
+    if (radiuses.size() == 0) {
+        return;
+    }
+
     calculateSphereLines(sphereLines, glm::vec3(0.0f), radiuses[0]);
 
     std::vector<SphereRegion> regions = {

--- a/libraries/physics/src/MultiSphereShape.cpp
+++ b/libraries/physics/src/MultiSphereShape.cpp
@@ -486,7 +486,10 @@ void MultiSphereShape::calculateDebugLines() {
                     break;
                 }
             }
-        }        
+        }
+        if (radiuses.size() == 0) {
+            radiuses.push_back(0.0f);
+        }
         calculateChamferBox(_debugLines, radiuses, axes, _midPoint);
     } else if (_spheres.size() == 8) {
         std::vector<glm::vec3> axes;

--- a/libraries/physics/src/MultiSphereShape.cpp
+++ b/libraries/physics/src/MultiSphereShape.cpp
@@ -508,12 +508,11 @@ void MultiSphereShape::connectEdges(std::vector<std::pair<glm::vec3, glm::vec3>>
 }
 
 void MultiSphereShape::calculateChamferBox(std::vector<std::pair<glm::vec3, glm::vec3>>& outLines, const std::vector<float>& radiuses, const std::vector<glm::vec3>& axes, const glm::vec3& translation) {
-    std::vector<std::pair<glm::vec3, glm::vec3>> sphereLines;
-
     if (radiuses.size() == 0) {
         return;
     }
 
+    std::vector<std::pair<glm::vec3, glm::vec3>> sphereLines;
     calculateSphereLines(sphereLines, glm::vec3(0.0f), radiuses[0]);
 
     std::vector<SphereRegion> regions = {


### PR DESCRIPTION
Some avatar geometries trigger this crash:
```
Exception thrown: read access violation.
**radius** was nullptr.

>	interface.exe!MultiSphereShape::calculateSphereLines(std::vector<std::pair<glm::vec<3,float,0>,glm::vec<3,float,0>>,std::allocator<std::pair<glm::vec<3,float,0>,glm::vec<3,float,0>>>> & outLines, const glm::vec<3,float,0> & center, const float & radius, const int & subdivisions, const glm::vec<3,float,0> & direction, const float & percentage, std::vector<glm::vec<3,float,0>,std::allocator<glm::vec<3,float,0>>> * edge) Line 593	C++
 	interface.exe!MultiSphereShape::calculateChamferBox(std::vector<std::pair<glm::vec<3,float,0>,glm::vec<3,float,0>>,std::allocator<std::pair<glm::vec<3,float,0>,glm::vec<3,float,0>>>> & outLines, const std::vector<float,std::allocator<float>> & radiuses, const std::vector<glm::vec<3,float,0>,std::allocator<glm::vec<3,float,0>>> & axes, const glm::vec<3,float,0> & translation) Line 515	C++
 	interface.exe!MultiSphereShape::calculateDebugLines() Line 493	C++
 	interface.exe!Avatar::computeMultiSphereShapes() Line 1614	C++
 	interface.exe!Avatar::rigReady() Line 1580	C++
 	[External Code]	
 	interface.exe!Model::updateGeometry() Line 313	C++
 	interface.exe!CauterizedModel::updateGeometry() Line 32	C++
 	interface.exe!Model::simulate(float deltaTime, bool fullUpdate) Line 1450	C++
 	interface.exe!SkeletonModel::simulate(float deltaTime, bool fullUpdate) Line 160	C++
 	interface.exe!MyAvatar::simulate(float deltaTime, bool inView) Line 952	C++
 	interface.exe!MyAvatar::update(float deltaTime) Line 800	C++
 	interface.exe!AvatarManager::updateMyAvatar(float deltaTime) Line 167	C++
 	interface.exe!Application::update(float deltaTime) Line 6730	C++
 	interface.exe!Application::idle() Line 5375	C++
 	interface.exe!Application::event(QEvent * event) Line 4323	C++
 	[External Code]	
 	interface.exe!Application::notify(QObject * object, QEvent * event) Line 4280	C++
 	[External Code]	
 	interface.exe!main(int argc, const char * * argv) Line 448	C++
 	interface.exe!WinMain(HINSTANCE__ * __formal, HINSTANCE__ * __formal, char * __formal, int __formal) Line 97	C++
 	[External Code]	
```
Aitolda encounteered this recently. Appears to be the same crash as in the following issues:
- https://github.com/vircadia/vircadia/issues/893
- https://github.com/vircadia/vircadia/issues/859

QA should include checking avatar debug rendering.