### PR TITLE
Assignment client protocol communications over WebRTC

### DIFF
--- a/domain-server/src/NodeConnectionData.cpp
+++ b/domain-server/src/NodeConnectionData.cpp
@@ -59,10 +59,6 @@ NodeConnectionData NodeConnectionData::fromDataStream(QDataStream& dataStream, c
     // needed: for WebRTC, the data channel ID is the important thing. The client's public Internet IP address still needs to
     // be known for domain access permissions, though, and this can be obtained from the WebSocket signaling connection.
     if (senderSockAddr.getSocketType() == SocketType::WebRTC) {
-        // WEBRTC TODO: Rather than setting the SocketType here, serialize and deserialize the SocketType in the leading byte of
-        // the 5 bytes used to encode the IP address.
-        newHeader.publicSockAddr.setSocketType(SocketType::WebRTC);
-        newHeader.localSockAddr.setSocketType(SocketType::WebRTC);
 
         // WEBRTC TODO: Set the public Internet address obtained from the WebSocket used in WebRTC signaling.
 

--- a/libraries/networking/src/SockAddr.cpp
+++ b/libraries/networking/src/SockAddr.cpp
@@ -135,21 +135,12 @@ QDebug operator<<(QDebug debug, const SockAddr& sockAddr) {
 }
 
 QDataStream& operator<<(QDataStream& dataStream, const SockAddr& sockAddr) {
-    // Don't include socketType because it can be implied from the type of connection used.
-    // WEBRTC TODO: Reconsider this.
-    dataStream << sockAddr._address << sockAddr._port;
+    dataStream << sockAddr._socketType << sockAddr._address << sockAddr._port;
     return dataStream;
 }
 
 QDataStream& operator>>(QDataStream& dataStream, SockAddr& sockAddr) {
-    // Don't include socketType because it can be implied from the type of connection used.
-    // WEBRTC TODO: Reconsider this.
-    dataStream >> sockAddr._address >> sockAddr._port;
-
-    // Set default for non-WebRTC code.
-    // WEBRTC TODO: Reconsider this.
-    sockAddr.setSocketType(SocketType::UDP);
-
+    dataStream >> sockAddr._socketType >> sockAddr._address >> sockAddr._port;
     return dataStream;
 }
 

--- a/libraries/networking/src/SocketType.h
+++ b/libraries/networking/src/SocketType.h
@@ -19,7 +19,7 @@
 
 
 /// @brief The types of network socket.
-enum class SocketType {
+enum class SocketType : uint8_t {
     Unknown,    ///< Unknown socket type.
     UDP,        ///< UDP socket.
     WebRTC      ///< WebRTC socket. A WebRTC data channel presented as a UDP-style socket.

--- a/libraries/networking/src/webrtc/WebRTCDataChannels.cpp
+++ b/libraries/networking/src/webrtc/WebRTCDataChannels.cpp
@@ -513,7 +513,7 @@ bool WebRTCDataChannels::sendDataMessage(int dataChannelID, const QByteArray& by
 
     // Find connection.
     if (!_connectionsByDataChannel.contains(dataChannelID)) {
-        qCWarning(networking_webrtc) << "Could not find data channel to send message on!";
+        qCWarning(networking_webrtc) << "Could not find WebRTC data channel to send message on!";
         return false;
     }
 
@@ -524,8 +524,14 @@ bool WebRTCDataChannels::sendDataMessage(int dataChannelID, const QByteArray& by
 
 /// @brief Gets the number of bytes waiting to be written on a data channel.
 /// @param port The data channel ID.
-/// @return The number of bytes waiting to be written on the data channel.
+/// @return The number of bytes waiting to be written on the data channel; 0 if the channel doesn't exist.
 qint64 WebRTCDataChannels::getBufferedAmount(int dataChannelID) const {
+    if (!_connectionsByDataChannel.contains(dataChannelID)) {
+#ifdef WEBRTC_DEBUG
+        qCDebug(networking_webrtc) << "WebRTCDataChannels::getBufferedAmount() : Channel doesn't exist:" << dataChannelID;
+#endif
+        return 0;
+    }
     auto connection = _connectionsByDataChannel.value(dataChannelID);
     return connection->getBufferedAmount();
 }


### PR DESCRIPTION
Wires up assignment clients to associate WebRTC connections with domain users.

Also:
- Uses client's WebSocket IP address and port as WebRTC connection's IP address and port, and as means to identify WebRTC data channel instead of an internally-assigned numeric ID.

This PR builds on top of PR: https://github.com/vircadia/vircadia/pull/1329