### PR TITLE
Assignment client protocol communications over WebRTC

### DIFF
--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -891,16 +891,7 @@ void DomainServer::routeWebRTCSignalingMessage(const QJsonObject& json) {
     if (json.value("to").toString() == NodeType::DomainServer) {
         emit webrtcSignalingMessageForDomainServer(json);
     } else {
-        // Insert the WebRTC data channel ID for the assignment client to use.
-        auto webrtcSocket = DependencyManager::get<LimitedNodeList>()->getWebRTCSocket();
-        auto channelID = webrtcSocket->getDataChannelIDForWebSocket((quint16)json.value("from").toInt());
-        if (channelID == 0 && json.value("echo").isUndefined()) {  // Let echo messages through without a domain connection.
-            qCritical() << "WebRTC data channel ID not found for assignment client signaling!";
-            return;
-        }
-        QJsonObject jsonModified = json;
-        jsonModified.insert("channel", QJsonValue(channelID));
-        sendWebRTCSignalingMessageToAssignmentClient(jsonModified);
+        sendWebRTCSignalingMessageToAssignmentClient(json);
     }
 }
 

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -891,7 +891,16 @@ void DomainServer::routeWebRTCSignalingMessage(const QJsonObject& json) {
     if (json.value("to").toString() == NodeType::DomainServer) {
         emit webrtcSignalingMessageForDomainServer(json);
     } else {
-        sendWebRTCSignalingMessageToAssignmentClient(json);
+        // Insert the WebRTC data channel ID for the assignment client to use.
+        auto webrtcSocket = DependencyManager::get<LimitedNodeList>()->getWebRTCSocket();
+        auto channelID = webrtcSocket->getDataChannelIDForWebSocket((quint16)json.value("from").toInt());
+        if (channelID == 0 && json.value("echo").isUndefined()) {  // Let echo messages through without a domain connection.
+            qCritical() << "WebRTC data channel ID not found for assignment client signaling!";
+            return;
+        }
+        QJsonObject jsonModified = json;
+        jsonModified.insert("channel", QJsonValue(channelID));
+        sendWebRTCSignalingMessageToAssignmentClient(jsonModified);
     }
 }
 

--- a/domain-server/src/NodeConnectionData.cpp
+++ b/domain-server/src/NodeConnectionData.cpp
@@ -51,20 +51,20 @@ NodeConnectionData NodeConnectionData::fromDataStream(QDataStream& dataStream, c
 
     dataStream >> newHeader.lastPingTimestamp;
     
+    SocketType publicSocketType, localSocketType;
     dataStream >> newHeader.nodeType
-        >> newHeader.publicSockAddr >> newHeader.localSockAddr
+        >> publicSocketType >> newHeader.publicSockAddr >> localSocketType >> newHeader.localSockAddr
         >> newHeader.interestList >> newHeader.placeName;
+    newHeader.publicSockAddr.setType(publicSocketType);
+    newHeader.localSockAddr.setType(localSocketType);
 
-    // A WebRTC web client doesn't necessarily know it's public Internet or local network addresses, and for WebRTC they aren't
-    // needed: for WebRTC, the data channel ID is the important thing. The client's public Internet IP address still needs to
-    // be known for domain access permissions, though, and this can be obtained from the WebSocket signaling connection.
-    if (senderSockAddr.getSocketType() == SocketType::WebRTC) {
-        // WEBRTC TODO: Rather than setting the SocketType here, serialize and deserialize the SocketType in the leading byte of
-        // the 5 bytes used to encode the IP address.
-        newHeader.publicSockAddr.setSocketType(SocketType::WebRTC);
-        newHeader.localSockAddr.setSocketType(SocketType::WebRTC);
-
-        // WEBRTC TODO: Set the public Internet address obtained from the WebSocket used in WebRTC signaling.
+    // For WebRTC connections, the user client doesn't know the WebRTC data channel ID that the domain server is using as its
+    // SockAddr port, so set the port values here.
+    if (senderSockAddr.getType() == SocketType::WebRTC) {
+        if (newHeader.publicSockAddr.getType() != SocketType::WebRTC
+            || newHeader.localSockAddr.getType() != SocketType::WebRTC) {
+            qDebug() << "Inconsistent WebRTC socket types!";
+        }
 
         newHeader.publicSockAddr.setPort(senderSockAddr.getPort());  // We don't know whether it's a public or local connection
         newHeader.localSockAddr.setPort(senderSockAddr.getPort());   // so set both ports.

--- a/domain-server/src/NodeConnectionData.cpp
+++ b/domain-server/src/NodeConnectionData.cpp
@@ -17,7 +17,7 @@
 NodeConnectionData NodeConnectionData::fromDataStream(QDataStream& dataStream, const SockAddr& senderSockAddr,
                                                       bool isConnectRequest) {
     NodeConnectionData newHeader;
-    
+
     if (isConnectRequest) {
         dataStream >> newHeader.connectUUID;
 
@@ -58,16 +58,21 @@ NodeConnectionData NodeConnectionData::fromDataStream(QDataStream& dataStream, c
     newHeader.publicSockAddr.setType(publicSocketType);
     newHeader.localSockAddr.setType(localSocketType);
 
-    // For WebRTC connections, the user client doesn't know the WebRTC data channel ID that the domain server is using as its
-    // SockAddr port, so set the port values here.
+    // For WebRTC connections, the user client's signaling channel WebSocket address is used instead of the actual data 
+    // channel's address.
     if (senderSockAddr.getType() == SocketType::WebRTC) {
         if (newHeader.publicSockAddr.getType() != SocketType::WebRTC
             || newHeader.localSockAddr.getType() != SocketType::WebRTC) {
             qDebug() << "Inconsistent WebRTC socket types!";
         }
 
-        newHeader.publicSockAddr.setPort(senderSockAddr.getPort());  // We don't know whether it's a public or local connection
-        newHeader.localSockAddr.setPort(senderSockAddr.getPort());   // so set both ports.
+        // We don't know whether it's a public or local connection so set both the same.
+        auto address = senderSockAddr.getAddress();
+        auto port = senderSockAddr.getPort();
+        newHeader.publicSockAddr.setAddress(address);
+        newHeader.publicSockAddr.setPort(port);
+        newHeader.localSockAddr.setAddress(address);
+        newHeader.localSockAddr.setPort(port);
     }
 
     newHeader.senderSockAddr = senderSockAddr;

--- a/libraries/networking/src/Node.cpp
+++ b/libraries/networking/src/Node.cpp
@@ -196,7 +196,9 @@ bool Node::isIgnoringNodeWithID(const QUuid& nodeID) const {
 QDataStream& operator<<(QDataStream& out, const Node& node) {
     out << node._type;
     out << node._uuid;
+    out << node._publicSocket.getType();
     out << node._publicSocket;
+    out << node._localSocket.getType();
     out << node._localSocket;
     out << node._permissions;
     out << node._isReplicated;
@@ -205,10 +207,15 @@ QDataStream& operator<<(QDataStream& out, const Node& node) {
 }
 
 QDataStream& operator>>(QDataStream& in, Node& node) {
+    SocketType publicSocketType, localSocketType;
     in >> node._type;
     in >> node._uuid;
+    in >> publicSocketType;
     in >> node._publicSocket;
+    node._publicSocket.setType(publicSocketType);
+    in >> localSocketType;
     in >> node._localSocket;
+    node._localSocket.setType(localSocketType);
     in >> node._permissions;
     in >> node._isReplicated;
     in >> node._localID;

--- a/libraries/networking/src/NodeList.cpp
+++ b/libraries/networking/src/NodeList.cpp
@@ -470,10 +470,12 @@ void NodeList::sendDomainServerCheckIn() {
             QByteArray compressedSystemInfo = qCompress(systemInfo);
 
             if (compressedSystemInfo.size() > MAX_SYSTEM_INFO_SIZE) {
+                // FIXME
                 // Highly unlikely, as not even unreasonable machines will
                 // overflow the max size, but prevent MTU overflow anyway.
                 // We could do something sophisticated like clearing specific
                 // values if they're too big, but we'll save that for later.
+                // Alternative solution would be to write system info at the end of the packet, only if there is space.
                 compressedSystemInfo.clear();
             }
 

--- a/libraries/networking/src/SockAddr.cpp
+++ b/libraries/networking/src/SockAddr.cpp
@@ -137,21 +137,14 @@ QDebug operator<<(QDebug debug, const SockAddr& sockAddr) {
 }
 
 QDataStream& operator<<(QDataStream& dataStream, const SockAddr& sockAddr) {
-    // Don't include socketType because it can be implied from the type of connection used.
-    // WEBRTC TODO: Reconsider this.
+    // Don't include socket type because ICE packets must not have it.
     dataStream << sockAddr._address << sockAddr._port;
     return dataStream;
 }
 
 QDataStream& operator>>(QDataStream& dataStream, SockAddr& sockAddr) {
-    // Don't include socketType because it can be implied from the type of connection used.
-    // WEBRTC TODO: Reconsider this.
+    // Don't include socket type because ICE packets must not have it.
     dataStream >> sockAddr._address >> sockAddr._port;
-
-    // Set default for non-WebRTC code.
-    // WEBRTC TODO: Reconsider this.
-    sockAddr.setSocketType(SocketType::UDP);
-
     return dataStream;
 }
 

--- a/libraries/networking/src/SockAddr.cpp
+++ b/libraries/networking/src/SockAddr.cpp
@@ -116,6 +116,10 @@ QString SockAddr::toString() const {
     return socketTypeToString(_socketType) + " " + _address.toString() + ":" + QString::number(_port);
 }
 
+QString SockAddr::toShortString() const {
+    return _address.toString() + ":" + QString::number(_port);
+}
+
 bool SockAddr::hasPrivateAddress() const {
     // an address is private if it is loopback or falls in any of the RFC1918 address spaces
     const QPair<QHostAddress, int> TWENTY_FOUR_BIT_BLOCK = { QHostAddress("10.0.0.0"), 8 };

--- a/libraries/networking/src/SockAddr.cpp
+++ b/libraries/networking/src/SockAddr.cpp
@@ -129,7 +129,9 @@ bool SockAddr::hasPrivateAddress() const {
 }
 
 QDebug operator<<(QDebug debug, const SockAddr& sockAddr) {
-    debug.nospace() << socketTypeToString(sockAddr._socketType).toLocal8Bit().constData() << " " 
+    debug.nospace() 
+        << (sockAddr._socketType != SocketType::Unknown 
+            ? (socketTypeToString(sockAddr._socketType) + " ").toLocal8Bit().constData() : "")
         << sockAddr._address.toString().toLocal8Bit().constData() << ":" << sockAddr._port;
     return debug.space();
 }

--- a/libraries/networking/src/SockAddr.h
+++ b/libraries/networking/src/SockAddr.h
@@ -40,9 +40,9 @@ public:
     bool operator==(const SockAddr& rhsSockAddr) const;
     bool operator!=(const SockAddr& rhsSockAddr) const { return !(*this == rhsSockAddr); }
 
-    SocketType getSocketType() const { return _socketType; }
+    SocketType getType() const { return _socketType; }
     SocketType* getSocketTypePointer() { return &_socketType; }
-    void setSocketType(const SocketType socketType) { _socketType = socketType; }
+    void setType(const SocketType socketType) { _socketType = socketType; }
 
     const QHostAddress& getAddress() const { return _address; }
     QHostAddress* getAddressPointer() { return &_address; }

--- a/libraries/networking/src/SockAddr.h
+++ b/libraries/networking/src/SockAddr.h
@@ -56,6 +56,7 @@ public:
     static int unpackSockAddr(const unsigned char* packetData, SockAddr& unpackDestSockAddr);
 
     QString toString() const;
+    QString toShortString() const;
 
     bool hasPrivateAddress() const; // checks if the address behind this sock addr is private per RFC 1918
 

--- a/libraries/networking/src/SocketType.h
+++ b/libraries/networking/src/SocketType.h
@@ -19,8 +19,8 @@
 
 
 /// @brief The types of network socket.
-enum class SocketType {
-    Unknown,    ///< Unknown socket type.
+enum class SocketType : uint8_t {
+    Unknown,    ///< Socket type unknown or not set.
     UDP,        ///< UDP socket.
     WebRTC      ///< WebRTC socket. A WebRTC data channel presented as a UDP-style socket.
 };

--- a/libraries/networking/src/udt/NetworkSocket.cpp
+++ b/libraries/networking/src/udt/NetworkSocket.cpp
@@ -133,7 +133,7 @@ qint64 NetworkSocket::writeDatagram(const QByteArray& datagram, const SockAddr& 
         return _udpSocket.writeDatagram(datagram, sockAddr.getAddress(), sockAddr.getPort());
 #if defined(WEBRTC_DATA_CHANNELS)
     case SocketType::WebRTC:
-        return _webrtcSocket.writeDatagram(datagram, sockAddr.getPort());
+        return _webrtcSocket.writeDatagram(datagram, sockAddr);
 #endif
     default:
         qCCritical(networking) << "Socket type not specified in writeDatagram() address";
@@ -141,13 +141,13 @@ qint64 NetworkSocket::writeDatagram(const QByteArray& datagram, const SockAddr& 
     }
 }
 
-qint64 NetworkSocket::bytesToWrite(SocketType socketType, quint16 port) const {
+qint64 NetworkSocket::bytesToWrite(SocketType socketType, const SockAddr& address) const {
     switch (socketType) {
     case SocketType::UDP:
         return _udpSocket.bytesToWrite();
 #if defined(WEBRTC_DATA_CHANNELS)
     case SocketType::WebRTC:
-        return _webrtcSocket.bytesToWrite(port);
+        return _webrtcSocket.bytesToWrite(address);
 #endif
     default:
         qCCritical(networking) << "Socket type not specified in bytesToWrite()";

--- a/libraries/networking/src/udt/NetworkSocket.cpp
+++ b/libraries/networking/src/udt/NetworkSocket.cpp
@@ -126,7 +126,7 @@ qintptr NetworkSocket::socketDescriptor(SocketType socketType) const {
 
 
 qint64 NetworkSocket::writeDatagram(const QByteArray& datagram, const SockAddr& sockAddr) {
-    switch (sockAddr.getSocketType()) {
+    switch (sockAddr.getType()) {
     case SocketType::UDP:
         // WEBRTC TODO: The Qt documentation says that the following call shouldn't be used if the UDP socket is connected!!!
         // https://doc.qt.io/qt-5/qudpsocket.html#writeDatagram
@@ -197,7 +197,7 @@ qint64 NetworkSocket::readDatagram(char* data, qint64 maxSize, SockAddr* sockAdd
         _lastSocketTypeRead = SocketType::UDP;
         _pendingDatagramSizeSocketType = SocketType::Unknown;
         if (sockAddr) {
-            sockAddr->setSocketType(SocketType::UDP);
+            sockAddr->setType(SocketType::UDP);
             return _udpSocket.readDatagram(data, maxSize, sockAddr->getAddressPointer(), sockAddr->getPortPointer());
         } else {
             return _udpSocket.readDatagram(data, maxSize);
@@ -206,7 +206,7 @@ qint64 NetworkSocket::readDatagram(char* data, qint64 maxSize, SockAddr* sockAdd
         _lastSocketTypeRead = SocketType::WebRTC;
         _pendingDatagramSizeSocketType = SocketType::Unknown;
         if (sockAddr) {
-            sockAddr->setSocketType(SocketType::WebRTC);
+            sockAddr->setType(SocketType::WebRTC);
             return _webrtcSocket.readDatagram(data, maxSize, sockAddr->getAddressPointer(), sockAddr->getPortPointer());
         } else {
             return _webrtcSocket.readDatagram(data, maxSize);
@@ -214,7 +214,7 @@ qint64 NetworkSocket::readDatagram(char* data, qint64 maxSize, SockAddr* sockAdd
     }
 #else
     if (sockAddr) {
-        sockAddr->setSocketType(SocketType::UDP);
+        sockAddr->setType(SocketType::UDP);
         return _udpSocket.readDatagram(data, maxSize, sockAddr->getAddressPointer(), sockAddr->getPortPointer());
     } else {
         return _udpSocket.readDatagram(data, maxSize);

--- a/libraries/networking/src/udt/NetworkSocket.h
+++ b/libraries/networking/src/udt/NetworkSocket.h
@@ -80,9 +80,10 @@ public:
     /// @brief Gets the number of bytes waiting to be written.
     /// @details For UDP, there's a single buffer used for all destinations. For WebRTC, each destination has its own buffer.
     /// @param socketType The type of socket for which to get the number of bytes waiting to be written.
-    /// @param port If a WebRTC socket, the data channel for which to get the number of bytes waiting.
+    /// @param address If a WebRTCSocket, the destination address for which to get the number of bytes waiting.
+    /// @param port If a WebRTC socket, the destination port for which to get the number of bytes waiting.
     /// @return The number of bytes waiting to be written.
-    qint64 bytesToWrite(SocketType socketType, quint16 port = 0) const;
+    qint64 bytesToWrite(SocketType socketType, const SockAddr& address = SockAddr()) const;
 
 
     /// @brief Gets whether there is a pending datagram waiting to be read.

--- a/libraries/networking/src/udt/PacketHeaders.cpp
+++ b/libraries/networking/src/udt/PacketHeaders.cpp
@@ -27,7 +27,7 @@ PacketVersion versionForPacketType(PacketType packetType) {
         case PacketType::DomainConnectRequestPending: // keeping the old version to maintain the protocol hash
             return 17;
         case PacketType::DomainList:
-            return static_cast<PacketVersion>(DomainListVersion::HasConnectReason);
+            return static_cast<PacketVersion>(DomainListVersion::SocketTypes);
         case PacketType::EntityAdd:
         case PacketType::EntityClone:
         case PacketType::EntityEdit:
@@ -72,10 +72,12 @@ PacketVersion versionForPacketType(PacketType packetType) {
             return static_cast<PacketVersion>(DomainConnectionDeniedVersion::IncludesExtraInfo);
 
         case PacketType::DomainConnectRequest:
-            return static_cast<PacketVersion>(DomainConnectRequestVersion::HasCompressedSystemInfo);
+            return static_cast<PacketVersion>(DomainConnectRequestVersion::SocketTypes);
+        case PacketType::DomainListRequest:
+            return static_cast<PacketVersion>(DomainListRequestVersion::SocketTypes);
 
         case PacketType::DomainServerAddedNode:
-            return static_cast<PacketVersion>(DomainServerAddedNodeVersion::PermissionsGrid);
+            return static_cast<PacketVersion>(DomainServerAddedNodeVersion::SocketTypes);
 
         case PacketType::EntityScriptCallMethod:
             return static_cast<PacketVersion>(EntityScriptCallMethodVersion::ClientCallable);

--- a/libraries/networking/src/udt/PacketHeaders.h
+++ b/libraries/networking/src/udt/PacketHeaders.h
@@ -368,7 +368,13 @@ enum class DomainConnectRequestVersion : PacketVersion {
     HasTimestamp,
     HasReason,
     HasSystemInfo,
-    HasCompressedSystemInfo
+    HasCompressedSystemInfo,
+    SocketTypes
+};
+
+enum class DomainListRequestVersion : PacketVersion {
+    PreSocketTypes = 22,
+    SocketTypes
 };
 
 enum class DomainConnectionDeniedVersion : PacketVersion {
@@ -379,7 +385,8 @@ enum class DomainConnectionDeniedVersion : PacketVersion {
 
 enum class DomainServerAddedNodeVersion : PacketVersion {
     PrePermissionsGrid = 17,
-    PermissionsGrid
+    PermissionsGrid,
+    SocketTypes
 };
 
 enum class DomainListVersion : PacketVersion {
@@ -389,7 +396,8 @@ enum class DomainListVersion : PacketVersion {
     GetMachineFingerprintFromUUIDSupport,
     AuthenticationOptional,
     HasTimestamp,
-    HasConnectReason
+    HasConnectReason,
+    SocketTypes
 };
 
 enum class AudioVersion : PacketVersion {

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -256,7 +256,7 @@ qint64 Socket::writeDatagram(const QByteArray& datagram, const SockAddr& sockAdd
     }
     qint64 bytesWritten = _networkSocket.writeDatagram(datagram, sockAddr);
 
-    int pending = _networkSocket.bytesToWrite(socketType, sockAddr.getPort());
+    int pending = _networkSocket.bytesToWrite(socketType, sockAddr);
     if (bytesWritten < 0 || pending) {
         int wsaError = 0;
         static std::atomic<int> previousWsaError (0);

--- a/libraries/networking/src/udt/Socket.cpp
+++ b/libraries/networking/src/udt/Socket.cpp
@@ -245,7 +245,7 @@ qint64 Socket::writeDatagram(const char* data, qint64 size, const SockAddr& sock
 }
 
 qint64 Socket::writeDatagram(const QByteArray& datagram, const SockAddr& sockAddr) {
-    auto socketType = sockAddr.getSocketType();
+    auto socketType = sockAddr.getType();
 
     // don't attempt to write the datagram if we're unbound.  Just drop it.
     // _networkSocket.writeDatagram will return an error anyway, but there are

--- a/libraries/networking/src/webrtc/WebRTCDataChannels.cpp
+++ b/libraries/networking/src/webrtc/WebRTCDataChannels.cpp
@@ -524,8 +524,14 @@ bool WebRTCDataChannels::sendDataMessage(int dataChannelID, const QByteArray& by
 
 /// @brief Gets the number of bytes waiting to be written on a data channel.
 /// @param port The data channel ID.
-/// @return The number of bytes waiting to be written on the data channel.
+/// @return The number of bytes waiting to be written on the data channel; 0 if the channel doesn't exist.
 qint64 WebRTCDataChannels::getBufferedAmount(int dataChannelID) const {
+    if (!_connectionsByDataChannel.contains(dataChannelID)) {
+#ifdef WEBRTC_DEBUG
+        qCDebug(networking_webrtc) << "WebRTCDataChannels::getBufferedAmount() : Channel doesn't exist:" << dataChannelID;
+#endif
+        return 0;
+    }
     auto connection = _connectionsByDataChannel.value(dataChannelID);
     return connection->getBufferedAmount();
 }

--- a/libraries/networking/src/webrtc/WebRTCDataChannels.cpp
+++ b/libraries/networking/src/webrtc/WebRTCDataChannels.cpp
@@ -430,6 +430,7 @@ void WebRTCDataChannels::reset() {
 }
 
 quint16 WebRTCDataChannels::getNewDataChannelID() {
+    // The first data channel ID is 1.
     static const int QUINT16_LIMIT = std::numeric_limits<uint16_t>::max() + 1;
     _lastDataChannelID = std::max((_lastDataChannelID + 1) % QUINT16_LIMIT, 1);
 #ifdef WEBRTC_DEBUG
@@ -533,7 +534,7 @@ bool WebRTCDataChannels::sendDataMessage(int dataChannelID, const QByteArray& by
 
     // Find connection.
     if (!_connectionsByDataChannel.contains(dataChannelID)) {
-        qCWarning(networking_webrtc) << "Could not find data channel to send message on!";
+        qCWarning(networking_webrtc) << "Could not find WebRTC data channel to send message on!";
         return false;
     }
 

--- a/libraries/networking/src/webrtc/WebRTCDataChannels.h
+++ b/libraries/networking/src/webrtc/WebRTCDataChannels.h
@@ -332,7 +332,7 @@ private:
 
     rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> _peerConnectionFactory { nullptr };
 
-    quint16 _lastDataChannelID { 0 };  // First data channel ID is 1.
+    quint16 _lastDataChannelID { 0 };
 
     QHash<quint16, WDCConnection*> _connectionsByWebSocket;
     QHash<quint16, WDCConnection*> _connectionsByDataChannel;

--- a/libraries/networking/src/webrtc/WebRTCDataChannels.h
+++ b/libraries/networking/src/webrtc/WebRTCDataChannels.h
@@ -129,7 +129,8 @@ public:
     /// @brief Constructs a new WDCConnection and opens a WebRTC data connection.
     /// @param parent The parent WebRTCDataChannels object.
     /// @param webSocketID The signaling channel that initiated the opening of the WebRTC data channel.
-    WDCConnection(WebRTCDataChannels* parent, quint16 webSocketID);
+    /// @param dataChannelID - The WebRTC data channel ID to assign to this connection.
+    WDCConnection(WebRTCDataChannels* parent, quint16 webSocketID, int dataChannelID);
 
     /// @brief Gets the WebSocket ID.
     /// @return The ID of the WebSocket.
@@ -241,11 +242,16 @@ public:
     /// @brief Immediately closes all connections and resets the socket.
     void reset();
     
-    /// @brief Get a new data channel ID to uniquely identify a WDCConnection.
+    /// @brief Gets a new data channel ID to uniquely identify a WDCConnection.
     /// @details This ID is assigned by WebRTCDataChannels; it is <em>not</em> the WebRTC data channel ID because that is only
     ///     unique within a peer connection.
     /// @return A new data channel ID.
     quint16 getNewDataChannelID();
+
+    /// @brief Gets the data channel ID associated with a WebSocket.
+    /// @param webSocketID The WebSocket.
+    /// @return The data channel ID associated with the WebSocket if found, `0` if the WebSocket was not found.
+    int getDataChannelIDForWebSocket(quint16 webSocketID) const;
 
     /// @brief Handles a WebRTC data channel opening.
     /// @param connection The WebRTC data channel connection.

--- a/libraries/networking/src/webrtc/WebRTCDataChannels.h
+++ b/libraries/networking/src/webrtc/WebRTCDataChannels.h
@@ -22,6 +22,7 @@
 #define emit
 
 #include "../NodeType.h"
+#include "../SockAddr.h"
 
 class WebRTCDataChannels;
 class WDCConnection;
@@ -128,17 +129,12 @@ public:
 
     /// @brief Constructs a new WDCConnection and opens a WebRTC data connection.
     /// @param parent The parent WebRTCDataChannels object.
-    /// @param webSocketID The signaling channel that initiated the opening of the WebRTC data channel.
-    /// @param dataChannelID - The WebRTC data channel ID to assign to this connection.
-    WDCConnection(WebRTCDataChannels* parent, quint16 webSocketID, int dataChannelID);
+    /// @param dataChannelID The data channel ID.
+    WDCConnection(WebRTCDataChannels* parent, const QString& dataChannelID);
 
-    /// @brief Gets the WebSocket ID.
-    /// @return The ID of the WebSocket.
-    quint16 getWebSocketID() const { return _webSocketID; }
-
-    /// @brief Gets the WebRTC data channel ID.
-    /// @return The WebRTC data channel ID. `-1` if not open yet.
-    int getDataChannelID() const { return _dataChannelID; }
+    /// @brief Gets the data channel ID.
+    /// @return The data channel ID.
+    QString getDataChannelID() const { return _dataChannelID; }
 
 
     /// @brief Sets the remote session description received from the remote client via the signaling channel.
@@ -160,7 +156,7 @@ public:
     /// @param data The ICE candidate.
     void addIceCandidate(QJsonObject& data);
 
-    /// @brief Sends an ICE candidate to the remote vlient via the signaling channel.
+    /// @brief Sends an ICE candidate to the remote client via the signaling channel.
     /// @param candidate The ICE candidate.
     void sendIceCandidate(const webrtc::IceCandidateInterface* candidate);
 
@@ -195,8 +191,7 @@ public:
     
 private:
     WebRTCDataChannels* _parent;
-    quint16 _webSocketID { 0 };
-    int _dataChannelID { -1 };
+    QString _dataChannelID;
 
     rtc::scoped_refptr<WDCSetSessionDescriptionObserver> _setSessionDescriptionObserver { nullptr };
     rtc::scoped_refptr<WDCCreateSessionDescriptionObserver> _createSessionDescriptionObserver { nullptr };
@@ -221,6 +216,9 @@ private:
 /// Additionally, for debugging purposes, instead of containing a Vircadia protocol payload, a WebRTC message may be an echo
 /// request. This is bounced back to the client.
 /// 
+/// A WebRTC data channel is identified by the IP address and port of the client WebSocket that was used when opening the data
+/// channel - this is considered to be the WebRTC data channel's address. The IP address and port of the actual WebRTC
+/// connection is not used.
 class WebRTCDataChannels : public QObject {
     Q_OBJECT
 
@@ -242,41 +240,30 @@ public:
     /// @brief Immediately closes all connections and resets the socket.
     void reset();
     
-    /// @brief Gets a new data channel ID to uniquely identify a WDCConnection.
-    /// @details This ID is assigned by WebRTCDataChannels; it is <em>not</em> the WebRTC data channel ID because that is only
-    ///     unique within a peer connection.
-    /// @return A new data channel ID.
-    quint16 getNewDataChannelID();
-
-    /// @brief Gets the data channel ID associated with a WebSocket.
-    /// @param webSocketID The WebSocket.
-    /// @return The data channel ID associated with the WebSocket if found, `0` if the WebSocket was not found.
-    int getDataChannelIDForWebSocket(quint16 webSocketID) const;
-
     /// @brief Handles a WebRTC data channel opening.
     /// @param connection The WebRTC data channel connection.
-    /// @param dataChannelID The WebRTC data channel ID.
-    void onDataChannelOpened(WDCConnection* connection, quint16 dataChannelID);
+    /// @param dataChannelID The IP address and port of the signaling WebSocket that the client used to connect, `"n.n.n.n:n"`.
+    void onDataChannelOpened(WDCConnection* connection, const QString& dataChannelID);
 
     /// @brief Emits a signalingMessage to be sent to the Interface client.
     /// @param message The WebRTC signaling message to send.
     void sendSignalingMessage(const QJsonObject& message);
 
     /// @brief Emits a dataMessage received from the Interface client.
-    /// @param dataChannelID The WebRTC data channel the message was received on.
+    /// @param dataChannelID The IP address and port of the signaling WebSocket that the client used to connect, `"n.n.n.n:n"`.
     /// @param byteArray The data message received.
-    void emitDataMessage(int dataChannelID, const QByteArray& byteArray);
+    void emitDataMessage(const QString& dataChannelID, const QByteArray& byteArray);
 
     /// @brief Sends a data message to an Interface client.
-    /// @param dataChannelID The WebRTC channel ID of the Interface client.
+    /// @param dataChannelID The IP address and port of the signaling WebSocket that the client used to connect, `"n.n.n.n:n"`.
     /// @param message The data message to send.
     /// @return `true` if the data message was sent, otherwise `false`.
-    bool sendDataMessage(int dataChannelID, const QByteArray& message);
+    bool sendDataMessage(const SockAddr& destination, const QByteArray& message);
 
     /// @brief Gets the number of bytes waiting to be sent on a data channel.
-    /// @param dataChannelID The data channel ID.
+    /// @param address The address of the signaling WebSocket that the client used to connect.
     /// @return The number of bytes waiting to be sent on the data channel.
-    qint64 getBufferedAmount(int dataChannelID) const;
+    qint64 getBufferedAmount(const SockAddr& address) const;
 
     /// @brief Creates a new WebRTC peer connection for connecting to an Interface client.
     /// @param peerConnectionObserver An observer to monitor the WebRTC peer connection.
@@ -311,9 +298,9 @@ signals:
 
     /// @brief A WebRTC data message received from the Interface client.
     /// @details This message is for handling at a higher level in the Vircadia protocol.
-    /// @param dataChannelID The WebRTC data channel ID.
+    /// @param address The address of the signaling WebSocket that the client used to connect.
     /// @param byteArray The Vircadia protocol message.
-    void dataMessage(int dataChannelID, const QByteArray& byteArray);
+    void dataMessage(const SockAddr& address, const QByteArray& byteArray);
 
     /// @brief Signals that the peer connection for a WebRTC data channel should be closed.
     /// @details Used by {@link WebRTCDataChannels.closePeerConnection}.
@@ -332,10 +319,9 @@ private:
 
     rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> _peerConnectionFactory { nullptr };
 
-    quint16 _lastDataChannelID { 0 };
-
-    QHash<quint16, WDCConnection*> _connectionsByWebSocket;
-    QHash<quint16, WDCConnection*> _connectionsByDataChannel;
+    QHash<QString, WDCConnection*> _connectionsByID;  // <client data channel ID, WDCConnection>
+    // The client's WebSocket IP and port is used as the data channel ID to uniquely identify each.
+    // The WebSocket IP address and port is formatted as "n.n.n.n:n", the same as used in WebRTCSignalingServer.
 };
 
 

--- a/libraries/networking/src/webrtc/WebRTCSignalingServer.h
+++ b/libraries/networking/src/webrtc/WebRTCSignalingServer.h
@@ -39,19 +39,20 @@
 /// signaling `data` payload or an `echo` request:
 ///
 /// | Interface -> Server ||
-/// | -------- | -----------------------|
-/// | `to`     | NodeType               |
-/// | `from`   | WebSocket port number* |
-/// | [`data`] | WebRTC payload         |
-/// | [`echo`] | Echo request           |
-/// * The `from` field is filled in by the WebRTCSignalingServer.
+/// | -------- | ---------------------------------------- |
+/// | `to`     | NodeType                                 |
+/// | `from`   | WebSocket IP address & port, "n.n.n.n:n" |
+/// | [`data`] | WebRTC signaling payload                 |
+/// | [`echo`] | Echo request                             |
+///
+/// `*` The `from` field is filled in upon receipt by the WebRTCSignalingServer.
 ///
 /// | Server -> Interface ||
-/// | -------- | ---------------------  |
-/// | `to`     | WebSocket port number  |
-/// | `from`   | NodeType               |
-/// | [`data`] | WebRTC payload         |
-/// | [`echo`] | Echo response          |
+/// | -------- | ---------------------------------------- |
+/// | `to`     | WebSocket IP address & port, "n.n.n.n:n" |
+/// | `from`   | NodeType                                 |
+/// | [`data`] | WebRTC signaling payload                 |
+/// | [`echo`] | Echo response                            |
 ///
 class WebRTCSignalingServer : public QObject {
     Q_OBJECT
@@ -97,7 +98,9 @@ private:
     QHostAddress _address;
     quint16 _port { 0 };
 
-    QHash<quint16, QWebSocket*> _webSockets;  // client WebSocket port, client WebSocket object
+    QHash<QString, QWebSocket*> _webSockets;  // <client WebSocket IP address and port, client connection WebSocket object>
+    // The WebSocket IP address and port is formatted as "n.n.n.n:n".
+    // A QString is used rather than a SockAddr, to make signaling easier.
 
     QTimer* _isWebSocketServerListeningTimer;
 };

--- a/libraries/networking/src/webrtc/WebRTCSocket.cpp
+++ b/libraries/networking/src/webrtc/WebRTCSocket.cpp
@@ -78,17 +78,17 @@ void WebRTCSocket::abort() {
 }
 
 
-qint64 WebRTCSocket::writeDatagram(const QByteArray& datagram, quint16 port) {
+qint64 WebRTCSocket::writeDatagram(const QByteArray& datagram, const SockAddr& destination) {
     clearError();
-    if (_dataChannels.sendDataMessage(port, datagram)) {
+    if (_dataChannels.sendDataMessage(destination, datagram)) {
         return datagram.length();
     }
     setError(QAbstractSocket::SocketError::UnknownSocketError, "Failed to write datagram");
     return -1;
 }
 
-qint64 WebRTCSocket::bytesToWrite(quint16 port) const {
-    return _dataChannels.getBufferedAmount(port);
+qint64 WebRTCSocket::bytesToWrite(const SockAddr& destination) const {
+    return _dataChannels.getBufferedAmount(destination);
 }
 
 
@@ -114,12 +114,11 @@ qint64 WebRTCSocket::readDatagram(char* data, qint64 maxSize, QHostAddress* addr
         }
 
         if (address) {
-            // WEBRTC TODO: Use signaling channel's remote WebSocket address? Or remote data channel address?
-            *address = QHostAddress::AnyIPv4;
+            *address = datagram.first.getAddress();
         }
 
         if (port) {
-            *port = datagram.first;
+            *port = datagram.first.getPort();
         }
 
         return length;
@@ -148,14 +147,9 @@ void WebRTCSocket::clearError() {
 }
 
 
-void WebRTCSocket::onDataChannelReceivedMessage(int dataChannelID, const QByteArray& message) {
-    _receivedQueue.enqueue(QPair<int, QByteArray>(dataChannelID, message));
+void WebRTCSocket::onDataChannelReceivedMessage(const SockAddr& source, const QByteArray& message) {
+    _receivedQueue.enqueue(QPair<SockAddr, QByteArray>(source, message));
     emit readyRead();
-}
-
-
-int WebRTCSocket::getDataChannelIDForWebSocket(quint16 webSocketID) const {
-    return _dataChannels.getDataChannelIDForWebSocket(webSocketID);
 }
 
 #endif // WEBRTC_DATA_CHANNELS

--- a/libraries/networking/src/webrtc/WebRTCSocket.cpp
+++ b/libraries/networking/src/webrtc/WebRTCSocket.cpp
@@ -153,4 +153,9 @@ void WebRTCSocket::onDataChannelReceivedMessage(int dataChannelID, const QByteAr
     emit readyRead();
 }
 
+
+int WebRTCSocket::getDataChannelIDForWebSocket(quint16 webSocketID) const {
+    return _dataChannels.getDataChannelIDForWebSocket(webSocketID);
+}
+
 #endif // WEBRTC_DATA_CHANNELS

--- a/libraries/networking/src/webrtc/WebRTCSocket.h
+++ b/libraries/networking/src/webrtc/WebRTCSocket.h
@@ -71,13 +71,11 @@ public:
     void abort();
 
     /// @brief Nominally gets the host port number.
-    /// @details 
     /// Included for compatibility with the QUdpSocket interface.
     /// @return <code>0</code> 
     quint16 localPort() const { return 0; }
 
     /// @brief Nominally gets the socket descriptor.
-    /// @details 
     /// Included for compatibility with the QUdpSocket interface.
     /// @return <code>-1</code>
     qintptr socketDescriptor() const { return -1; }

--- a/libraries/networking/src/webrtc/WebRTCSocket.h
+++ b/libraries/networking/src/webrtc/WebRTCSocket.h
@@ -120,6 +120,12 @@ public:
     /// @return The description of the error that last occurred.
     QString errorString() const;
 
+
+    /// @brief Gets the data channel ID associated with a WebSocket.
+    /// @param webSocketID
+    /// @return The data channel ID associated with the WebSocket if found, `0` if the WebSocket was not found.
+    int getDataChannelIDForWebSocket(quint16 webSocketID) const;
+
 public slots:
 
     /// @brief Handles the WebRTC data channel receiving a message.


### PR DESCRIPTION
Wires up assignment clients to associate WebRTC connections with domain users.

Also:
- Uses client's WebSocket IP address and port as WebRTC connection's IP address and port, and as means to identify WebRTC data channel instead of an internally-assigned numeric ID.