### PR TITLE
[low-priority] code review: use of "#include <QtCore/QSharedPointer>"

### DIFF
--- a/assignment-client/src/Agent.h
+++ b/assignment-client/src/Agent.h
@@ -17,6 +17,7 @@
 
 #include <QtScript/QScriptEngine>
 #include <QtCore/QObject>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QUrl>
 #include <QtCore/QTimer>
 #include <QUuid>

--- a/assignment-client/src/AssignmentClient.h
+++ b/assignment-client/src/AssignmentClient.h
@@ -15,6 +15,7 @@
 
 #include <QtCore/QCoreApplication>
 #include <QtCore/QPointer>
+#include <QtCore/QSharedPointer>
 
 #include "ThreadedAssignment.h"
 

--- a/assignment-client/src/AssignmentClientMonitor.h
+++ b/assignment-client/src/AssignmentClientMonitor.h
@@ -17,6 +17,7 @@
 #include <QtCore/qpointer.h>
 #include <QtCore/QProcess>
 #include <QtCore/QDateTime>
+#include <QtCore/QSharedPointer>
 #include <QDir>
 
 #include <Assignment.h>

--- a/assignment-client/src/assets/AssetServer.h
+++ b/assignment-client/src/assets/AssetServer.h
@@ -13,6 +13,7 @@
 #define hifi_AssetServer_h
 
 #include <QtCore/QDir>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QThreadPool>
 #include <QRunnable>
 

--- a/assignment-client/src/audio/AudioMixer.h
+++ b/assignment-client/src/audio/AudioMixer.h
@@ -12,6 +12,8 @@
 #ifndef hifi_AudioMixer_h
 #define hifi_AudioMixer_h
 
+#include <QtCore/QSharedPointer>
+
 #include <AABox.h>
 #include <AudioHRTF.h>
 #include <AudioRingBuffer.h>

--- a/assignment-client/src/audio/AudioMixerClientData.h
+++ b/assignment-client/src/audio/AudioMixerClientData.h
@@ -20,6 +20,7 @@
 #endif
 
 #include <QtCore/QJsonObject>
+#include <QtCore/QSharedPointer>
 
 #include <AABox.h>
 #include <AudioHRTF.h>

--- a/assignment-client/src/avatars/AvatarMixer.h
+++ b/assignment-client/src/avatars/AvatarMixer.h
@@ -16,6 +16,8 @@
 #ifndef hifi_AvatarMixer_h
 #define hifi_AvatarMixer_h
 
+#include <QtCore/QSharedPointer>
+
 #include <set>
 #include <shared/RateCounter.h>
 #include <PortableHighResolutionClock.h>

--- a/assignment-client/src/avatars/AvatarMixerClientData.h
+++ b/assignment-client/src/avatars/AvatarMixerClientData.h
@@ -19,6 +19,7 @@
 #include <queue>
 
 #include <QtCore/QJsonObject>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QUrl>
 
 #include "MixerAvatar.h"

--- a/assignment-client/src/entities/EntityServer.h
+++ b/assignment-client/src/entities/EntityServer.h
@@ -14,6 +14,8 @@
 
 #include "../octree/OctreeServer.h"
 
+#include <QtCore/QSharedPointer>
+
 #include <memory>
 
 #include <EntityItem.h>

--- a/assignment-client/src/messages/MessagesMixer.h
+++ b/assignment-client/src/messages/MessagesMixer.h
@@ -15,6 +15,8 @@
 #ifndef hifi_MessagesMixer_h
 #define hifi_MessagesMixer_h
 
+#include <QtCore/QSharedPointer>
+
 #include <ThreadedAssignment.h>
 
 /// Handles assignments of type MessagesMixer - distribution of avatar data to various clients

--- a/assignment-client/src/octree/OctreeHeadlessViewer.h
+++ b/assignment-client/src/octree/OctreeHeadlessViewer.h
@@ -12,6 +12,8 @@
 #ifndef hifi_OctreeHeadlessViewer_h
 #define hifi_OctreeHeadlessViewer_h
 
+#include <QtCore/QSharedPointer>
+
 #include <OctreeProcessor.h>
 #include <OctreeQuery.h>
 

--- a/assignment-client/src/octree/OctreeInboundPacketProcessor.h
+++ b/assignment-client/src/octree/OctreeInboundPacketProcessor.h
@@ -14,6 +14,8 @@
 #ifndef hifi_OctreeInboundPacketProcessor_h
 #define hifi_OctreeInboundPacketProcessor_h
 
+#include <QtCore/QSharedPointer>
+
 #include <ReceivedPacketProcessor.h>
 
 #include "SequenceNumberStats.h"

--- a/assignment-client/src/octree/OctreeServer.h
+++ b/assignment-client/src/octree/OctreeServer.h
@@ -17,6 +17,7 @@
 #include <QStringList>
 #include <QDateTime>
 #include <QtCore/QCoreApplication>
+#include <QtCore/QSharedPointer>
 
 #include <HTTPManager.h>
 

--- a/assignment-client/src/scripts/EntityScriptServer.h
+++ b/assignment-client/src/scripts/EntityScriptServer.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include <QtCore/QObject>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QUuid>
 
 #include <EntityEditPacketSender.h>

--- a/domain-server/src/DomainGatekeeper.h
+++ b/domain-server/src/DomainGatekeeper.h
@@ -20,6 +20,7 @@
 
 #include <QtCore/QObject>
 #include <QtNetwork/QNetworkReply>
+#include <QtCore/QSharedPointer>
 
 #include <DomainHandler.h>
 

--- a/domain-server/src/DomainServerSettingsManager.h
+++ b/domain-server/src/DomainServerSettingsManager.h
@@ -17,6 +17,7 @@
 #include <QtCore/QJsonObject>
 #include <QtCore/QJsonDocument>
 #include <QtNetwork/QNetworkReply>
+#include <QtCore/QSharedPointer>
 
 #include <HifiConfigVariantMap.h>
 #include <HTTPManager.h>

--- a/ice-server/src/IceServer.cpp
+++ b/ice-server/src/IceServer.cpp
@@ -19,6 +19,7 @@
 #include <QtCore/QTimer>
 #include <QtNetwork/QNetworkReply>
 #include <QtNetwork/QNetworkRequest>
+#include <QtCore/QSharedPointer>
 
 #include <LimitedNodeList.h>
 #include <NetworkAccessManager.h>

--- a/ice-server/src/IceServer.h
+++ b/ice-server/src/IceServer.h
@@ -14,7 +14,6 @@
 #define hifi_IceServer_h
 
 #include <QtCore/QCoreApplication>
-#include <QtCore/QSharedPointer>
 #include <QUdpSocket>
 
 #include <openssl/rsa.h>

--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -18,6 +18,7 @@
 #include <QtCore/QHash>
 #include <QtCore/QPointer>
 #include <QtCore/QSet>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QStringList>
 #include <QtQuick/QQuickItem>
 

--- a/interface/src/InterfaceParentFinder.cpp
+++ b/interface/src/InterfaceParentFinder.cpp
@@ -11,6 +11,8 @@
 
 #include "InterfaceParentFinder.h"
 
+#include <QtCore/QSharedPointer>
+
 #include <Application.h>
 #include <AvatarData.h>
 #include <avatar/AvatarManager.h>

--- a/interface/src/LoginStateManager.h
+++ b/interface/src/LoginStateManager.h
@@ -11,7 +11,6 @@
 #ifndef hifi_LoginStateManager_h
 #define hifi_LoginStateManager_h
 #include <QtCore/QList>
-#include <QtCore/QSharedPointer>
 #include <QtCore/QVariant>
 
 #include <PointerEvent.h>

--- a/interface/src/avatar/AvatarManager.h
+++ b/interface/src/avatar/AvatarManager.h
@@ -16,7 +16,6 @@
 
 #include <QtCore/QHash>
 #include <QtCore/QObject>
-#include <QtCore/QSharedPointer>
 
 #include <AvatarHashMap.h>
 #include <PhysicsEngine.h>

--- a/interface/src/avatar/GrabManager.cpp
+++ b/interface/src/avatar/GrabManager.cpp
@@ -11,6 +11,7 @@
 
 
 #include "GrabManager.h"
+#include <QtCore/QSharedPointer>
 
 void GrabManager::simulateGrabs() {
     QSharedPointer<AvatarManager> avatarManager = DependencyManager::get<AvatarManager>();

--- a/interface/src/commerce/Wallet.h
+++ b/interface/src/commerce/Wallet.h
@@ -14,6 +14,8 @@
 #ifndef hifi_Wallet_h
 #define hifi_Wallet_h
 
+#include <QtCore/QSharedPointer>
+
 #include <DependencyManager.h>
 #include <Node.h>
 #include <ReceivedMessage.h>

--- a/interface/src/octree/OctreePacketProcessor.h
+++ b/interface/src/octree/OctreePacketProcessor.h
@@ -12,6 +12,8 @@
 #ifndef hifi_OctreePacketProcessor_h
 #define hifi_OctreePacketProcessor_h
 
+#include <QtCore/QSharedPointer>
+
 #include <ReceivedPacketProcessor.h>
 #include <ReceivedMessage.h>
 

--- a/interface/src/raypick/CollisionPick.h
+++ b/interface/src/raypick/CollisionPick.h
@@ -8,6 +8,8 @@
 #ifndef hifi_CollisionPick_h
 #define hifi_CollisionPick_h
 
+#include <QtCore/QSharedPointer>
+
 #include <PhysicsEngine.h>
 #include <model-networking/ModelCache.h>
 #include <RegisteredMetaTypes.h>

--- a/interface/src/scripting/ScreenshareScriptingInterface.h
+++ b/interface/src/scripting/ScreenshareScriptingInterface.h
@@ -16,6 +16,7 @@
 #include <QProcess>
 #include <QtCore/QCoreApplication>
 #include <QNetworkReply>
+#include <QtCore/QSharedPointer>
 
 #include <PathUtils.h>
 #include <ReceivedMessage.h>

--- a/interface/src/scripting/SelectionScriptingInterface.h
+++ b/interface/src/scripting/SelectionScriptingInterface.h
@@ -14,6 +14,7 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QMap>
+#include <QtCore/QSharedPointer>
 #include <DependencyManager.h>
 
 #include <AbstractViewStateInterface.h>

--- a/interface/src/scripting/WalletScriptingInterface.cpp
+++ b/interface/src/scripting/WalletScriptingInterface.cpp
@@ -10,6 +10,7 @@
 //
 
 #include "WalletScriptingInterface.h"
+#include <QtCore/QSharedPointer>
 #include <SettingHandle.h>
 
 CheckoutProxy::CheckoutProxy(QObject* qmlObject, QObject* parent) : QmlWrapper(qmlObject, parent) {

--- a/interface/src/ui/JSConsole.h
+++ b/interface/src/ui/JSConsole.h
@@ -14,7 +14,6 @@
 
 #include <QFutureWatcher>
 #include <QObject>
-#include <QSharedPointer>
 #include <QCompleter>
 #include <QtCore/QJsonArray>
 

--- a/interface/src/ui/SnapshotAnimated.h
+++ b/interface/src/ui/SnapshotAnimated.h
@@ -12,6 +12,7 @@
 #ifndef hifi_SnapshotAnimated_h
 #define hifi_SnapshotAnimated_h
 
+#include <QtCore/QSharedPointer>
 #include <QtCore/QVector>
 #include <Application.h>
 #include <DependencyManager.h>

--- a/interface/src/ui/overlays/ContextOverlayInterface.h
+++ b/interface/src/ui/overlays/ContextOverlayInterface.h
@@ -15,6 +15,7 @@
 
 #include <QtCore/QObject>
 #include <QUuid>
+#include <QtCore/QSharedPointer>
 
 #include <DependencyManager.h>
 #include <PointerEvent.h>

--- a/libraries/animation/src/AnimNodeLoader.h
+++ b/libraries/animation/src/AnimNodeLoader.h
@@ -14,6 +14,7 @@
 #include <memory>
 
 #include <QNetworkReply>
+#include <QtCore/QSharedPointer>
 #include <QString>
 #include <QUrl>
 

--- a/libraries/animation/src/AnimationCache.h
+++ b/libraries/animation/src/AnimationCache.h
@@ -13,6 +13,7 @@
 #define hifi_AnimationCache_h
 
 #include <QtCore/QRunnable>
+#include <QtCore/QSharedPointer>
 #include <QtScript/QScriptEngine>
 #include <QtScript/QScriptValue>
 

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -24,6 +24,7 @@
 #include <QtCore/QByteArray>
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QObject>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QVector>
 #include <QtMultimedia/QAudio>
 #include <QtMultimedia/QAudioFormat>

--- a/libraries/audio-client/src/AudioIOStats.h
+++ b/libraries/audio-client/src/AudioIOStats.h
@@ -15,6 +15,7 @@
 #include "MovingMinMaxAvg.h"
 
 #include <QObject>
+#include <QtCore/QSharedPointer>
 
 #include <AudioStreamStats.h>
 #include <Node.h>

--- a/libraries/audio/src/AbstractAudioInterface.cpp
+++ b/libraries/audio/src/AbstractAudioInterface.cpp
@@ -8,8 +8,6 @@
 
 #include "AbstractAudioInterface.h"
 
-#include <QtCore/QSharedPointer>
-
 #include <Node.h>
 #include <NodeType.h>
 #include <DependencyManager.h>

--- a/libraries/audio/src/AudioInjectorManager.cpp
+++ b/libraries/audio/src/AudioInjectorManager.cpp
@@ -12,6 +12,7 @@
 #include "AudioInjectorManager.h"
 
 #include <QtCore/QCoreApplication>
+#include <QtCore/QSharedPointer>
 
 #include <SharedUtil.h>
 #include <shared/QtHelpers.h>

--- a/libraries/audio/src/Sound.h
+++ b/libraries/audio/src/Sound.h
@@ -14,6 +14,7 @@
 
 #include <QRunnable>
 #include <QtCore/QObject>
+#include <QtCore/QSharedPointer>
 #include <QtNetwork/QNetworkReply>
 #include <QtScript/qscriptengine.h>
 

--- a/libraries/audio/src/SoundCache.h
+++ b/libraries/audio/src/SoundCache.h
@@ -12,6 +12,8 @@
 #ifndef hifi_SoundCache_h
 #define hifi_SoundCache_h
 
+#include <QtCore/QSharedPointer>
+
 #include <ResourceCache.h>
 
 #include "Sound.h"

--- a/libraries/avatars/src/ClientTraitsHandler.h
+++ b/libraries/avatars/src/ClientTraitsHandler.h
@@ -12,6 +12,8 @@
 #ifndef hifi_ClientTraitsHandler_h
 #define hifi_ClientTraitsHandler_h
 
+#include <QtCore/QSharedPointer>
+
 #include <ReceivedMessage.h>
 
 #include "AssociatedTraitValues.h"

--- a/libraries/baking/src/MaterialBaker.h
+++ b/libraries/baking/src/MaterialBaker.h
@@ -12,6 +12,8 @@
 #ifndef hifi_MaterialBaker_h
 #define hifi_MaterialBaker_h
 
+#include <QtCore/QSharedPointer>
+
 #include "Baker.h"
 
 #include "TextureBaker.h"

--- a/libraries/baking/src/ModelBaker.h
+++ b/libraries/baking/src/ModelBaker.h
@@ -17,6 +17,7 @@
 #include <QtCore/QUrl>
 #include <QtNetwork/QNetworkReply>
 #include <QJsonArray>
+#include <QtCore/QSharedPointer>
 
 #include "Baker.h"
 #include "MaterialBaker.h"

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -14,6 +14,7 @@
 
 #include <QtCore/QCoreApplication>
 #include <QtCore/QBuffer>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QThread>
 #include <QtCore/QTimer>
 #include <QtCore/QFileInfo>

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -15,6 +15,7 @@
 #include <QtCore/QSet>
 #include <QtCore/QStack>
 #include <QtGui/QMouseEvent>
+#include <QtCore/QSharedPointer>
 
 #include <AudioInjectorManager.h>
 #include <EntityScriptingInterface.h> // for RayToEntityIntersectionResult

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.h
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.h
@@ -10,6 +10,7 @@
 #ifndef hifi_RenderableWebEntityItem_h
 #define hifi_RenderableWebEntityItem_h
 
+#include <QtCore/QSharedPointer>
 #include <WebEntityItem.h>
 #include "RenderableEntityItem.h"
 

--- a/libraries/entities/src/EntityEditPacketSender.h
+++ b/libraries/entities/src/EntityEditPacketSender.h
@@ -12,6 +12,8 @@
 #ifndef hifi_EntityEditPacketSender_h
 #define hifi_EntityEditPacketSender_h
 
+#include <QtCore/QSharedPointer>
+
 #include <OctreeEditPacketSender.h>
 
 #include <mutex>

--- a/libraries/entities/src/EntityScriptServerLogClient.h
+++ b/libraries/entities/src/EntityScriptServerLogClient.h
@@ -13,6 +13,7 @@
 #define hifi_EntityScriptServerLogClient_h
 
 #include <QObject>
+#include <QtCore/QSharedPointer>
 
 #include <NodeList.h>
 

--- a/libraries/entities/src/EntityScriptingInterface.h
+++ b/libraries/entities/src/EntityScriptingInterface.h
@@ -17,6 +17,7 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QStringList>
+#include <QtCore/QSharedPointer>
 #include <QtQml/QJSValue>
 #include <QtQml/QJSValueList>
 

--- a/libraries/material-networking/src/material-networking/ShaderCache.h
+++ b/libraries/material-networking/src/material-networking/ShaderCache.h
@@ -9,6 +9,7 @@
 #ifndef hifi_ShaderCache_h
 #define hifi_ShaderCache_h
 
+#include <QtCore/QSharedPointer>
 #include <ResourceCache.h>
 
 class NetworkShader : public Resource {

--- a/libraries/material-networking/src/material-networking/TextureCache.h
+++ b/libraries/material-networking/src/material-networking/TextureCache.h
@@ -18,6 +18,7 @@
 #include <QMap>
 #include <QColor>
 #include <QMetaEnum>
+#include <QtCore/QSharedPointer>
 
 #include <DependencyManager.h>
 #include <ResourceCache.h>

--- a/libraries/model-networking/src/model-networking/ModelCache.h
+++ b/libraries/model-networking/src/model-networking/ModelCache.h
@@ -12,6 +12,8 @@
 #ifndef hifi_ModelCache_h
 #define hifi_ModelCache_h
 
+#include <QtCore/QSharedPointer>
+
 #include <DependencyManager.h>
 #include <ResourceCache.h>
 

--- a/libraries/networking/src/AssetClient.h
+++ b/libraries/networking/src/AssetClient.h
@@ -15,6 +15,7 @@
 #include <QStandardItemModel>
 #include <QtQml/QJSEngine>
 #include <QString>
+#include <QtCore/QSharedPointer>
 
 #include <map>
 

--- a/libraries/networking/src/BaseAssetScriptingInterface.h
+++ b/libraries/networking/src/BaseAssetScriptingInterface.h
@@ -15,6 +15,7 @@
 #define hifi_BaseAssetScriptingInterface_h
 
 #include <QtCore/QObject>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QThread>
 #include "AssetClient.h"
 #include <shared/MiniPromises.h>

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -17,6 +17,7 @@
 
 #include <QtCore/QJsonObject>
 #include <QtCore/QObject>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QTimer>
 #include <QtCore/QUuid>
 #include <QtCore/QUrl>

--- a/libraries/networking/src/EntityScriptClient.h
+++ b/libraries/networking/src/EntityScriptClient.h
@@ -12,6 +12,8 @@
 #ifndef hifi_EntityScriptClient_h
 #define hifi_EntityScriptClient_h
 
+#include <QtCore/QSharedPointer>
+
 #include "ClientServerUtils.h"
 #include "LimitedNodeList.h"
 #include "ReceivedMessage.h"

--- a/libraries/networking/src/LimitedNodeList.h
+++ b/libraries/networking/src/LimitedNodeList.h
@@ -29,6 +29,7 @@
 #include <QtCore/QReadWriteLock>
 #include <QtCore/QSet>
 #include <QtCore/QSharedMemory>
+#include <QtCore/QSharedPointer>
 #include <QtNetwork/QUdpSocket>
 #include <QtNetwork/QHostAddress>
 

--- a/libraries/networking/src/MappingRequest.cpp
+++ b/libraries/networking/src/MappingRequest.cpp
@@ -11,6 +11,7 @@
 
 #include "MappingRequest.h"
 
+#include <QtCore/QSharedPointer>
 #include <QtCore/QThread>
 
 #include <DependencyManager.h>

--- a/libraries/networking/src/MessagesClient.h
+++ b/libraries/networking/src/MessagesClient.h
@@ -15,6 +15,7 @@
 
 #include <QString>
 #include <QByteArray>
+#include <QtCore/QSharedPointer>
 
 #include <DependencyManager.h>
 

--- a/libraries/networking/src/NLPacket.h
+++ b/libraries/networking/src/NLPacket.h
@@ -13,8 +13,6 @@
 #ifndef hifi_NLPacket_h
 #define hifi_NLPacket_h
 
-#include <QtCore/QSharedPointer>
-
 #include <UUID.h>
 
 #include "udt/Packet.h"

--- a/libraries/networking/src/NLPacketList.h
+++ b/libraries/networking/src/NLPacketList.h
@@ -12,6 +12,7 @@
 #ifndef hifi_NLPacketList_h
 #define hifi_NLPacketList_h
 
+#include <QtCore/QSharedPointer>
 #include "udt/PacketList.h"
 
 #include "NLPacket.h"

--- a/libraries/networking/src/NetworkPeer.h
+++ b/libraries/networking/src/NetworkPeer.h
@@ -16,6 +16,7 @@
 #include <atomic>
 
 #include <QtCore/QObject>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QTimer>
 #include <QtCore/QUuid>
 

--- a/libraries/networking/src/NodeData.h
+++ b/libraries/networking/src/NodeData.h
@@ -14,7 +14,6 @@
 
 #include <QtCore/QMutex>
 #include <QtCore/QObject>
-#include <QtCore/QSharedPointer>
 
 #include "NetworkPeer.h"
 #include "NLPacket.h"

--- a/libraries/networking/src/ReceivedMessage.cpp
+++ b/libraries/networking/src/ReceivedMessage.cpp
@@ -15,8 +15,6 @@
 #include <algorithm>
 #include <chrono>
 
-#include "QSharedPointer"
-
 int receivedMessageMetaTypeId = qRegisterMetaType<ReceivedMessage*>("ReceivedMessage*");
 int sharedPtrReceivedMessageMetaTypeId = qRegisterMetaType<QSharedPointer<ReceivedMessage>>("QSharedPointer<ReceivedMessage>");
 

--- a/libraries/networking/src/ReceivedMessage.h
+++ b/libraries/networking/src/ReceivedMessage.h
@@ -15,6 +15,7 @@
 
 #include <QByteArray>
 #include <QObject>
+#include <QtCore/QSharedPointer>
 
 #include <atomic>
 

--- a/libraries/networking/src/ReceivedPacketProcessor.h
+++ b/libraries/networking/src/ReceivedPacketProcessor.h
@@ -12,6 +12,7 @@
 #ifndef hifi_ReceivedPacketProcessor_h
 #define hifi_ReceivedPacketProcessor_h
 
+#include <QtCore/QSharedPointer>
 #include <QWaitCondition>
 
 #include "NodeList.h"

--- a/libraries/octree/src/OctreePersistThread.h
+++ b/libraries/octree/src/OctreePersistThread.h
@@ -15,6 +15,7 @@
 #define hifi_OctreePersistThread_h
 
 #include <QString>
+#include <QtCore/QSharedPointer>
 #include <GenericThread.h>
 #include "Octree.h"
 

--- a/libraries/physics/src/ObjectDynamic.cpp
+++ b/libraries/physics/src/ObjectDynamic.cpp
@@ -11,6 +11,8 @@
 
 #include "ObjectDynamic.h"
 
+#include <QtCore/QSharedPointer>
+
 #include "EntitySimulation.h"
 
 #include "PhysicsLogging.h"

--- a/libraries/plugins/src/plugins/DisplayPlugin.h
+++ b/libraries/plugins/src/plugins/DisplayPlugin.h
@@ -18,6 +18,7 @@
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QJsonObject>
 #include <QtCore/QMutex>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QWaitCondition>
 
 #include <GLMHelpers.h>

--- a/libraries/plugins/src/plugins/PluginManager.h
+++ b/libraries/plugins/src/plugins/PluginManager.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <QObject>
+#include <QtCore/QSharedPointer>
 
 #include <DependencyManager.h>
 #include <SettingHandle.h>

--- a/libraries/procedural/src/procedural/ProceduralMaterialCache.h
+++ b/libraries/procedural/src/procedural/ProceduralMaterialCache.h
@@ -8,6 +8,8 @@
 #ifndef hifi_MaterialCache_h
 #define hifi_MaterialCache_h
 
+#include <QtCore/QSharedPointer>
+
 #include "glm/glm.hpp"
 
 #include <ResourceCache.h>

--- a/libraries/qml/src/qml/OffscreenSurface.h
+++ b/libraries/qml/src/qml/OffscreenSurface.h
@@ -17,7 +17,6 @@
 #include <QtCore/QUrl>
 #include <QtCore/QSize>
 #include <QtCore/QPointF>
-#include <QtCore/QSharedPointer>
 #include <QtCore/QTimer>
 
 #include <QtQml/QJSValue>

--- a/libraries/qml/src/qml/impl/SharedObject.h
+++ b/libraries/qml/src/qml/impl/SharedObject.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <QtCore/QObject>
-#include <QtCore/QSharedPointer>
 #include <QtCore/QThread>
 #include <QtCore/QWaitCondition>
 #include <QtCore/QMutex>

--- a/libraries/recording/src/recording/ClipCache.h
+++ b/libraries/recording/src/recording/ClipCache.h
@@ -9,6 +9,8 @@
 #ifndef hifi_Recording_ClipCache_h
 #define hifi_Recording_ClipCache_h
 
+#include <QtCore/QSharedPointer>
+
 #include <ResourceCache.h>
 
 #include "Forward.h"

--- a/libraries/render-utils/src/FboCache.h
+++ b/libraries/render-utils/src/FboCache.h
@@ -15,7 +15,7 @@
 #include <QOffscreenSurface>
 #include <QQueue>
 #include <QMap>
-#include <QSharedPointer>
+#include <QtCore/QSharedPointer>
 #include <QMutex>
 
 class QOpenGLFramebufferObject;

--- a/libraries/script-engine/src/RecordingScriptingInterface.h
+++ b/libraries/script-engine/src/RecordingScriptingInterface.h
@@ -16,6 +16,7 @@
 #include <mutex>
 
 #include <QtCore/QObject>
+#include <QtCore/QSharedPointer>
 
 #include <BaseScriptEngine.h>
 #include <DependencyManager.h>

--- a/libraries/script-engine/src/ScriptEngine.h
+++ b/libraries/script-engine/src/ScriptEngine.h
@@ -22,6 +22,7 @@
 #include <QtCore/QObject>
 #include <QtCore/QUrl>
 #include <QtCore/QSet>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QWaitCondition>
 #include <QtCore/QStringList>
 #include <QMap>

--- a/libraries/script-engine/src/ScriptEngines.cpp
+++ b/libraries/script-engine/src/ScriptEngines.cpp
@@ -9,6 +9,7 @@
 #include "ScriptEngines.h"
 
 #include <QtCore/QStandardPaths>
+#include <QtCore/QSharedPointer>
 
 #include <QtWidgets/QApplication>
 

--- a/libraries/script-engine/src/ScriptEngines.h
+++ b/libraries/script-engine/src/ScriptEngines.h
@@ -19,6 +19,7 @@
 #include <QtCore/QObject>
 #include <QtCore/QMutex>
 #include <QtCore/QReadWriteLock>
+#include <QtCore/QUrl>
 
 #include <SettingHandle.h>
 #include <DependencyManager.h>

--- a/libraries/shared/src/BaseScriptEngine.h
+++ b/libraries/shared/src/BaseScriptEngine.h
@@ -14,6 +14,7 @@
 
 #include <functional>
 #include <QtCore/QDebug>
+#include <QtCore/QSharedPointer>
 #include <QtScript/QScriptEngine>
 
 class ScriptEngine;

--- a/libraries/shared/src/DependencyManager.h
+++ b/libraries/shared/src/DependencyManager.h
@@ -15,7 +15,7 @@
 #include <QtGlobal>
 #include <QDebug>
 #include <QHash>
-#include <QSharedPointer>
+#include <QtCore/QSharedPointer>
 #include <QWeakPointer>
 #include <QMutex>
 

--- a/libraries/shared/src/SettingHandle.h
+++ b/libraries/shared/src/SettingHandle.h
@@ -18,6 +18,7 @@
 #include <QtCore/QString>
 #include <QtCore/QVariant>
 #include <QtCore/QReadWriteLock>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QDebug>
 
 #include <glm/glm.hpp>

--- a/libraries/shared/src/SpatiallyNestable.cpp
+++ b/libraries/shared/src/SpatiallyNestable.cpp
@@ -11,6 +11,8 @@
 
 #include "SpatiallyNestable.h"
 
+#include <QtCore/QSharedPointer>
+
 #include <queue>
 
 #include "DependencyManager.h"

--- a/libraries/shared/src/shared/ScriptInitializerMixin.h
+++ b/libraries/shared/src/shared/ScriptInitializerMixin.h
@@ -10,7 +10,6 @@
 
 #include <functional>
 #include <mutex>
-#include <QSharedPointer>
 #include "../DependencyManager.h"
 
 class QScriptEngine;

--- a/libraries/ui/src/CursorManager.cpp
+++ b/libraries/ui/src/CursorManager.cpp
@@ -9,6 +9,7 @@
 #include "CursorManager.h"
 
 #include <QCursor>
+#include <QtCore/QSharedPointer>
 #include <QWidget>
 #include <QUrl>
 

--- a/libraries/ui/src/DesktopPreviewProvider.h
+++ b/libraries/ui/src/DesktopPreviewProvider.h
@@ -8,6 +8,7 @@
 
 #include <DependencyManager.h>
 #include <QImage>
+#include <QtCore/QSharedPointer>
 
 class DesktopPreviewProvider : public QObject, public Dependency {
     SINGLETON_DEPENDENCY

--- a/libraries/ui/src/VirtualPadManager.cpp
+++ b/libraries/ui/src/VirtualPadManager.cpp
@@ -7,6 +7,7 @@
 //
 
 #include "VirtualPadManager.h"
+#include <QtCore/QSharedPointer>
 
 namespace VirtualPad {
 

--- a/libraries/ui/src/ui/OffscreenQmlSurface.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurface.cpp
@@ -24,6 +24,7 @@
 #include <QtQuick/QQuickRenderControl>
 #include <QtCore/QThread>
 #include <QtCore/QMutex>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QWaitCondition>
 #include <QtMultimedia/QMediaService>
 #include <QtMultimedia/QAudioOutputSelectorControl>

--- a/libraries/ui/src/ui/TabletScriptingInterface.h
+++ b/libraries/ui/src/ui/TabletScriptingInterface.h
@@ -13,6 +13,7 @@
 #include <atomic>
 
 #include <QtCore/QObject>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QUuid>
 #include <QtCore/QVariant>
 #include <QtCore/QAbstractListModel>

--- a/libraries/ui/src/ui/types/ContextAwareProfile.h
+++ b/libraries/ui/src/ui/types/ContextAwareProfile.h
@@ -15,7 +15,6 @@
 #include <QtCore/QHash>
 #include <QtCore/QReadWriteLock>
 #include <QtCore/QSet>
-#include <QtCore/QSharedPointer>
 
 #if !defined(Q_OS_ANDROID)
 #include <QtWebEngine/QQuickWebEngineProfile>

--- a/plugins/JSAPIExample/src/JSAPIExample.cpp
+++ b/plugins/JSAPIExample/src/JSAPIExample.cpp
@@ -14,6 +14,7 @@
 #include <QtCore/QByteArray>
 #include <QtCore/QDir>
 #include <QtCore/QFileInfo>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QJsonObject>
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QThread>

--- a/tools/gpu-frame-player/src/main.cpp
+++ b/tools/gpu-frame-player/src/main.cpp
@@ -7,6 +7,7 @@
 //
 
 #include <QtWidgets/QApplication>
+#include <QtCore/QSharedPointer>
 
 #include <shared/FileLogger.h>
 #include "PlayerWindow.h"

--- a/tools/ice-client/src/ICEClientApp.cpp
+++ b/tools/ice-client/src/ICEClientApp.cpp
@@ -15,6 +15,7 @@
 #include <QDataStream>
 #include <QLoggingCategory>
 #include <QCommandLineParser>
+#include <QtCore/QSharedPointer>
 
 #include <PathUtils.h>
 #include <LimitedNodeList.h>

--- a/tools/oven/src/DomainBaker.h
+++ b/tools/oven/src/DomainBaker.h
@@ -15,6 +15,7 @@
 #include <QtCore/QJsonDocument>
 #include <QtCore/QJsonArray>
 #include <QtCore/QObject>
+#include <QtCore/QSharedPointer>
 #include <QtCore/QUrl>
 #include <QtCore/QThread>
 


### PR DESCRIPTION
This code review removes #includes for files that don't actually make use of QSharedPointer and adds them where they do.

This strengthens the codebase by:
- removing references to unused libraries
- removing indirect references to QSharedPointer that may be broken on removal of an "unrelated" .h file (or removal of QSharedPointer from that .h file)

(This code review sprouted out of one of the last review checks done before flagging PR 1200 as ready-to-review, the results were unrelated enough to the script engine that I figured it might be worth its own PR)

Testing focus:
* NONE - I don't see any possible effects on the code from this change, this is strictly a compile-time and code-review/coding-style adjustment.