### PR TITLE
Housekeeping: use of std::make_shared / QSharedPointer::create.

### DIFF
--- a/assignment-client/src/AssignmentDynamicFactory.cpp
+++ b/assignment-client/src/AssignmentDynamicFactory.cpp
@@ -13,7 +13,7 @@
 
 
 EntityDynamicPointer assignmentDynamicFactory(EntityDynamicType type, const QUuid& id, EntityItemPointer ownerEntity) {
-    return EntityDynamicPointer(new AssignmentDynamic(type, id, ownerEntity));
+    return std::make_shared<AssignmentDynamic>(type, id, ownerEntity);
 }
 
 EntityDynamicPointer AssignmentDynamicFactory::factory(EntityDynamicType type,

--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -94,7 +94,7 @@ std::unique_ptr<OctreeQueryNode> EntityServer::createOctreeQueryNode() {
 }
 
 OctreePointer EntityServer::createTree() {
-    EntityTreePointer tree = EntityTreePointer(new EntityTree(true));
+    EntityTreePointer tree = std::make_shared<EntityTree>(true);
     tree->createRootElement();
     tree->addNewlyCreatedHook(this);
     if (!_entitySimulation) {

--- a/assignment-client/src/entities/EntityTreeHeadlessViewer.h
+++ b/assignment-client/src/entities/EntityTreeHeadlessViewer.h
@@ -54,7 +54,7 @@ public:
 
 protected:
     virtual OctreePointer createTree() override {
-        EntityTreePointer newTree = EntityTreePointer(new EntityTree(true));
+        EntityTreePointer newTree = std::make_shared<EntityTree>(true);
         newTree->createRootElement();
         return newTree;
     }

--- a/domain-server/src/DomainServerSettingsManager.cpp
+++ b/domain-server/src/DomainServerSettingsManager.cpp
@@ -834,7 +834,7 @@ bool DomainServerSettingsManager::ensurePermissionsForGroupRanks() {
             if (_groupPermissions.contains(nameKey)) {
                 perms = _groupPermissions[nameKey];
             } else {
-                perms = NodePermissionsPointer(new NodePermissions(nameKey));
+                perms = std::make_shared<NodePermissions>(nameKey);
                 _groupPermissions[nameKey] = perms;
                 changed = true;
             }
@@ -861,7 +861,7 @@ bool DomainServerSettingsManager::ensurePermissionsForGroupRanks() {
             if (_groupForbiddens.contains(nameKey)) {
                 perms = _groupForbiddens[nameKey];
             } else {
-                perms = NodePermissionsPointer(new NodePermissions(nameKey));
+                perms = std::make_shared<NodePermissions>(nameKey);
                 _groupForbiddens[nameKey] = perms;
                 changed = true;
             }

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -1033,9 +1033,9 @@ Application::Application(int& argc, char** argv, QElapsedTimer& startupTimer, bo
     _logger(new FileLogger(this)),
 #endif
     _previousSessionCrashed(setupEssentials(argc, argv, runningMarkerExisted)),
-    _entitySimulation(new PhysicalEntitySimulation()),
-    _physicsEngine(new PhysicsEngine(Vectors::ZERO)),
-    _entityClipboard(new EntityTree()),
+    _entitySimulation(std::make_shared<PhysicalEntitySimulation>()),
+    _physicsEngine(std::make_shared<PhysicsEngine>(Vectors::ZERO)),
+    _entityClipboard(std::make_shared<EntityTree>()),
     _previousScriptLocation("LastScriptLocation", DESKTOP_LOCATION),
     _fieldOfView("fieldOfView", DEFAULT_FIELD_OF_VIEW_DEGREES),
     _hmdTabletScale("hmdTabletScale", DEFAULT_HMD_TABLET_SCALE_PERCENT),

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -4155,7 +4155,7 @@ std::map<QString, QString> Application::prepareServerlessDomainContents(QUrl dom
     nodeList->setPermissions(permissions);
 
     // FIXME: Lock the main tree and import directly into it.
-    EntityTreePointer tmpTree(new EntityTree());
+    EntityTreePointer tmpTree(std::make_shared<EntityTree>());
     tmpTree->setIsServerlessMode(true);
     tmpTree->createRootElement();
     auto myAvatar = getMyAvatar();

--- a/interface/src/raypick/ParabolaPointer.cpp
+++ b/interface/src/raypick/ParabolaPointer.cpp
@@ -414,7 +414,7 @@ gpu::PipelinePointer ParabolaPointer::RenderState::ParabolaRenderItem::getParabo
         };
 
         for (auto& key : keys) {
-            gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+            gpu::StatePointer state = std::make_shared<gpu::State>();
             state->setDepthTest(true, !std::get<0>(key), gpu::LESS_EQUAL);
             if (std::get<0>(key)) {
                 PrepareStencil::testMask(*state);

--- a/interface/src/ui/overlays/Overlays.cpp
+++ b/interface/src/ui/overlays/Overlays.cpp
@@ -786,11 +786,11 @@ QUuid Overlays::addOverlay(const QString& type, const QVariant& properties) {
 
         Overlay::Pointer overlay;
         if (type == ImageOverlay::TYPE) {
-            overlay = Overlay::Pointer(new ImageOverlay(), [](Overlay* ptr) { ptr->deleteLater(); });
+            overlay = std::shared_ptr<ImageOverlay>(new ImageOverlay(), [](ImageOverlay* ptr) { ptr->deleteLater(); });
         } else if (type == TextOverlay::TYPE) {
-            overlay = Overlay::Pointer(new TextOverlay(), [](Overlay* ptr) { ptr->deleteLater(); });
+            overlay = std::shared_ptr<TextOverlay>(new TextOverlay(), [](TextOverlay* ptr) { ptr->deleteLater(); });
         } else if (type == RectangleOverlay::TYPE) {
-            overlay = Overlay::Pointer(new RectangleOverlay(), [](Overlay* ptr) { ptr->deleteLater(); });
+            overlay = std::shared_ptr<RectangleOverlay>(new RectangleOverlay(), [](RectangleOverlay* ptr) { ptr->deleteLater(); });
         }
         if (overlay) {
             overlay->setProperties(properties.toMap());

--- a/libraries/animation/src/AnimationCache.cpp
+++ b/libraries/animation/src/AnimationCache.cpp
@@ -37,11 +37,11 @@ AnimationPointer AnimationCache::getAnimation(const QUrl& url) {
 }
 
 QSharedPointer<Resource> AnimationCache::createResource(const QUrl& url) {
-    return QSharedPointer<Resource>(new Animation(url), &Resource::deleter);
+    return QSharedPointer<Animation>(new Animation(url), &Resource::deleter);
 }
 
 QSharedPointer<Resource> AnimationCache::createResourceCopy(const QSharedPointer<Resource>& resource) {
-    return QSharedPointer<Resource>(new Animation(*resource.staticCast<Animation>()), &Resource::deleter);
+    return QSharedPointer<Animation>(new Animation(*resource.staticCast<Animation>()), &Resource::deleter);
 }
 
 AnimationReader::AnimationReader(const QUrl& url, const QByteArray& data) :

--- a/libraries/audio/src/SoundCache.cpp
+++ b/libraries/audio/src/SoundCache.cpp
@@ -34,11 +34,11 @@ SharedSoundPointer SoundCache::getSound(const QUrl& url) {
 }
 
 QSharedPointer<Resource> SoundCache::createResource(const QUrl& url) {
-    auto resource = QSharedPointer<Resource>(new Sound(url), &Resource::deleter);
+    auto resource = QSharedPointer<Sound>(new Sound(url), &Resource::deleter);
     resource->setLoadPriority(this, SOUNDS_LOADING_PRIORITY);
     return resource;
 }
 
 QSharedPointer<Resource> SoundCache::createResourceCopy(const QSharedPointer<Resource>& resource) {
-    return QSharedPointer<Resource>(new Sound(*resource.staticCast<Sound>()), &Resource::deleter);
+    return QSharedPointer<Sound>(new Sound(*resource.staticCast<Sound>()), &Resource::deleter);
 }

--- a/libraries/baking/src/MaterialBaker.cpp
+++ b/libraries/baking/src/MaterialBaker.cpp
@@ -67,7 +67,7 @@ void MaterialBaker::loadMaterial() {
     if (!_isURL) {
         qCDebug(material_baking) << "Loading local material" << _materialData;
 
-        _materialResource = NetworkMaterialResourcePointer(new NetworkMaterialResource());
+        _materialResource = QSharedPointer<NetworkMaterialResource>::create();
         // TODO: add baseURL to allow these to reference relative files next to them
         _materialResource->parsedMaterials = NetworkMaterialResource::parseJSONMaterials(QJsonDocument::fromJson(_materialData.toUtf8()), QUrl());
     } else {

--- a/libraries/controllers/src/controllers/impl/MappingBuilderProxy.cpp
+++ b/libraries/controllers/src/controllers/impl/MappingBuilderProxy.cpp
@@ -34,7 +34,7 @@ QObject* MappingBuilderProxy::from(const QScriptValue& source) {
 
 QObject* MappingBuilderProxy::from(const Endpoint::Pointer& source) {
     if (source) {
-        auto route = Route::Pointer(new Route());
+        auto route = std::make_shared<Route>();
         route->source = source;
         return new RouteBuilderProxy(_parent, _mapping, route);
     } else {

--- a/libraries/controllers/src/controllers/impl/RouteBuilderProxy.cpp
+++ b/libraries/controllers/src/controllers/impl/RouteBuilderProxy.cpp
@@ -70,7 +70,7 @@ QObject* RouteBuilderProxy::when(const QScriptValue& expression) {
     // Note that "!" is supported when parsing a JSON file, in UserInputMapper::parseConditional().
     auto newConditional = _parent.conditionalFor(expression);
     if (_route->conditional) {
-        _route->conditional = ConditionalPointer(new AndConditional(_route->conditional, newConditional));
+        _route->conditional = std::make_shared<AndConditional>(_route->conditional, newConditional);
     } else {
         _route->conditional = newConditional;
     }
@@ -80,7 +80,7 @@ QObject* RouteBuilderProxy::when(const QScriptValue& expression) {
 QObject* RouteBuilderProxy::whenQml(const QJSValue& expression) {
     auto newConditional = _parent.conditionalFor(expression);
     if (_route->conditional) {
-        _route->conditional = ConditionalPointer(new AndConditional(_route->conditional, newConditional));
+        _route->conditional = std::make_shared<AndConditional>(_route->conditional, newConditional);
     } else {
         _route->conditional = newConditional;
     }

--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -382,7 +382,7 @@ void OpenGLDisplayPlugin::customizeContext() {
     }
 
     if (!_linearToSRGBPipeline) {
-        gpu::StatePointer blendState = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer blendState = std::make_shared<gpu::State>();
         blendState->setDepthTest(gpu::State::DepthTest(false));
         blendState->setBlendFunction(true,
                                      gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD,
@@ -390,7 +390,7 @@ void OpenGLDisplayPlugin::customizeContext() {
                                      gpu::State::FACTOR_ALPHA, gpu::State::BLEND_OP_ADD,
                                      gpu::State::ONE);
 
-        gpu::StatePointer scissorState = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer scissorState = std::make_shared<gpu::State>();
         scissorState->setDepthTest(gpu::State::DepthTest(false));
         scissorState->setScissorEnable(true);
 

--- a/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/hmd/HmdDisplayPlugin.cpp
@@ -419,7 +419,7 @@ void HmdDisplayPlugin::HUDRenderer::build() {
     uniformsBuffer = std::make_shared<gpu::Buffer>(sizeof(Uniforms), nullptr);
 
     auto program = gpu::Shader::createProgram(shader::render_utils::program::hmd_ui);
-    gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+    gpu::StatePointer state = std::make_shared<gpu::State>();
     state->setDepthTest(gpu::State::DepthTest(true, true, gpu::LESS_EQUAL));
     state->setBlendFunction(true,
                             gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,

--- a/libraries/display-plugins/src/display-plugins/stereo/InterleavedStereoDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/stereo/InterleavedStereoDisplayPlugin.cpp
@@ -19,7 +19,7 @@ void InterleavedStereoDisplayPlugin::customizeContext() {
     StereoDisplayPlugin::customizeContext();
     if (!_interleavedPresentPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::display_plugins::program::InterleavedSrgbToLinear);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
         state->setDepthTest(gpu::State::DepthTest(false));
         _interleavedPresentPipeline = gpu::Pipeline::create(program, state);
     }

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -162,7 +162,7 @@ public slots:
 
 protected:
     virtual OctreePointer createTree() override {
-        EntityTreePointer newTree = EntityTreePointer(new EntityTree(true));
+        EntityTreePointer newTree = std::make_shared<EntityTree>(true);
         newTree->createRootElement();
         return newTree;
     }

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -52,8 +52,8 @@ ModelPointer ModelEntityWrapper::getModel() const {
 }
 
 EntityItemPointer RenderableModelEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    EntityItemPointer entity(new RenderableModelEntityItem(entityID, properties.getDimensionsInitialized()),
-                             [](EntityItem* ptr) { ptr->deleteLater(); });
+    std::shared_ptr<RenderableModelEntityItem> entity(new RenderableModelEntityItem(entityID, properties.getDimensionsInitialized()),
+                             [](RenderableModelEntityItem* ptr) { ptr->deleteLater(); });
     
     entity->setProperties(properties);
 

--- a/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyLineEntityItem.cpp
@@ -79,7 +79,7 @@ void PolyLineEntityRenderer::buildPipelines() {
             program = gpu::Shader::createProgram(shader::entities_renderer::program::paintStroke_forward);
         }
 
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         state->setCullMode(gpu::State::CullMode::CULL_NONE);
         state->setDepthTest(true, !transparent, gpu::LESS_EQUAL);

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -1288,7 +1288,7 @@ void RenderablePolyVoxEntityItem::recomputeMesh() {
     auto entity = std::static_pointer_cast<RenderablePolyVoxEntityItem>(getThisPointer());
 
     QtConcurrent::run([entity, voxelSurfaceStyle] {
-        graphics::MeshPointer mesh(new graphics::Mesh());
+        graphics::MeshPointer mesh(std::make_shared<graphics::Mesh>());
 
         // A mesh object to hold the result of surface extraction
         PolyVox::SurfaceMesh<PolyVox::PositionMaterialNormal> polyVoxMesh;

--- a/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderablePolyVoxEntityItem.cpp
@@ -163,7 +163,8 @@ void loop3(const T& start, const T& end, F f) {
 }
 
 EntityItemPointer RenderablePolyVoxEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    std::shared_ptr<RenderablePolyVoxEntityItem> entity(new RenderablePolyVoxEntityItem(entityID), [](EntityItem* ptr) { ptr->deleteLater(); });
+    std::shared_ptr<RenderablePolyVoxEntityItem> entity(new RenderablePolyVoxEntityItem(entityID),
+                                                        [](RenderablePolyVoxEntityItem* ptr) { ptr->deleteLater(); });
     entity->setProperties(properties);
     entity->initializePolyVox();
     return entity;

--- a/libraries/entities/src/GizmoEntityItem.cpp
+++ b/libraries/entities/src/GizmoEntityItem.cpp
@@ -13,7 +13,7 @@
 #include <qmath.h>
 
 EntityItemPointer GizmoEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    Pointer entity(new GizmoEntityItem(entityID), [](EntityItem* ptr) { ptr->deleteLater(); });
+    Pointer entity(new GizmoEntityItem(entityID), [](GizmoEntityItem* ptr) { ptr->deleteLater(); });
     entity->setProperties(properties);
     return entity;
 }

--- a/libraries/entities/src/GridEntityItem.cpp
+++ b/libraries/entities/src/GridEntityItem.cpp
@@ -14,7 +14,7 @@ const uint32_t GridEntityItem::DEFAULT_MAJOR_GRID_EVERY = 5;
 const float GridEntityItem::DEFAULT_MINOR_GRID_EVERY = 1.0f;
 
 EntityItemPointer GridEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    Pointer entity(new GridEntityItem(entityID), [](EntityItem* ptr) { ptr->deleteLater(); });
+    Pointer entity(new GridEntityItem(entityID), [](GridEntityItem* ptr) { ptr->deleteLater(); });
     entity->setProperties(properties);
     return entity;
 }

--- a/libraries/entities/src/ImageEntityItem.cpp
+++ b/libraries/entities/src/ImageEntityItem.cpp
@@ -11,7 +11,7 @@
 #include "EntityItemProperties.h"
 
 EntityItemPointer ImageEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    Pointer entity(new ImageEntityItem(entityID), [](EntityItem* ptr) { ptr->deleteLater(); });
+    Pointer entity(new ImageEntityItem(entityID), [](ImageEntityItem* ptr) { ptr->deleteLater(); });
     entity->setProperties(properties);
     return entity;
 }

--- a/libraries/entities/src/LightEntityItem.cpp
+++ b/libraries/entities/src/LightEntityItem.cpp
@@ -32,7 +32,7 @@ const float LightEntityItem::DEFAULT_CUTOFF = PI / 2.0f;
 bool LightEntityItem::_lightsArePickable = false;
 
 EntityItemPointer LightEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    EntityItemPointer entity(new LightEntityItem(entityID), [](EntityItem* ptr) { ptr->deleteLater(); });
+    std::shared_ptr<LightEntityItem> entity(new LightEntityItem(entityID), [](LightEntityItem* ptr) { ptr->deleteLater(); });
     entity->setProperties(properties);
     return entity;
 }

--- a/libraries/entities/src/LineEntityItem.cpp
+++ b/libraries/entities/src/LineEntityItem.cpp
@@ -24,7 +24,7 @@
 const int LineEntityItem::MAX_POINTS_PER_LINE = 70;
 
 EntityItemPointer LineEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    EntityItemPointer entity(new LineEntityItem(entityID), [](EntityItem* ptr) { ptr->deleteLater(); });
+    std::shared_ptr<LineEntityItem> entity(new LineEntityItem(entityID), [](LineEntityItem* ptr) { ptr->deleteLater(); });
     entity->setProperties(properties);
     return entity;
 }

--- a/libraries/entities/src/MaterialEntityItem.cpp
+++ b/libraries/entities/src/MaterialEntityItem.cpp
@@ -14,7 +14,7 @@
 #include "QJsonArray"
 
 EntityItemPointer MaterialEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    Pointer entity(new MaterialEntityItem(entityID), [](EntityItem* ptr) { ptr->deleteLater(); });
+    Pointer entity(new MaterialEntityItem(entityID), [](MaterialEntityItem* ptr) { ptr->deleteLater(); });
     entity->setProperties(properties);
     return entity;
 }

--- a/libraries/entities/src/ModelEntityItem.cpp
+++ b/libraries/entities/src/ModelEntityItem.cpp
@@ -28,7 +28,7 @@ const QString ModelEntityItem::DEFAULT_MODEL_URL = QString("");
 const QString ModelEntityItem::DEFAULT_COMPOUND_SHAPE_URL = QString("");
 
 EntityItemPointer ModelEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    EntityItemPointer entity(new ModelEntityItem(entityID), [](EntityItem* ptr) { ptr->deleteLater(); });
+    std::shared_ptr<ModelEntityItem> entity(new ModelEntityItem(entityID), [](ModelEntityItem* ptr) { ptr->deleteLater(); });
     entity->setProperties(properties);
     return entity;
 }

--- a/libraries/entities/src/ParticleEffectEntityItem.cpp
+++ b/libraries/entities/src/ParticleEffectEntityItem.cpp
@@ -153,7 +153,7 @@ uint64_t Properties::emitIntervalUsecs() const {
 }
 
 EntityItemPointer ParticleEffectEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    EntityItemPointer entity(new ParticleEffectEntityItem(entityID), [](EntityItem* ptr) { ptr->deleteLater(); });
+    std::shared_ptr<ParticleEffectEntityItem> entity(new ParticleEffectEntityItem(entityID), [](ParticleEffectEntityItem* ptr) { ptr->deleteLater(); });
     entity->setProperties(properties);
     return entity;
 }

--- a/libraries/entities/src/PolyLineEntityItem.cpp
+++ b/libraries/entities/src/PolyLineEntityItem.cpp
@@ -26,7 +26,7 @@ const float PolyLineEntityItem::DEFAULT_LINE_WIDTH = 0.1f;
 const int PolyLineEntityItem::MAX_POINTS_PER_LINE = 60;
 
 EntityItemPointer PolyLineEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    EntityItemPointer entity(new PolyLineEntityItem(entityID), [](EntityItem* ptr) { ptr->deleteLater(); });
+    std::shared_ptr<PolyLineEntityItem> entity(new PolyLineEntityItem(entityID), [](PolyLineEntityItem* ptr) { ptr->deleteLater(); });
     entity->setProperties(properties);
     return entity;
 }

--- a/libraries/entities/src/PolyVoxEntityItem.cpp
+++ b/libraries/entities/src/PolyVoxEntityItem.cpp
@@ -47,7 +47,7 @@ const QString PolyVoxEntityItem::DEFAULT_Y_TEXTURE_URL = QString("");
 const QString PolyVoxEntityItem::DEFAULT_Z_TEXTURE_URL = QString("");
 
 EntityItemPointer PolyVoxEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    EntityItemPointer entity(new PolyVoxEntityItem(entityID), [](EntityItem* ptr) { ptr->deleteLater(); });
+    std::shared_ptr<PolyVoxEntityItem> entity(new PolyVoxEntityItem(entityID), [](PolyVoxEntityItem* ptr) { ptr->deleteLater(); });
     entity->setProperties(properties);
     return entity;
 }

--- a/libraries/entities/src/ShapeEntityItem.cpp
+++ b/libraries/entities/src/ShapeEntityItem.cpp
@@ -87,7 +87,7 @@ void ShapeEntityItem::setShapeInfoCalulator(ShapeEntityItem::ShapeInfoCalculator
 }
 
 ShapeEntityItem::Pointer ShapeEntityItem::baseFactory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    Pointer entity(new ShapeEntityItem(entityID), [](EntityItem* ptr) { ptr->deleteLater(); });
+    Pointer entity(new ShapeEntityItem(entityID), [](ShapeEntityItem* ptr) { ptr->deleteLater(); });
     entity->setProperties(properties);
     return entity;
 }

--- a/libraries/entities/src/TextEntityItem.cpp
+++ b/libraries/entities/src/TextEntityItem.cpp
@@ -32,7 +32,7 @@ const float TextEntityItem::DEFAULT_MARGIN = 0.0f;
 const float TextEntityItem::DEFAULT_TEXT_EFFECT_THICKNESS = 0.2f;
 
 EntityItemPointer TextEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    EntityItemPointer entity(new TextEntityItem(entityID), [](EntityItem* ptr) { ptr->deleteLater(); });
+    std::shared_ptr<TextEntityItem> entity(new TextEntityItem(entityID), [](TextEntityItem* ptr) { ptr->deleteLater(); });
     entity->setProperties(properties);
     return entity;
 }

--- a/libraries/entities/src/WebEntityItem.cpp
+++ b/libraries/entities/src/WebEntityItem.cpp
@@ -29,7 +29,7 @@ const QString WebEntityItem::DEFAULT_USER_AGENT = NetworkingConstants::WEB_ENTIT
 const uint8_t WebEntityItem::DEFAULT_MAX_FPS = 10;
 
 EntityItemPointer WebEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    EntityItemPointer entity(new WebEntityItem(entityID), [](EntityItem* ptr) { ptr->deleteLater(); });
+    std::shared_ptr<WebEntityItem> entity(new WebEntityItem(entityID), [](WebEntityItem* ptr) { ptr->deleteLater(); });
     entity->setProperties(properties);
     return entity;
 }

--- a/libraries/entities/src/ZoneEntityItem.cpp
+++ b/libraries/entities/src/ZoneEntityItem.cpp
@@ -33,7 +33,7 @@ const bool ZoneEntityItem::DEFAULT_GHOSTING_ALLOWED = true;
 const QString ZoneEntityItem::DEFAULT_FILTER_URL = "";
 
 EntityItemPointer ZoneEntityItem::factory(const EntityItemID& entityID, const EntityItemProperties& properties) {
-    EntityItemPointer entity(new ZoneEntityItem(entityID), [](EntityItem* ptr) { ptr->deleteLater(); });
+    std::shared_ptr<ZoneEntityItem> entity(new ZoneEntityItem(entityID), [](ZoneEntityItem* ptr) { ptr->deleteLater(); });
     entity->setProperties(properties);
     return entity;
 }

--- a/libraries/gpu/src/gpu/Context.cpp
+++ b/libraries/gpu/src/gpu/Context.cpp
@@ -347,7 +347,7 @@ Size Context::getTextureResourcePopulatedGPUMemSize() {
 
 PipelinePointer Context::createMipGenerationPipeline(const ShaderPointer& ps) {
     auto vs = gpu::Shader::createVertex(shader::gpu::vertex::DrawViewportQuadTransformTexcoord);
-	static gpu::StatePointer state(new gpu::State());
+	static gpu::StatePointer state(std::make_shared<gpu::State>());
 
 	gpu::ShaderPointer program = gpu::Shader::createProgram(vs, ps);
 

--- a/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.cpp
+++ b/libraries/graphics-scripting/src/graphics-scripting/GraphicsScriptingInterface.cpp
@@ -237,7 +237,7 @@ scriptable::ScriptableMeshPointer GraphicsScriptingInterface::newMesh(const QVar
         qCWarning(graphics_scripting) << "newMesh - texCoords1 not yet supported; ignoring";
     }
 
-    graphics::MeshPointer mesh(new graphics::Mesh());
+    graphics::MeshPointer mesh(std::make_shared<graphics::Mesh>());
     mesh->modelName = "graphics::newMesh";
     mesh->displayName = meshName.toStdString();
 

--- a/libraries/graphics/src/graphics/Geometry.cpp
+++ b/libraries/graphics/src/graphics/Geometry.cpp
@@ -235,7 +235,7 @@ graphics::MeshPointer Mesh::map(std::function<glm::vec3(glm::vec3)> vertexFunc,
         indexDataCursor += sizeof(index);
     }
 
-    graphics::MeshPointer result(new graphics::Mesh());
+    graphics::MeshPointer result(std::make_shared<graphics::Mesh>());
     result->displayName = displayName;
 
     gpu::Element vertexElement = gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ);

--- a/libraries/material-networking/src/material-networking/ShaderCache.cpp
+++ b/libraries/material-networking/src/material-networking/ShaderCache.cpp
@@ -25,9 +25,9 @@ NetworkShaderPointer ShaderCache::getShader(const QUrl& url) {
 }
 
 QSharedPointer<Resource> ShaderCache::createResource(const QUrl& url) {
-    return QSharedPointer<Resource>(new NetworkShader(url), &Resource::deleter);
+    return QSharedPointer<NetworkShader>(new NetworkShader(url), &Resource::deleter);
 }
 
 QSharedPointer<Resource> ShaderCache::createResourceCopy(const QSharedPointer<Resource>& resource) {
-    return QSharedPointer<Resource>(new NetworkShader(*resource.staticCast<NetworkShader>()), &Resource::deleter);
+    return QSharedPointer<NetworkShader>(new NetworkShader(*resource.staticCast<NetworkShader>()), &Resource::deleter);
 }

--- a/libraries/material-networking/src/material-networking/TextureCache.cpp
+++ b/libraries/material-networking/src/material-networking/TextureCache.cpp
@@ -366,11 +366,11 @@ gpu::TexturePointer TextureCache::getImageTexture(const QString& path, image::Te
 }
 
 QSharedPointer<Resource> TextureCache::createResource(const QUrl& url) {
-    return QSharedPointer<Resource>(new NetworkTexture(url), &Resource::deleter);
+    return QSharedPointer<NetworkTexture>(new NetworkTexture(url), &Resource::deleter);
 }
 
 QSharedPointer<Resource> TextureCache::createResourceCopy(const QSharedPointer<Resource>& resource) {
-    return QSharedPointer<Resource>(new NetworkTexture(*resource.staticCast<NetworkTexture>()), &Resource::deleter);
+    return QSharedPointer<NetworkTexture>(new NetworkTexture(*resource.staticCast<NetworkTexture>()), &Resource::deleter);
 }
 
 int networkTexturePointerMetaTypeId = qRegisterMetaType<QWeakPointer<NetworkTexture>>();
@@ -1390,7 +1390,7 @@ NetworkTexturePointer TextureCache::getTextureByUUID(const QString& uuid) {
     if (!quuid.isNull()) {
         // We mark this as a resource texture because it's just a reference to another texture.  The source
         // texture will be marked properly
-        NetworkTexturePointer toReturn = NetworkTexturePointer(new NetworkTexture(uuid, true));
+        NetworkTexturePointer toReturn = NetworkTexturePointer::create(uuid, true);
         toReturn->setImageOperator(Texture::getTextureForUUIDOperator(uuid));
         return toReturn;
     }

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -377,11 +377,11 @@ ModelCache::ModelCache() {
 }
 
 QSharedPointer<Resource> ModelCache::createResource(const QUrl& url) {
-    return QSharedPointer<Resource>(new GeometryResource(url, _modelLoader), &GeometryResource::deleter);
+    return QSharedPointer<GeometryResource>(new GeometryResource(url, _modelLoader), &GeometryResource::deleter);
 }
 
 QSharedPointer<Resource> ModelCache::createResourceCopy(const QSharedPointer<Resource>& resource) {
-    return QSharedPointer<Resource>(new GeometryResource(*resource.staticCast<GeometryResource>()), &GeometryResource::deleter);
+    return QSharedPointer<GeometryResource>(new GeometryResource(*resource.staticCast<GeometryResource>()), &GeometryResource::deleter);
 }
 
 GeometryResource::Pointer ModelCache::getGeometryResource(const QUrl& url, const GeometryMappingPair& mapping, const QUrl& textureBaseUrl) {

--- a/libraries/networking/src/NodePermissions.h
+++ b/libraries/networking/src/NodePermissions.h
@@ -119,7 +119,7 @@ public:
     NodePermissionsPointer& operator[](const NodePermissionsKey& key) {
         NodePermissionsKey dataKey(key.first.toLower(), key.second);
         if (0 == _data.count(dataKey)) {
-            _data[dataKey] = NodePermissionsPointer(new NodePermissions(key));
+            _data[dataKey] = std::make_shared<NodePermissions>(key);
         }
         return _data[dataKey];
     }

--- a/libraries/plugins/src/plugins/PluginManager.cpp
+++ b/libraries/plugins/src/plugins/PluginManager.cpp
@@ -124,7 +124,7 @@ int PluginManager::instantiate() {
 
             for (auto plugin : candidates) {
                 qCDebug(plugins) << "Attempting plugin" << qPrintable(plugin);
-                QSharedPointer<QPluginLoader> loader(new QPluginLoader(pluginPath + plugin));
+                auto loader = QSharedPointer<QPluginLoader>::create(pluginPath + plugin);
                 const QJsonObject pluginMetaData = loader->metaData();
 #if defined(HIFI_PLUGINMANAGER_DEBUG)
                 QJsonDocument metaDataDoc(pluginMetaData);

--- a/libraries/procedural/src/procedural/ProceduralMaterialCache.cpp
+++ b/libraries/procedural/src/procedural/ProceduralMaterialCache.cpp
@@ -581,11 +581,11 @@ NetworkMaterialResourcePointer MaterialCache::getMaterial(const QUrl& url) {
 }
 
 QSharedPointer<Resource> MaterialCache::createResource(const QUrl& url) {
-    return QSharedPointer<Resource>(new NetworkMaterialResource(url), &Resource::deleter);
+    return QSharedPointer<NetworkMaterialResource>(new NetworkMaterialResource(url), &Resource::deleter);
 }
 
 QSharedPointer<Resource> MaterialCache::createResourceCopy(const QSharedPointer<Resource>& resource) {
-    return QSharedPointer<Resource>(new NetworkMaterialResource(*resource.staticCast<NetworkMaterialResource>()), &Resource::deleter);
+    return QSharedPointer<NetworkMaterialResource>(new NetworkMaterialResource(*resource.staticCast<NetworkMaterialResource>()), &Resource::deleter);
 }
 
 NetworkMaterial::NetworkMaterial(const NetworkMaterial& m) :

--- a/libraries/recording/src/recording/ClipCache.cpp
+++ b/libraries/recording/src/recording/ClipCache.cpp
@@ -56,9 +56,9 @@ NetworkClipLoaderPointer ClipCache::getClipLoader(const QUrl& url) {
 
 QSharedPointer<Resource> ClipCache::createResource(const QUrl& url) {
     qCDebug(recordingLog) << "Loading recording at" << url;
-    return QSharedPointer<Resource>(new NetworkClipLoader(url), &Resource::deleter);
+    return QSharedPointer<NetworkClipLoader>(new NetworkClipLoader(url), &Resource::deleter);
 }
 
 QSharedPointer<Resource> ClipCache::createResourceCopy(const QSharedPointer<Resource>& resource) {
-    return QSharedPointer<Resource>(new NetworkClipLoader(*resource.staticCast<NetworkClipLoader>()), &Resource::deleter);
+    return QSharedPointer<NetworkClipLoader>(new NetworkClipLoader(*resource.staticCast<NetworkClipLoader>()), &Resource::deleter);
 }

--- a/libraries/render-utils/src/AmbientOcclusionEffect.cpp
+++ b/libraries/render-utils/src/AmbientOcclusionEffect.cpp
@@ -521,7 +521,7 @@ void AmbientOcclusionEffect::updateFramebufferSizes() {
 const gpu::PipelinePointer& AmbientOcclusionEffect::getOcclusionPipeline() {
     if (!_occlusionPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::ssao_makeOcclusion);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         state->setColorWriteMask(true, true, true, true);
 
@@ -534,7 +534,7 @@ const gpu::PipelinePointer& AmbientOcclusionEffect::getOcclusionPipeline() {
 const gpu::PipelinePointer& AmbientOcclusionEffect::getBilateralBlurPipeline() {
     if (!_bilateralBlurPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::ssao_bilateralBlur);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         state->setColorWriteMask(true, true, true, false);
         
@@ -554,7 +554,7 @@ const gpu::PipelinePointer& AmbientOcclusionEffect::getMipCreationPipeline() {
 const gpu::PipelinePointer& AmbientOcclusionEffect::getGatherPipeline() {
     if (!_gatherPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::ssao_gather);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         state->setColorWriteMask(true, true, true, true);
 
@@ -567,7 +567,7 @@ const gpu::PipelinePointer& AmbientOcclusionEffect::getGatherPipeline() {
 const gpu::PipelinePointer& AmbientOcclusionEffect::getBuildNormalsPipeline() {
     if (!_buildNormalsPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::ssao_buildNormals);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         state->setColorWriteMask(true, true, true, true);
 
@@ -847,7 +847,7 @@ void DebugAmbientOcclusion::configure(const Config& config) {
 const gpu::PipelinePointer& DebugAmbientOcclusion::getDebugPipeline() {
     if (!_debugPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::ssao_debugOcclusion);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         state->setColorWriteMask(true, true, true, false);
         state->setBlendFunction(true, gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA);

--- a/libraries/render-utils/src/AntialiasingEffect.cpp
+++ b/libraries/render-utils/src/AntialiasingEffect.cpp
@@ -54,7 +54,7 @@ Antialiasing::~Antialiasing() {
 const gpu::PipelinePointer& Antialiasing::getAntialiasingPipeline() {
     if (!_antialiasingPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::fxaa);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         state->setDepthTest(false, false, gpu::LESS_EQUAL);
         PrepareStencil::testNoAA(*state);
@@ -69,7 +69,7 @@ const gpu::PipelinePointer& Antialiasing::getAntialiasingPipeline() {
 const gpu::PipelinePointer& Antialiasing::getBlendPipeline() {
     if (!_blendPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::fxaa_blend);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
         state->setDepthTest(false, false, gpu::LESS_EQUAL);
         PrepareStencil::testNoAA(*state);
 
@@ -158,7 +158,7 @@ const gpu::PipelinePointer& Antialiasing::getAntialiasingPipeline(const render::
    
     if (!_antialiasingPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::taa);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
         
         PrepareStencil::testNoAA(*state);
 
@@ -172,7 +172,7 @@ const gpu::PipelinePointer& Antialiasing::getAntialiasingPipeline(const render::
 const gpu::PipelinePointer& Antialiasing::getBlendPipeline() {
     if (!_blendPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::fxaa_blend);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
         PrepareStencil::testNoAA(*state);
         // Good to go add the brand new pipeline
         _blendPipeline = gpu::Pipeline::create(program, state);
@@ -183,7 +183,7 @@ const gpu::PipelinePointer& Antialiasing::getBlendPipeline() {
 const gpu::PipelinePointer& Antialiasing::getDebugBlendPipeline() {
     if (!_debugBlendPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::taa_blend);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
         PrepareStencil::testNoAA(*state);
 
 

--- a/libraries/render-utils/src/BloomEffect.cpp
+++ b/libraries/render-utils/src/BloomEffect.cpp
@@ -68,7 +68,7 @@ void BloomThreshold::run(const render::RenderContextPointer& renderContext, cons
 
     if (!_pipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::bloomThreshold);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
         _pipeline = gpu::Pipeline::create(program, state);
     }
 
@@ -113,7 +113,7 @@ void BloomApply::run(const render::RenderContextPointer& renderContext, const In
 
     if (!_pipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::bloomApply);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
         state->setDepthTest(gpu::State::DepthTest(false, false));
         _pipeline = gpu::Pipeline::create(program, state);
     }
@@ -164,7 +164,7 @@ void BloomDraw::run(const render::RenderContextPointer& renderContext, const Inp
 
         if (!_pipeline) {
             gpu::ShaderPointer program = gpu::Shader::createProgram(shader::gpu::program::drawTransformUnitQuadTextureOpaque);
-            gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+            gpu::StatePointer state = std::make_shared<gpu::State>();
             state->setDepthTest(gpu::State::DepthTest(false, false));
             state->setBlendFunction(true, gpu::State::ONE, gpu::State::BLEND_OP_ADD, gpu::State::ONE,
                                     gpu::State::ZERO, gpu::State::BLEND_OP_ADD, gpu::State::ONE);
@@ -225,7 +225,7 @@ void DebugBloom::run(const render::RenderContextPointer& renderContext, const In
 
     if (!_pipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::gpu::program::drawTextureOpaqueTexcoordRect);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
         state->setDepthTest(gpu::State::DepthTest(false));
         _pipeline = gpu::Pipeline::create(program, state);
     }

--- a/libraries/render-utils/src/DrawHaze.cpp
+++ b/libraries/render-utils/src/DrawHaze.cpp
@@ -55,7 +55,7 @@ void DrawHaze::run(const render::RenderContextPointer& renderContext, const Inpu
 
     if (!_hazePipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::haze);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         state->setBlendFunction(true,
                                 gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA,

--- a/libraries/render-utils/src/GeometryCache.cpp
+++ b/libraries/render-utils/src/GeometryCache.cpp
@@ -2024,7 +2024,7 @@ void GeometryCache::useGridPipeline(gpu::Batch& batch, GridBuffer gridBuffer, bo
         };
 
         for (auto& key : keys) {
-            gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+            gpu::StatePointer state = std::make_shared<gpu::State>();
             state->setDepthTest(true, !std::get<0>(key), gpu::LESS_EQUAL);
             if (std::get<0>(key)) {
                 PrepareStencil::testMask(*state);
@@ -2132,7 +2132,7 @@ gpu::PipelinePointer GeometryCache::getWebBrowserProgram(bool transparent, bool 
             // For any non-opaque or non-deferred pipeline, we use web_browser_forward
             auto pipeline = (transparent || forward) ? web_browser_forward : web_browser;
 
-            gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+            gpu::StatePointer state = std::make_shared<gpu::State>();
             state->setDepthTest(true, !transparent, gpu::LESS_EQUAL);
             // FIXME: do we need a testMaskDrawNoAA?
             PrepareStencil::testMaskDrawShapeNoAA(*state);
@@ -2419,7 +2419,7 @@ graphics::MeshPointer GeometryCache::meshFromShape(Shape geometryShape, glm::vec
         colorsBufferView.edit<glm::vec3>((gpu::BufferView::Index)i) = color;
     }
 
-    graphics::MeshPointer mesh(new graphics::Mesh());
+    graphics::MeshPointer mesh(std::make_shared<graphics::Mesh>());
     mesh->setVertexBuffer(positionsBufferView);
     mesh->setIndexBuffer(indexBufferView);
     mesh->addAttribute(gpu::Stream::NORMAL, normalsBufferView);

--- a/libraries/render-utils/src/SubsurfaceScattering.cpp
+++ b/libraries/render-utils/src/SubsurfaceScattering.cpp
@@ -301,7 +301,7 @@ void diffuseProfileGPU(gpu::TexturePointer& profileMap, RenderArgs* args) {
     {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::subsurfaceScattering_makeProfile);
 
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         makePipeline = gpu::Pipeline::create(program, state);
     }
@@ -330,7 +330,7 @@ void diffuseScatterGPU(const gpu::TexturePointer& profileMap, gpu::TexturePointe
 
     gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::subsurfaceScattering_makeLUT);
 
-    gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+    gpu::StatePointer state = std::make_shared<gpu::State>();
 
     gpu::PipelinePointer makePipeline = gpu::Pipeline::create(program, state);
     
@@ -359,7 +359,7 @@ void computeSpecularBeckmannGPU(gpu::TexturePointer& beckmannMap, RenderArgs* ar
     {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::subsurfaceScattering_makeSpecularBeckmann);
 
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         makePipeline = gpu::Pipeline::create(program, state);
     }
@@ -432,7 +432,7 @@ void DebugSubsurfaceScattering::configure(const Config& config) {
 gpu::PipelinePointer DebugSubsurfaceScattering::getScatteringPipeline() {
     if (!_scatteringPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::subsurfaceScattering_drawScattering);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         _scatteringPipeline = gpu::Pipeline::create(program, state);
     }
@@ -445,7 +445,7 @@ gpu::PipelinePointer _showLUTPipeline;
 gpu::PipelinePointer DebugSubsurfaceScattering::getShowLUTPipeline() {
     if (!_showLUTPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::gpu::program::drawUnitQuatTextureOpaque);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
         _showLUTPipeline = gpu::Pipeline::create(program, state);
     }
 

--- a/libraries/render-utils/src/SurfaceGeometryPass.cpp
+++ b/libraries/render-utils/src/SurfaceGeometryPass.cpp
@@ -228,7 +228,7 @@ const gpu::PipelinePointer& LinearDepthPass::getLinearDepthPipeline(const render
     if (!_linearDepthPipeline) {
         program = gpu::Shader::createProgram(shader::render_utils::program::surfaceGeometry_makeLinearDepth);
 
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         // Stencil test the curvature pass for objects pixels only, not the background
         PrepareStencil::testShape(*state);
@@ -248,7 +248,7 @@ const gpu::PipelinePointer& LinearDepthPass::getDownsamplePipeline(const render:
     if (!_downsamplePipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::surfaceGeometry_downsampleDepthNormal);
 
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
         PrepareStencil::testShape(*state);
 
         state->setColorWriteMask(true, true, true, false);
@@ -536,7 +536,7 @@ const gpu::PipelinePointer& SurfaceGeometryPass::getCurvaturePipeline(const rend
     if (!_curvaturePipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::surfaceGeometry_makeCurvature);
 
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
 #ifdef USE_STENCIL_TEST
         // Stencil test the curvature pass for objects pixels only, not the background

--- a/libraries/render-utils/src/ToneMapAndResampleTask.cpp
+++ b/libraries/render-utils/src/ToneMapAndResampleTask.cpp
@@ -32,7 +32,7 @@ ToneMapAndResample::ToneMapAndResample() {
 
 void ToneMapAndResample::init() {
     // shared_ptr to gpu::State
-    gpu::StatePointer blitState = gpu::StatePointer(new gpu::State());
+    gpu::StatePointer blitState = std::make_shared<gpu::State>();
 
     blitState->setDepthTest(gpu::State::DepthTest(false, false));
     blitState->setColorWriteMask(true, true, true, true);

--- a/libraries/render-utils/src/VelocityBufferPass.cpp
+++ b/libraries/render-utils/src/VelocityBufferPass.cpp
@@ -147,7 +147,7 @@ void VelocityBufferPass::run(const render::RenderContextPointer& renderContext, 
 const gpu::PipelinePointer& VelocityBufferPass::getCameraMotionPipeline(const render::RenderContextPointer& renderContext) {
     if (!_cameraMotionPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::velocityBuffer_cameraMotion);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         // Stencil test the curvature pass for objects pixels only, not the background
        // PrepareStencil::testShape(*state);

--- a/libraries/render-utils/src/ZoneRenderer.cpp
+++ b/libraries/render-utils/src/ZoneRenderer.cpp
@@ -85,7 +85,7 @@ void SetupZones::run(const RenderContextPointer& context, const Input& input) {
 const gpu::PipelinePointer& DebugZoneLighting::getKeyLightPipeline() {
     if (!_keyLightPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::zone_drawKeyLight);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         PrepareStencil::testMask(*state);
         state->setBlendFunction(true, gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA);
@@ -97,7 +97,7 @@ const gpu::PipelinePointer& DebugZoneLighting::getKeyLightPipeline() {
 const gpu::PipelinePointer& DebugZoneLighting::getAmbientPipeline() {
     if (!_ambientPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::zone_drawAmbient);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         PrepareStencil::testMask(*state);
         state->setBlendFunction(true, gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA);
@@ -108,7 +108,7 @@ const gpu::PipelinePointer& DebugZoneLighting::getAmbientPipeline() {
 const gpu::PipelinePointer& DebugZoneLighting::getBackgroundPipeline() {
     if (!_backgroundPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render_utils::program::zone_drawSkybox);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         PrepareStencil::testMask(*state);
         state->setBlendFunction(true, gpu::State::SRC_ALPHA, gpu::State::BLEND_OP_ADD, gpu::State::INV_SRC_ALPHA);

--- a/libraries/render/src/render/BlurTask.cpp
+++ b/libraries/render/src/render/BlurTask.cpp
@@ -202,7 +202,7 @@ BlurGaussian::BlurGaussian() {
 gpu::PipelinePointer BlurGaussian::getBlurVPipeline() {
     if (!_blurVPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render::program::blurGaussianV);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         // Stencil test the curvature pass for objects pixels only, not the background
       //  state->setStencilTest(true, 0xFF, gpu::State::StencilTest(0, 0xFF, gpu::NOT_EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
@@ -216,7 +216,7 @@ gpu::PipelinePointer BlurGaussian::getBlurVPipeline() {
 gpu::PipelinePointer BlurGaussian::getBlurHPipeline() {
     if (!_blurHPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render::program::blurGaussianH);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         // Stencil test the curvature pass for objects pixels only, not the background
        // state->setStencilTest(true, 0xFF, gpu::State::StencilTest(0, 0xFF, gpu::NOT_EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
@@ -305,7 +305,7 @@ BlurGaussianDepthAware::BlurGaussianDepthAware(bool generateOutputFramebuffer, c
 gpu::PipelinePointer BlurGaussianDepthAware::getBlurVPipeline() {
     if (!_blurVPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render::program::blurGaussianDepthAwareV);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         // Stencil test the curvature pass for objects pixels only, not the background
       //  state->setStencilTest(true, 0xFF, gpu::State::StencilTest(0, 0xFF, gpu::NOT_EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));
@@ -319,7 +319,7 @@ gpu::PipelinePointer BlurGaussianDepthAware::getBlurVPipeline() {
 gpu::PipelinePointer BlurGaussianDepthAware::getBlurHPipeline() {
     if (!_blurHPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::render::program::blurGaussianDepthAwareH);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
 
         // Stencil test the curvature pass for objects pixels only, not the background
     //    state->setStencilTest(true, 0xFF, gpu::State::StencilTest(0, 0xFF, gpu::NOT_EQUAL, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP, gpu::State::STENCIL_OP_KEEP));

--- a/libraries/render/src/render/DrawTask.cpp
+++ b/libraries/render/src/render/DrawTask.cpp
@@ -268,7 +268,7 @@ gpu::PipelinePointer DrawQuadVolume::getPipeline() {
 
     if (!pipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::gpu::program::drawColor);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
         state->setDepthTest(gpu::State::DepthTest(true, false));
         pipeline = gpu::Pipeline::create(program, state);
     }

--- a/libraries/render/src/render/ResampleTask.cpp
+++ b/libraries/render/src/render/ResampleTask.cpp
@@ -53,7 +53,7 @@ void HalfDownsample::run(const RenderContextPointer& renderContext, const gpu::F
 
     if (!_pipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::gpu::program::drawTransformUnitQuadTextureOpaque);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
         state->setDepthTest(gpu::State::DepthTest(false, false));
         _pipeline = gpu::Pipeline::create(program, state);
     }
@@ -109,7 +109,7 @@ void Upsample::run(const RenderContextPointer& renderContext, const gpu::Framebu
     if (resampledFrameBuffer != sourceFramebuffer) {
         if (!_pipeline) {
             gpu::ShaderPointer program = gpu::Shader::createProgram(shader::gpu::program::drawTransformUnitQuadTextureOpaque);
-            gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+            gpu::StatePointer state = std::make_shared<gpu::State>();
             state->setDepthTest(gpu::State::DepthTest(false, false));
             _pipeline = gpu::Pipeline::create(program, state);
         }
@@ -150,7 +150,7 @@ void UpsampleToBlitFramebuffer::run(const RenderContextPointer& renderContext, c
 
     if (resampledFrameBuffer != sourceFramebuffer) {
         if (!_pipeline) {
-            gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+            gpu::StatePointer state = std::make_shared<gpu::State>();
             state->setDepthTest(gpu::State::DepthTest(false, false));
 
             _pipeline = gpu::Pipeline::create(gpu::Shader::createProgram(drawTransformUnitQuadTextureOpaque), state);

--- a/libraries/script-engine/src/ModelScriptingInterface.cpp
+++ b/libraries/script-engine/src/ModelScriptingInterface.cpp
@@ -102,7 +102,7 @@ QScriptValue ModelScriptingInterface::appendMeshes(MeshProxyList in) {
         indexStartOffset += numVertices;
     }
 
-    graphics::MeshPointer result(new graphics::Mesh());
+    graphics::MeshPointer result(std::make_shared<graphics::Mesh>());
 
     gpu::Element vertexElement = gpu::Element(gpu::VEC3, gpu::FLOAT, gpu::XYZ);
     gpu::Buffer* combinedVertexBuffer = new gpu::Buffer(combinedVertexSize, combinedVertexData.get());
@@ -199,7 +199,7 @@ QScriptValue ModelScriptingInterface::getVertex(MeshProxy* meshProxy, int vertex
 QScriptValue ModelScriptingInterface::newMesh(const QVector<glm::vec3>& vertices,
                                               const QVector<glm::vec3>& normals,
                                               const QVector<MeshFace>& faces) {
-    graphics::MeshPointer mesh(new graphics::Mesh());
+    graphics::MeshPointer mesh(std::make_shared<graphics::Mesh>());
 
     // vertices
     auto vertexBuffer = std::make_shared<gpu::Buffer>(vertices.size() * sizeof(glm::vec3), (gpu::Byte*)vertices.data());

--- a/libraries/ui/src/ui/OffscreenQmlSurfaceCache.cpp
+++ b/libraries/ui/src/ui/OffscreenQmlSurfaceCache.cpp
@@ -45,7 +45,7 @@ void OffscreenQmlSurfaceCache::release(const QString& rootSource, const QSharedP
 }
 
 QSharedPointer<OffscreenQmlSurface> OffscreenQmlSurfaceCache::buildSurface(const QString& rootSource) {
-    auto surface = QSharedPointer<OffscreenQmlSurface>(new OffscreenQmlSurface());
+    auto surface = QSharedPointer<OffscreenQmlSurface>::create();
 
     QObject::connect(surface.data(), &hifi::qml::OffscreenSurface::rootContextCreated, [this, rootSource](QQmlContext* surfaceContext) {
         if (_onRootContextCreated) {

--- a/libraries/ui/src/ui/TabletScriptingInterface.cpp
+++ b/libraries/ui/src/ui/TabletScriptingInterface.cpp
@@ -82,7 +82,7 @@ TabletButtonProxy* TabletButtonListModel::addButton(const QVariant& properties) 
         newProperties[BUTTON_SORT_ORDER_KEY] = DEFAULT_BUTTON_SORT_ORDER;
     }
     int index = computeNewButtonIndex(newProperties);
-    auto button = QSharedPointer<TabletButtonProxy>(new TabletButtonProxy(newProperties));
+    auto button = QSharedPointer<TabletButtonProxy>::create(newProperties);
     beginResetModel();
     int numButtons = (int)_buttons.size();
     if (index < numButtons) {

--- a/plugins/hifiCodec/src/HiFiCodecProvider.cpp
+++ b/plugins/hifiCodec/src/HiFiCodecProvider.cpp
@@ -30,7 +30,7 @@ public:
         static std::once_flag once;
         std::call_once(once, [&] {
 
-            CodecPluginPointer hiFiCodec(new HiFiCodec());
+            CodecPluginPointer hiFiCodec(std::make_shared<HiFiCodec>());
             if (hiFiCodec->isSupported()) {
                 _codecPlugins.push_back(hiFiCodec);
             }

--- a/plugins/hifiNeuron/src/NeuronProvider.cpp
+++ b/plugins/hifiNeuron/src/NeuronProvider.cpp
@@ -30,7 +30,7 @@ public:
     virtual InputPluginList getInputPlugins() override {
         static std::once_flag once;
         std::call_once(once, [&] {
-            InputPluginPointer plugin(new NeuronPlugin());
+            InputPluginPointer plugin(std::make_shared<NeuronPlugin>());
             if (plugin->isSupported()) {
                 _inputPlugins.push_back(plugin);
             }

--- a/plugins/hifiOsc/src/OscProvider.cpp
+++ b/plugins/hifiOsc/src/OscProvider.cpp
@@ -30,7 +30,7 @@ public:
     virtual InputPluginList getInputPlugins() override {
         static std::once_flag once;
         std::call_once(once, [&] {
-            InputPluginPointer plugin(new OscPlugin());
+            InputPluginPointer plugin(std::make_shared<OscPlugin>());
             if (plugin->isSupported()) {
                 _inputPlugins.push_back(plugin);
             }

--- a/plugins/hifiSdl2/src/SDL2Provider.cpp
+++ b/plugins/hifiSdl2/src/SDL2Provider.cpp
@@ -29,7 +29,7 @@ public:
     virtual InputPluginList getInputPlugins() override {
         static std::once_flag once;
         std::call_once(once, [&] {
-            InputPluginPointer plugin(new SDL2Manager());
+            InputPluginPointer plugin(std::make_shared<SDL2Manager>());
             if (plugin->isSupported()) {
                 _inputPlugins.push_back(plugin);
             }

--- a/plugins/oculus/src/OculusProvider.cpp
+++ b/plugins/oculus/src/OculusProvider.cpp
@@ -38,7 +38,7 @@ public:
     virtual DisplayPluginList getDisplayPlugins() override {
         static std::once_flag once;
         std::call_once(once, [&] {
-            DisplayPluginPointer plugin(new OculusDisplayPlugin());
+            DisplayPluginPointer plugin(std::make_shared<OculusDisplayPlugin>());
             if (plugin->isSupported()) {
                 _displayPlugins.push_back(plugin);
             }
@@ -46,7 +46,7 @@ public:
             // Windows Oculus Simulator... uses head tracking and the same rendering 
             // as the connected hardware, but without using the SDK to display to the 
             // Rift.  Useful for debugging Rift performance with nSight.
-            plugin = DisplayPluginPointer(new OculusDebugDisplayPlugin());
+            plugin = std::make_shared<OculusDebugDisplayPlugin>();
             if (plugin->isSupported()) {
                 _displayPlugins.push_back(plugin);
             }
@@ -57,7 +57,7 @@ public:
     virtual InputPluginList getInputPlugins() override {
         static std::once_flag once;
         std::call_once(once, [&] {
-            InputPluginPointer plugin(new OculusControllerManager());
+            InputPluginPointer plugin(std::make_shared<OculusControllerManager>());
             if (plugin->isSupported()) {
                 _inputPlugins.push_back(plugin);
             }

--- a/plugins/openvr/src/OpenVrProvider.cpp
+++ b/plugins/openvr/src/OpenVrProvider.cpp
@@ -32,7 +32,7 @@ public:
     virtual DisplayPluginList getDisplayPlugins() override {
         static std::once_flag once;
         std::call_once(once, [&] {
-            DisplayPluginPointer plugin(new OpenVrDisplayPlugin());
+            DisplayPluginPointer plugin(std::make_shared<OpenVrDisplayPlugin>());
             if (plugin->isSupported()) {
                 _displayPlugins.push_back(plugin);
             }
@@ -43,7 +43,7 @@ public:
     virtual InputPluginList getInputPlugins() override {
         static std::once_flag once;
         std::call_once(once, [&] {
-            InputPluginPointer plugin(new ViveControllerManager());
+            InputPluginPointer plugin(std::make_shared<ViveControllerManager>());
             if (plugin->isSupported()) {
                 _inputPlugins.push_back(plugin);
             }

--- a/plugins/opusCodec/src/OpusCodecProvider.cpp
+++ b/plugins/opusCodec/src/OpusCodecProvider.cpp
@@ -30,7 +30,7 @@ public:
         static std::once_flag once;
         std::call_once(once, [&] {
 
-            CodecPluginPointer opusCodec(new AthenaOpusCodec());
+            CodecPluginPointer opusCodec(std::make_shared<AthenaOpusCodec>());
             if (opusCodec->isSupported()) {
                 _codecPlugins.push_back(opusCodec);
             }

--- a/plugins/pcmCodec/src/PCMCodecProvider.cpp
+++ b/plugins/pcmCodec/src/PCMCodecProvider.cpp
@@ -30,12 +30,12 @@ public:
         static std::once_flag once;
         std::call_once(once, [&] {
 
-            CodecPluginPointer pcmCodec(new PCMCodec());
+            CodecPluginPointer pcmCodec(std::make_shared<PCMCodec>());
             if (pcmCodec->isSupported()) {
                 _codecPlugins.push_back(pcmCodec);
             }
 
-            CodecPluginPointer zlibCodec(new zLibCodec());
+            CodecPluginPointer zlibCodec(std::make_shared<zLibCodec>());
             if (zlibCodec->isSupported()) {
                 _codecPlugins.push_back(zlibCodec);
             }

--- a/tools/gpu-frame-player/src/RenderThread.cpp
+++ b/tools/gpu-frame-player/src/RenderThread.cpp
@@ -54,7 +54,7 @@ void RenderThread::initialize(QWindow* window) {
     
     if (!_presentPipeline) {
         gpu::ShaderPointer program = gpu::Shader::createProgram(shader::gpu::program::DrawTexture);
-        gpu::StatePointer state = gpu::StatePointer(new gpu::State());
+        gpu::StatePointer state = std::make_shared<gpu::State>();
         _presentPipeline = gpu::Pipeline::create(program, state);
     }
 #else


### PR DESCRIPTION
This was a code review of all uses of the "new" keyword when constructing a std::shared_ptr or QSharedPointer object:

(1) convert to make_shared / QSharedPointer::create if possible/appropriate.  This ensured that:
- there was less "gap" between construction of the raw pointer and the construction of the shared pointer object.
- There is less ability to specify a different pointer type between the object and the pointer
- the STL spec apparently ensures that the pointer and object are constructed within a single memory allocator, so this saves another trip to the heap allocator.

make_shared cannot be used when:
- there is a custom deleter (there may be value in factoring out a common building object that uses QObject::deleteLater though)
- the constructor is not public or otherwise inaccessible to the template function

(2) Where make_shared / QSharedPointer could not be used, ensure that the shared pointer is *initially* constructed with the actual datatype of the object
- This is mostly for the standard deleter, otherwise destructing a base class depends on virtual destructors being setup properly and potentially could cause potential memory leaks.  I noticed the plugin code did this a *lot*
- When using a custom deleter... might have value? unsure so much

There is likely at least some code changes that would take effect with this code, most likely:
- allocation differences (make_shared doing in-place construction), and
- the delete operation will be deleting the object as the type it was constructed (rather than any base class)

Testing focus:
- Check for any change in behavior or persistent memory usage on shutdown or recycling? There may be *slight* changes in behavior for:
- - "Dynamic" assignment client startup/shutdown (whatever this is)
- - "Controller conditional routing"
- - HiFi codec plugin
- - Neuron input plugin
- - Osc input plugin
- - SDL2 input plugin
- - Oculus display plugin
- - Oculus input plugin
- - OpenVR display plugin
- - Vive input plugin
- - Athena codec plugin
- - PCM codec plugin
- - zLib codec plugin