### PR TITLE
Housekeeping: Update use of "auto" with plugin lists.

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -288,10 +288,10 @@ void Agent::nodeKilled(SharedNodePointer killedNode) {
 void Agent::negotiateAudioFormat() {
     auto nodeList = DependencyManager::get<NodeList>();
     auto negotiateFormatPacket = NLPacket::create(PacketType::NegotiateAudioFormat);
-    auto codecPlugins = PluginManager::getInstance()->getCodecPlugins();
+    const auto& codecPlugins = PluginManager::getInstance()->getCodecPlugins();
     quint8 numberOfCodecs = (quint8)codecPlugins.size();
     negotiateFormatPacket->writePrimitive(numberOfCodecs);
-    for (auto& plugin : codecPlugins) {
+    for (const auto& plugin : codecPlugins) {
         auto codecName = plugin->getName();
         negotiateFormatPacket->writeString(codecName);
     }
@@ -326,8 +326,8 @@ void Agent::selectAudioFormat(const QString& selectedCodecName) {
     }
     _receivedAudioStream.cleanupCodec();
 
-    auto codecPlugins = PluginManager::getInstance()->getCodecPlugins();
-    for (auto& plugin : codecPlugins) {
+    const auto& codecPlugins = PluginManager::getInstance()->getCodecPlugins();
+    for (const auto& plugin : codecPlugins) {
         if (_selectedCodecName == plugin->getName()) {
             _codec = plugin;
             _receivedAudioStream.setupCodec(plugin, _selectedCodecName, AudioConstants::STEREO);

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -77,10 +77,9 @@ AudioMixer::AudioMixer(ReceivedMessage& message) :
     pluginManager->setPluginFilter(codecPluginFilter);
 
     const auto& codecPlugins = pluginManager->getCodecPlugins();
-    for_each(codecPlugins.cbegin(), codecPlugins.cend(),
-        [&](const CodecPluginPointer& codec) {
-            _availableCodecs[codec->getName()] = codec;
-        });
+    for(const auto& codec : codecPlugins) {
+        _availableCodecs[codec->getName()] = codec;
+    }
 
     auto nodeList = DependencyManager::get<NodeList>();
     auto& packetReceiver = nodeList->getPacketReceiver();

--- a/assignment-client/src/audio/AudioMixer.cpp
+++ b/assignment-client/src/audio/AudioMixer.cpp
@@ -76,7 +76,7 @@ AudioMixer::AudioMixer(ReceivedMessage& message) :
     };
     pluginManager->setPluginFilter(codecPluginFilter);
 
-    auto codecPlugins = pluginManager->getCodecPlugins();
+    const auto& codecPlugins = pluginManager->getCodecPlugins();
     for_each(codecPlugins.cbegin(), codecPlugins.cend(),
         [&](const CodecPluginPointer& codec) {
             _availableCodecs[codec->getName()] = codec;

--- a/assignment-client/src/scripts/EntityScriptServer.cpp
+++ b/assignment-client/src/scripts/EntityScriptServer.cpp
@@ -399,10 +399,10 @@ void EntityScriptServer::nodeKilled(SharedNodePointer killedNode) {
 void EntityScriptServer::negotiateAudioFormat() {
     auto nodeList = DependencyManager::get<NodeList>();
     auto negotiateFormatPacket = NLPacket::create(PacketType::NegotiateAudioFormat);
-    auto codecPlugins = PluginManager::getInstance()->getCodecPlugins();
+    const auto& codecPlugins = PluginManager::getInstance()->getCodecPlugins();
     quint8 numberOfCodecs = (quint8)codecPlugins.size();
     negotiateFormatPacket->writePrimitive(numberOfCodecs);
-    for (auto& plugin : codecPlugins) {
+    for (const auto& plugin : codecPlugins) {
         auto codecName = plugin->getName();
         negotiateFormatPacket->writeString(codecName);
     }
@@ -433,8 +433,8 @@ void EntityScriptServer::selectAudioFormat(const QString& selectedCodecName) {
         _codec = nullptr;
     }
 
-    auto codecPlugins = PluginManager::getInstance()->getCodecPlugins();
-    for (auto& plugin : codecPlugins) {
+    const auto& codecPlugins = PluginManager::getInstance()->getCodecPlugins();
+    for (const auto& plugin : codecPlugins) {
         if (_selectedCodecName == plugin->getName()) {
             _codec = plugin;
             _encoder = plugin->createEncoder(AudioConstants::SAMPLE_RATE, AudioConstants::MONO);

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -2696,21 +2696,21 @@ QString Application::getUserAgent() {
     auto formatPluginName = [](QString name) -> QString { return name.trimmed().replace(" ", "-");  };
 
     // For each plugin, add to userAgent
-    auto displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
-    for (auto& dp : displayPlugins) {
+    const auto& displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
+    for (const auto& dp : displayPlugins) {
         if (dp->isActive() && dp->isHmd()) {
             userAgent += " " + formatPluginName(dp->getName());
         }
     }
-    auto inputPlugins= PluginManager::getInstance()->getInputPlugins();
-    for (auto& ip : inputPlugins) {
+    const auto& inputPlugins = PluginManager::getInstance()->getInputPlugins();
+    for (const auto& ip : inputPlugins) {
         if (ip->isActive()) {
             userAgent += " " + formatPluginName(ip->getName());
         }
     }
     // for codecs, we include all of them, even if not active
-    auto codecPlugins = PluginManager::getInstance()->getCodecPlugins();
-    for (auto& cp : codecPlugins) {
+    const auto& codecPlugins = PluginManager::getInstance()->getCodecPlugins();
+    for (const auto& cp : codecPlugins) {
         userAgent += " " + formatPluginName(cp->getName());
     }
 
@@ -2777,7 +2777,7 @@ void Application::onAboutToQuit() {
         _firstRun.set(false);
     }
 
-    foreach(auto inputPlugin, PluginManager::getInstance()->getInputPlugins()) {
+    for(const auto& inputPlugin : PluginManager::getInstance()->getInputPlugins()) {
         if (inputPlugin->isActive()) {
             inputPlugin->deactivate();
         }
@@ -3159,14 +3159,14 @@ void Application::initializeGL() {
 }
 
 void Application::initializeDisplayPlugins() {
-    auto displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
+    const auto& displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
     Setting::Handle<QString> activeDisplayPluginSetting{ ACTIVE_DISPLAY_PLUGIN_SETTING_NAME, displayPlugins.at(0)->getName() };
     auto lastActiveDisplayPluginName = activeDisplayPluginSetting.get();
 
     auto defaultDisplayPlugin = displayPlugins.at(0);
     // Once time initialization code
     DisplayPluginPointer targetDisplayPlugin;
-    foreach(auto displayPlugin, displayPlugins) {
+    for(const auto& displayPlugin : displayPlugins) {
         displayPlugin->setContext(_graphicsEngine.getGPUContext());
         if (displayPlugin->getName() == lastActiveDisplayPluginName) {
             targetDisplayPlugin = displayPlugin;
@@ -3416,7 +3416,7 @@ void Application::initializeUi() {
 
     // This will set up the input plugins UI
     _activeInputPlugins.clear();
-    foreach(auto inputPlugin, PluginManager::getInstance()->getInputPlugins()) {
+    for(const auto& inputPlugin : PluginManager::getInstance()->getInputPlugins()) {
         if (KeyboardMouseDevice::NAME == inputPlugin->getName()) {
             _keyboardMouseDevice = std::dynamic_pointer_cast<KeyboardMouseDevice>(inputPlugin);
         }
@@ -3466,7 +3466,7 @@ void Application::initializeUi() {
 #if !defined(DISABLE_QML)
     // Now that the menu is instantiated, ensure the display plugin menu is properly updated
     {
-        auto displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
+        DisplayPluginList displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
         // first sort the plugins into groupings: standard, advanced, developer
         std::stable_sort(displayPlugins.begin(), displayPlugins.end(),
             [](const DisplayPluginPointer& a, const DisplayPluginPointer& b) -> bool { return a->getGrouping() < b->getGrouping(); });
@@ -4490,7 +4490,7 @@ void Application::keyPressEvent(QKeyEvent* event) {
             case Qt::Key_7:
                 if (isControlOrCommand || isOption) {
                     unsigned int index = static_cast<unsigned int>(event->key() - Qt::Key_1);
-                    auto displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
+                    const auto& displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
                     if (index < displayPlugins.size()) {
                         auto targetPlugin = displayPlugins.at(index);
                         QString targetName = targetPlugin->getName();
@@ -4545,7 +4545,7 @@ void Application::keyPressEvent(QKeyEvent* event) {
             case Qt::Key_7:
                 if (isControlOrCommand || isOption) {
                     unsigned int index = static_cast<unsigned int>(event->key() - Qt::Key_1);
-                    auto displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
+                    const auto& displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
                     if (index < displayPlugins.size()) {
                         auto targetPlugin = displayPlugins.at(index);
                         QString targetName = targetPlugin->getName();
@@ -4718,8 +4718,8 @@ void Application::keyReleaseEvent(QKeyEvent* event) {
 }
 
 void Application::focusOutEvent(QFocusEvent* event) {
-    auto inputPlugins = PluginManager::getInstance()->getInputPlugins();
-    foreach(auto inputPlugin, inputPlugins) {
+    const auto& inputPlugins = PluginManager::getInstance()->getInputPlugins();
+    for(const auto& inputPlugin : inputPlugins) {
         if (inputPlugin->isActive()) {
             inputPlugin->pluginFocusOutEvent();
         }
@@ -5406,8 +5406,8 @@ void Application::idle() {
         PerformanceTimer perfTimer("pluginIdle");
         PerformanceWarning warn(showWarnings, "Application::idle()... pluginIdle()");
         getActiveDisplayPlugin()->idle();
-        auto inputPlugins = PluginManager::getInstance()->getInputPlugins();
-        foreach(auto inputPlugin, inputPlugins) {
+        const auto& inputPlugins = PluginManager::getInstance()->getInputPlugins();
+        for(const auto& inputPlugin : inputPlugins) {
             if (inputPlugin->isActive()) {
                 inputPlugin->idle();
             }
@@ -5550,8 +5550,8 @@ void Application::loadSettings() {
 
     bool isFirstPerson = false;
     if (arguments().contains("--no-launcher")) {
-        auto displayPlugins = pluginManager->getDisplayPlugins();
-        for (auto& plugin : displayPlugins) {
+        const auto& displayPlugins = pluginManager->getDisplayPlugins();
+        for (const auto& plugin : displayPlugins) {
             if (!plugin->isHmd()) {
                 if (auto action = menu->getActionForOption(plugin->getName())) {
                     action->setChecked(true);
@@ -5565,8 +5565,8 @@ void Application::loadSettings() {
         if (_firstRun.get()) {
             // If this is our first run, and no preferred devices were set, default to
             // an HMD device if available.
-            auto displayPlugins = pluginManager->getDisplayPlugins();
-            for (auto& plugin : displayPlugins) {
+            const auto& displayPlugins = pluginManager->getDisplayPlugins();
+            for (const auto& plugin : displayPlugins) {
                 if (plugin->isHmd()) {
                     if (auto action = menu->getActionForOption(plugin->getName())) {
                         action->setChecked(true);
@@ -5603,8 +5603,8 @@ void Application::loadSettings() {
     _myCamera.setMode((isFirstPerson) ? CAMERA_MODE_FIRST_PERSON_LOOK_AT : CAMERA_MODE_LOOK_AT);
     cameraMenuChanged();
 
-    auto inputs = pluginManager->getInputPlugins();
-    for (auto plugin : inputs) {
+    const auto& inputs = pluginManager->getInputPlugins();
+    for (const auto& plugin : inputs) {
         if (!plugin->isActive()) {
             plugin->activate();
         }
@@ -6426,7 +6426,7 @@ void Application::update(float deltaTime) {
         };
 
         InputPluginPointer keyboardMousePlugin;
-        for (auto inputPlugin : PluginManager::getInstance()->getInputPlugins()) {
+        for(const auto& inputPlugin : PluginManager::getInstance()->getInputPlugins()) {
             if (inputPlugin->getName() == KeyboardMouseDevice::NAME) {
                 keyboardMousePlugin = inputPlugin;
             } else if (inputPlugin->isActive()) {
@@ -9028,14 +9028,14 @@ void Application::updateDisplayMode() {
     }
 
     // Once time initialization code that depends on the UI being available
-    auto displayPlugins = getDisplayPlugins();
+    const auto& displayPlugins = getDisplayPlugins();
 
     // Default to the first item on the list, in case none of the menu items match
 
     DisplayPluginPointer newDisplayPlugin = displayPlugins.at(0);
     auto menu = getPrimaryMenu();
     if (menu) {
-        foreach(DisplayPluginPointer displayPlugin, PluginManager::getInstance()->getDisplayPlugins()) {
+        for (const auto& displayPlugin : PluginManager::getInstance()->getDisplayPlugins()) {
             QString name = displayPlugin->getName();
             QAction* action = menu->getActionForOption(name);
             // Menu might have been removed if the display plugin lost
@@ -9088,7 +9088,7 @@ void Application::setDisplayPlugin(DisplayPluginPointer newDisplayPlugin) {
         bool active = newDisplayPlugin->activate();
 
         if (!active) {
-            auto displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
+            const DisplayPluginList& displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
 
             // If the new plugin fails to activate, fallback to last display
             qWarning() << "Failed to activate display: " << newDisplayPlugin->getName();
@@ -9429,7 +9429,7 @@ void Application::unresponsiveApplication() {
 
 void Application::setActiveDisplayPlugin(const QString& pluginName) {
     DisplayPluginPointer newDisplayPlugin;
-    for (DisplayPluginPointer displayPlugin : PluginManager::getInstance()->getDisplayPlugins()) {
+    for (const DisplayPluginPointer& displayPlugin : PluginManager::getInstance()->getDisplayPlugins()) {
         QString name = displayPlugin->getName();
         if (pluginName == name) {
             newDisplayPlugin = displayPlugin;

--- a/interface/src/ui/HMDToolsDialog.cpp
+++ b/interface/src/ui/HMDToolsDialog.cpp
@@ -37,7 +37,7 @@ HMDToolsDialog::HMDToolsDialog(QWidget* parent) :
     QDialog(parent, Qt::Window | Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowStaysOnTopHint)
 {
     // FIXME do we want to support more than one connected HMD?  It seems like a pretty corner case
-    foreach(auto displayPlugin, PluginManager::getInstance()->getDisplayPlugins()) {
+    for (const auto &displayPlugin : PluginManager::getInstance()->getDisplayPlugins()) {
         // The first plugin is always the standard 2D display, by convention
         if (_defaultPluginName.isEmpty()) {
             _defaultPluginName = displayPlugin->getName();
@@ -198,8 +198,8 @@ void HMDToolsDialog::hideEvent(QHideEvent* event) {
 
 void HMDToolsDialog::screenCountChanged(int newCount) {
     int hmdScreenNumber = -1;
-    auto displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
-    foreach(auto dp, displayPlugins) {
+    const auto& displayPlugins = PluginManager::getInstance()->getDisplayPlugins();
+    for(const auto& dp : displayPlugins) {
         if (dp->isHmd()) {
             if (dp->getHmdScreen() >= 0) {
                 hmdScreenNumber = dp->getHmdScreen();

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -962,10 +962,10 @@ void AudioClient::handleMuteEnvironmentPacket(QSharedPointer<ReceivedMessage> me
 void AudioClient::negotiateAudioFormat() {
     auto nodeList = DependencyManager::get<NodeList>();
     auto negotiateFormatPacket = NLPacket::create(PacketType::NegotiateAudioFormat);
-    auto codecPlugins = PluginManager::getInstance()->getCodecPlugins();
+    const auto& codecPlugins = PluginManager::getInstance()->getCodecPlugins();
     quint8 numberOfCodecs = (quint8)codecPlugins.size();
     negotiateFormatPacket->writePrimitive(numberOfCodecs);
-    for (auto& plugin : codecPlugins) {
+    for (const auto& plugin : codecPlugins) {
         auto codecName = plugin->getName();
         negotiateFormatPacket->writeString(codecName);
     }
@@ -998,8 +998,8 @@ void AudioClient::selectAudioFormat(const QString& selectedCodecName) {
     }
     _receivedAudioStream.cleanupCodec();
 
-    auto codecPlugins = PluginManager::getInstance()->getCodecPlugins();
-    for (auto& plugin : codecPlugins) {
+    const auto& codecPlugins = PluginManager::getInstance()->getCodecPlugins();
+    for (const auto& plugin : codecPlugins) {
         if (_selectedCodecName == plugin->getName()) {
             _codec = plugin;
             _receivedAudioStream.setupCodec(plugin, _selectedCodecName, AudioConstants::STEREO);
@@ -2476,8 +2476,8 @@ void AudioClient::loadSettings() {
     _receivedAudioStream.setStaticJitterBufferFrames(staticJitterBufferFrames.get());
 
     qCDebug(audioclient) << "---- Initializing Audio Client ----";
-    auto codecPlugins = PluginManager::getInstance()->getCodecPlugins();
-    for (auto& plugin : codecPlugins) {
+    const auto& codecPlugins = PluginManager::getInstance()->getCodecPlugins();
+    for (const auto& plugin : codecPlugins) {
         qCDebug(audioclient) << "Codec available:" << plugin->getName();
     }
 

--- a/libraries/plugins/src/plugins/InputConfiguration.cpp
+++ b/libraries/plugins/src/plugins/InputConfiguration.cpp
@@ -29,7 +29,7 @@ QStringList InputConfiguration::inputPlugins() {
     }
 
     QStringList inputPlugins;
-    for (auto plugin : PluginManager::getInstance()->getInputPlugins()) {
+    for (const auto& plugin : PluginManager::getInstance()->getInputPlugins()) {
         QString pluginName = plugin->getName();
         if (pluginName == QString("OpenVR")) {
             QString headsetName = plugin->getDeviceName();
@@ -51,7 +51,7 @@ QStringList InputConfiguration::activeInputPlugins() {
     }
 
     QStringList activePlugins;
-    for (auto plugin : PluginManager::getInstance()->getInputPlugins()) {
+    for (const auto& plugin : PluginManager::getInstance()->getInputPlugins()) {
         if (plugin->configurable()) {
             QString pluginName = plugin->getName();
             if (pluginName == QString("OpenVR")) {
@@ -75,7 +75,7 @@ QString InputConfiguration::configurationLayout(QString pluginName) {
     }
 
     QString sourcePath;
-    for (auto plugin : PluginManager::getInstance()->getInputPlugins()) {
+    for (const auto& plugin : PluginManager::getInstance()->getInputPlugins()) {
         if (plugin->getName() == pluginName || plugin->getDeviceName() == pluginName) {
             return plugin->configurationLayout();
         }
@@ -91,7 +91,7 @@ void InputConfiguration::setConfigurationSettings(QJsonObject configurationSetti
         return;
     }
 
-    for (auto plugin : PluginManager::getInstance()->getInputPlugins()) {
+    for (const auto& plugin : PluginManager::getInstance()->getInputPlugins()) {
         if (plugin->getName() == pluginName) {
             plugin->setConfigurationSettings(configurationSettings);
         }
@@ -107,7 +107,7 @@ QJsonObject InputConfiguration::configurationSettings(QString pluginName) {
         return result;
     }
 
-    for (auto plugin : PluginManager::getInstance()->getInputPlugins()) {
+    for (const auto& plugin : PluginManager::getInstance()->getInputPlugins()) {
         if (plugin->getName() == pluginName) {
             return plugin->configurationSettings();
         }
@@ -121,7 +121,7 @@ void InputConfiguration::calibratePlugin(QString pluginName) {
         return;
     }
 
-    for (auto plugin : PluginManager::getInstance()->getInputPlugins()) {
+    for (const auto& plugin : PluginManager::getInstance()->getInputPlugins()) {
         if (plugin->getName() == pluginName) {
             plugin->calibrate();
         }
@@ -137,7 +137,7 @@ bool InputConfiguration::uncalibratePlugin(QString pluginName) {
         return result;
     }
 
-    for (auto plugin : PluginManager::getInstance()->getInputPlugins()) {
+    for (const auto& plugin : PluginManager::getInstance()->getInputPlugins()) {
         if (plugin->getName() == pluginName) {
             return plugin->uncalibrate();
         }

--- a/libraries/plugins/src/plugins/PluginManager.cpp
+++ b/libraries/plugins/src/plugins/PluginManager.cpp
@@ -173,7 +173,7 @@ const CodecPluginList& PluginManager::getCodecPlugins() {
         for (auto loader : getLoadedPlugins()) {
             CodecProvider* codecProvider = qobject_cast<CodecProvider*>(loader->instance());
             if (codecProvider) {
-                for (auto codecPlugin : codecProvider->getCodecPlugins()) {
+                for (const auto& codecPlugin : codecProvider->getCodecPlugins()) {
                     if (codecPlugin->isSupported()) {
                         codecPlugins.push_back(codecPlugin);
                     }
@@ -247,7 +247,7 @@ DisplayPluginList PluginManager::getAllDisplayPlugins() {
         for (auto loader : getLoadedPlugins()) {
             DisplayProvider* displayProvider = qobject_cast<DisplayProvider*>(loader->instance());
             if (displayProvider) {
-                for (auto displayPlugin : displayProvider->getDisplayPlugins()) {
+                for (const auto& displayPlugin : displayProvider->getDisplayPlugins()) {
                     _displayPlugins.push_back(displayPlugin);
                 }
             }
@@ -292,7 +292,7 @@ const InputPluginList& PluginManager::getInputPlugins() {
         for (auto loader : getLoadedPlugins()) {
             InputProvider* inputProvider = qobject_cast<InputProvider*>(loader->instance());
             if (inputProvider) {
-                for (auto inputPlugin : inputProvider->getInputPlugins()) {
+                for (const auto& inputPlugin : inputProvider->getInputPlugins()) {
                     if (inputPlugin->isSupported()) {
                         _inputPlugins.push_back(inputPlugin);
                     }
@@ -333,9 +333,9 @@ DisplayPluginList PluginManager::getPreferredDisplayPlugins() {
     static std::once_flag once;
     std::call_once(once, [&] {
         // Grab the built in plugins
-        auto plugins = getDisplayPlugins();
+        const auto& plugins = getDisplayPlugins();
 
-        for (auto pluginName : preferredDisplayPlugins) {
+        for (const auto& pluginName : preferredDisplayPlugins) {
             auto it = std::find_if(plugins.begin(), plugins.end(), [&](DisplayPluginPointer plugin) {
                 return plugin->getName() == pluginName;
             });
@@ -362,13 +362,13 @@ void PluginManager::saveSettings() {
 }
 
 void PluginManager::shutdown() {
-    for (auto inputPlugin : getInputPlugins()) {
+    for (const auto& inputPlugin : getInputPlugins()) {
         if (inputPlugin->isActive()) {
             inputPlugin->deactivate();
         }
     }
 
-    for (auto displayPlugins : getDisplayPlugins()) {
+    for (const auto& displayPlugins : getDisplayPlugins()) {
         if (displayPlugins->isActive()) {
             displayPlugins->deactivate();
         }

--- a/libraries/plugins/src/plugins/PluginUtils.cpp
+++ b/libraries/plugins/src/plugins/PluginUtils.cpp
@@ -15,7 +15,7 @@
 #include "PluginManager.h"
 
 bool PluginUtils::isHMDAvailable(const QString& pluginName) {
-    for (auto& displayPlugin : PluginManager::getInstance()->getDisplayPlugins()) {
+    for (const auto& displayPlugin : PluginManager::getInstance()->getDisplayPlugins()) {
         // Temporarily only enable this for Vive
         if (displayPlugin->isHmd() && (pluginName.isEmpty() || displayPlugin->getName() == pluginName)) {
             return true;
@@ -25,7 +25,7 @@ bool PluginUtils::isHMDAvailable(const QString& pluginName) {
 }
 
 bool PluginUtils::isHeadControllerAvailable(const QString& pluginName) {
-    for (auto& inputPlugin : PluginManager::getInstance()->getInputPlugins()) {
+    for (const auto& inputPlugin : PluginManager::getInstance()->getInputPlugins()) {
         if (inputPlugin->isHeadController() && (pluginName.isEmpty() || inputPlugin->getName() == pluginName)) {
             return true;
         }
@@ -34,7 +34,7 @@ bool PluginUtils::isHeadControllerAvailable(const QString& pluginName) {
 };
 
 bool PluginUtils::isHandControllerAvailable(const QString& pluginName) {
-    for (auto& inputPlugin : PluginManager::getInstance()->getInputPlugins()) {
+    for (const auto& inputPlugin : PluginManager::getInstance()->getInputPlugins()) {
         if (inputPlugin->isHandController() && (pluginName.isEmpty() || inputPlugin->getName() == pluginName)) {
             return true;
         }
@@ -43,7 +43,7 @@ bool PluginUtils::isHandControllerAvailable(const QString& pluginName) {
 };
 
 bool PluginUtils::isSubdeviceContainingNameAvailable(QString name) {
-    for (auto& inputPlugin : PluginManager::getInstance()->getInputPlugins()) {
+    for (const auto& inputPlugin : PluginManager::getInstance()->getInputPlugins()) {
         if (inputPlugin->isActive()) {
             auto subdeviceNames = inputPlugin->getSubdeviceNames();
             for (auto& subdeviceName : subdeviceNames) {


### PR DESCRIPTION
The returned plugin lists are all coming back as "const&" and in most cases are assigned to "auto" (which strips out qualifiers).

This adds in as many "const auto&" ref qualifiers as I could for plugin references so as to reduce unnecessary copies.

(This came out of a tooltip while poking at the networking code)

Testing focus:
* The only thing I can think of is "make sure all plugins are recognized and used". This code assumes that the list of plugins is set before the first call returns and never changes?
* If the list of plugins changes after launch somehow then this may cause crashes.
* Also maybe "check for shutdown crashes" in case the list of plugins is destroyed while it's still being used by someone?