### PR TITLE
Code Review: use of Q_DISABLE_COPY.

### DIFF
--- a/assignment-client/src/audio/AvatarAudioStream.h
+++ b/assignment-client/src/audio/AvatarAudioStream.h
@@ -23,9 +23,7 @@ public:
     AvatarAudioStream(bool isStereo, int numStaticJitterFrames = -1);
 
 private:
-    // disallow copying of AvatarAudioStream objects
-    AvatarAudioStream(const AvatarAudioStream&);
-    AvatarAudioStream& operator= (const AvatarAudioStream&);
+    Q_DISABLE_COPY(AvatarAudioStream)
 
     int parseStreamProperties(PacketType type, const QByteArray& packetAfterSeqNum, int& numAudioSamples) override;
 };

--- a/interface/src/avatar/MyHead.h
+++ b/interface/src/avatar/MyHead.h
@@ -23,8 +23,8 @@ public:
 
 private:
     // disallow copies of the Head, copy of owning Avatar is disallowed too
-    MyHead(const Head&);
-    MyHead& operator= (const MyHead&);
+    MyHead(const Head&) = delete;
+    MyHead& operator= (const MyHead&) = delete;
 };
 
 #endif // hifi_MyHead_h

--- a/interface/src/avatar/MyHead.h
+++ b/interface/src/avatar/MyHead.h
@@ -22,9 +22,7 @@ public:
     void simulate(float deltaTime) override;
 
 private:
-    // disallow copies of the Head, copy of owning Avatar is disallowed too
-    MyHead(const Head&) = delete;
-    MyHead& operator= (const MyHead&) = delete;
+    Q_DISABLE_COPY(MyHead)
 };
 
 #endif // hifi_MyHead_h

--- a/libraries/animation/src/AnimNodeLoader.h
+++ b/libraries/animation/src/AnimNodeLoader.h
@@ -44,10 +44,7 @@ protected:
     QSharedPointer<Resource> _resource;
 
 private:
-
-    // no copies
-    AnimNodeLoader(const AnimNodeLoader&) = delete;
-    AnimNodeLoader& operator=(const AnimNodeLoader&) = delete;
+    Q_DISABLE_COPY(AnimNodeLoader)
 };
 
 #endif // hifi_AnimNodeLoader

--- a/libraries/animation/src/AnimRandomSwitch.h
+++ b/libraries/animation/src/AnimRandomSwitch.h
@@ -120,9 +120,7 @@ protected:
         std::vector<Transition> _transitions;
 
     private:
-        // no copies
-        RandomSwitchState(const RandomSwitchState&) = delete;
-        RandomSwitchState& operator=(const RandomSwitchState&) = delete;
+        Q_DISABLE_COPY(RandomSwitchState)
     };
 
 public:
@@ -181,9 +179,7 @@ protected:
     QString _lastPlayedState;
 
 private:
-    // no copies
-    AnimRandomSwitch(const AnimRandomSwitch&) = delete;
-    AnimRandomSwitch& operator=(const AnimRandomSwitch&) = delete;
+    Q_DISABLE_COPY(AnimRandomSwitch)
 };
 
 #endif // hifi_AnimRandomSwitch_h

--- a/libraries/animation/src/AnimStateMachine.h
+++ b/libraries/animation/src/AnimStateMachine.h
@@ -107,9 +107,7 @@ protected:
         std::vector<Transition> _transitions;
 
     private:
-        // no copies
-        State(const State&) = delete;
-        State& operator=(const State&) = delete;
+        Q_DISABLE_COPY(State)
     };
 
 public:
@@ -152,9 +150,7 @@ protected:
     QString _currentStateVar;
 
 private:
-    // no copies
-    AnimStateMachine(const AnimStateMachine&) = delete;
-    AnimStateMachine& operator=(const AnimStateMachine&) = delete;
+    Q_DISABLE_COPY(AnimStateMachine)
 };
 
 #endif // hifi_AnimStateMachine_h

--- a/libraries/audio/src/AudioInjectorManager.h
+++ b/libraries/audio/src/AudioInjectorManager.h
@@ -72,8 +72,7 @@ private:
     bool wouldExceedLimits();
 
     AudioInjectorManager() { createThread(); }
-    AudioInjectorManager(const AudioInjectorManager&) = delete;
-    AudioInjectorManager& operator=(const AudioInjectorManager&) = delete;
+    Q_DISABLE_COPY(AudioInjectorManager)
 
     void createThread();
 

--- a/libraries/audio/src/InjectedAudioStream.h
+++ b/libraries/audio/src/InjectedAudioStream.h
@@ -28,9 +28,7 @@ public:
     virtual const QUuid& getStreamIdentifier() const override { return _streamIdentifier; }
 
 private:
-    // disallow copying of InjectedAudioStream objects
-    InjectedAudioStream(const InjectedAudioStream&);
-    InjectedAudioStream& operator= (const InjectedAudioStream&);
+    Q_DISABLE_COPY(InjectedAudioStream)
 
     AudioStreamStats getAudioStreamStats() const override;
     int parseStreamProperties(PacketType type, const QByteArray& packetAfterSeqNum, int& numAudioSamples) override;

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1887,11 +1887,10 @@ protected:
     virtual void clearAvatarGrabData(const QUuid& grabID);
 
 private:
+    Q_DISABLE_COPY(AvatarData)
+
     friend void avatarStateFromFrame(const QByteArray& frameData, AvatarData* _avatar);
     static QUrl _defaultFullAvatarModelUrl;
-    // privatize the copy constructor and assignment operator so they cannot be called
-    AvatarData(const AvatarData&);
-    AvatarData& operator= (const AvatarData&);
 };
 Q_DECLARE_METATYPE(AvatarData*)
 

--- a/libraries/avatars/src/HeadData.h
+++ b/libraries/avatars/src/HeadData.h
@@ -128,9 +128,7 @@ protected:
     AvatarData* _owningAvatar;
 
 private:
-    // privatize copy ctor and assignment operator so copies of this object cannot be made
-    HeadData(const HeadData&);
-    HeadData& operator= (const HeadData&);
+    Q_DISABLE_COPY(HeadData)
 
     void setHeadOrientation(const glm::quat& orientation);
 };

--- a/libraries/networking/src/AccountManager.h
+++ b/libraries/networking/src/AccountManager.h
@@ -163,8 +163,7 @@ private slots:
     void postAccountSettingsError(QNetworkReply::NetworkError error);
 
 private:
-    AccountManager(AccountManager const& other) = delete;
-    void operator=(AccountManager const& other) = delete;
+    Q_DISABLE_COPY(AccountManager);
 
     void persistAccountToFile();
 

--- a/libraries/networking/src/NLPacketList.h
+++ b/libraries/networking/src/NLPacketList.h
@@ -27,11 +27,10 @@ public:
     qint64 getMaxSegmentSize() const override { return NLPacket::maxPayloadSize(_packetType, _isOrdered); }
     
 private:
+    Q_DISABLE_COPY(NLPacketList)
     NLPacketList(PacketType packetType, QByteArray extendedHeader = QByteArray(), bool isReliable = false,
                  bool isOrdered = false);
     NLPacketList(udt::PacketList&& packetList);
-    NLPacketList(const NLPacketList& other) = delete;
-    NLPacketList& operator=(const NLPacketList& other) = delete;
 
     virtual std::unique_ptr<udt::Packet> createPacket() override;
 

--- a/libraries/networking/src/Node.h
+++ b/libraries/networking/src/Node.h
@@ -109,9 +109,7 @@ public:
     float getOutboundKbps() const;
 
 private:
-    // privatize copy and assignment operator to disallow Node copying
-    Node(const Node &otherNode);
-    Node& operator=(Node otherNode);
+    Q_DISABLE_COPY(Node)
 
     NodeType_t _type;
 

--- a/libraries/networking/src/NodeList.h
+++ b/libraries/networking/src/NodeList.h
@@ -156,10 +156,9 @@ private slots:
     void maybeSendIgnoreSetToNode(SharedNodePointer node);
 
 private:
+    Q_DISABLE_COPY(NodeList)
     NodeList() : LimitedNodeList(INVALID_PORT, INVALID_PORT) { assert(false); } // Not implemented, needed for DependencyManager templates compile
     NodeList(char ownerType, int socketListenPort = INVALID_PORT, int dtlsListenPort = INVALID_PORT);
-    NodeList(NodeList const&) = delete; // Don't implement, needed to avoid copies of singleton
-    void operator=(NodeList const&) = delete; // Don't implement, needed to avoid copies of singleton
 
     void processDomainServerAuthRequest(const QByteArray& packet);
     void requestAuthForDomainServer();

--- a/libraries/networking/src/udt/CongestionControl.h
+++ b/libraries/networking/src/udt/CongestionControl.h
@@ -64,8 +64,7 @@ protected:
     SequenceNumber _sendCurrSeqNum; // current maximum seq num sent out
     
 private:
-    CongestionControl(const CongestionControl& other) = delete;
-    CongestionControl& operator=(const CongestionControl& other) = delete;
+    Q_DISABLE_COPY(CongestionControl);
 };
     
     

--- a/libraries/networking/src/udt/ControlPacket.h
+++ b/libraries/networking/src/udt/ControlPacket.h
@@ -48,13 +48,12 @@ public:
     void setType(Type type);
     
 private:
+    Q_DISABLE_COPY(ControlPacket)
     ControlPacket(Type type, qint64 size = -1);
     ControlPacket(std::unique_ptr<char[]> data, qint64 size, const SockAddr& senderSockAddr);
     ControlPacket(ControlPacket&& other);
-    ControlPacket(const ControlPacket& other) = delete;
     
     ControlPacket& operator=(ControlPacket&& other);
-    ControlPacket& operator=(const ControlPacket& other) = delete;
     
     // Header read/write
     void readType();

--- a/libraries/networking/src/udt/PacketList.h
+++ b/libraries/networking/src/udt/PacketList.h
@@ -84,9 +84,8 @@ private:
     friend class PacketQueue;
     friend class SendQueue;
     friend class Socket;
-    
-    PacketList(const PacketList& other) = delete;
-    PacketList& operator=(const PacketList& other) = delete;
+
+    Q_DISABLE_COPY(PacketList)
     
     // Takes the first packet of the list and returns it.
     template<typename T> std::unique_ptr<T> takeFront();

--- a/libraries/networking/src/udt/SendQueue.h
+++ b/libraries/networking/src/udt/SendQueue.h
@@ -90,10 +90,9 @@ private slots:
     void run();
     
 private:
+    Q_DISABLE_COPY_MOVE(SendQueue)
     SendQueue(Socket* socket, SockAddr dest, SequenceNumber currentSequenceNumber,
               MessageNumber currentMessageNumber, bool hasReceivedHandshakeACK);
-    SendQueue(SendQueue& other) = delete;
-    SendQueue(SendQueue&& other) = delete;
     
     void sendHandshake();
     

--- a/libraries/shaders/src/shaders/Shaders.h
+++ b/libraries/shaders/src/shaders/Shaders.h
@@ -155,8 +155,8 @@ struct Source {
     static const Source& get(uint32_t shaderId);
 
 private:
-    // Disallow copy construction and assignment
-    Source(const Source& other) = default;
+    // Disallow copy construction
+    Source(const Source& other) = delete;
 
     static Source::Pointer loadSource(uint32_t shaderId) ;
 

--- a/libraries/ui/src/VrMenu.cpp
+++ b/libraries/ui/src/VrMenu.cpp
@@ -141,7 +141,7 @@ public:
     }
 
 private:
-    MenuUserData(const MenuUserData&);
+    Q_DISABLE_COPY(MenuUserData);
 
     QMetaObject::Connection _shutdownConnection;
     QMetaObject::Connection _changedConnection;


### PR DESCRIPTION
This attempts to find and replace most instances of "do not copy this class" code with Q_DISABLE_COPY.  This:
* standardizes the code,
* ensures that both the copy constructor and assignment operator are handled,
* ensures use of the newer "= delete" syntax

There are a few places that I did not replace the code:
* Two classes didn't obviously #include QObject (which defines Q_DISABLE_COPY) or didn't appear intended to, and
* What the heck is happening with interface/src/avatar/MyHead.h, is this a typo or bug in the code?

Testing focus:
* NONE - these changes should not have any effect outside of the compiler