### PR TITLE
Optimization coding pass over AudioMixerSlavePool and AvatarMixerSlavePool pt. 1.

### DIFF
--- a/assignment-client/src/audio/AudioMixerSlavePool.cpp
+++ b/assignment-client/src/audio/AudioMixerSlavePool.cpp
@@ -189,13 +189,14 @@ void AudioMixerSlavePool::resize(int numThreads) {
         while (_numStopped != (_numThreads - numThreads)) {
             {
                 Lock slaveLock(_slaveMutex);
-                _numStarted = _numFinished = _numStopped;
+                _numStarted = _numFinished = 0;
                 _slaveCondition.notify_all();
             }
             _poolCondition.wait(poolLock, [&] {
                 assert(_numFinished <= _numThreads);
                 return _numFinished == _numThreads;
             });
+            assert(_numStopped == (_numThreads - numThreads));
         }
 
         // ...wait for threads to finish...

--- a/assignment-client/src/audio/AudioMixerSlavePool.cpp
+++ b/assignment-client/src/audio/AudioMixerSlavePool.cpp
@@ -53,15 +53,16 @@ void AudioMixerSlaveThread::wait() {
 }
 
 void AudioMixerSlaveThread::notify(bool stopping) {
-    {
-        Lock lock(_pool._mutex);
-        assert(_pool._numFinished < _pool._numThreads);
-        ++_pool._numFinished;
-        if (stopping) {
-            ++_pool._numStopped;
-        }
+    Lock lock(_pool._mutex);
+    assert(_pool._numFinished < _pool._numThreads);
+    ++_pool._numFinished;
+    if (stopping) {
+        ++_pool._numStopped;
     }
-    _pool._poolCondition.notify_one();
+
+    if(_pool._numFinished == _pool._numThreads) {
+        _pool._poolCondition.notify_one();
+    }
 }
 
 bool AudioMixerSlaveThread::try_pop(SharedNodePointer& node) {

--- a/assignment-client/src/audio/AudioMixerSlavePool.cpp
+++ b/assignment-client/src/audio/AudioMixerSlavePool.cpp
@@ -38,8 +38,8 @@ void AudioMixerSlaveThread::run() {
 
 void AudioMixerSlaveThread::wait() {
     {
-        Lock lock(_pool._mutex);
-        _pool._slaveCondition.wait(lock, [&] {
+        Lock slaveLock(_pool._slaveMutex);
+        _pool._slaveCondition.wait(slaveLock, [&] {
             assert(_pool._numStarted <= _pool._numThreads);
             return _pool._numStarted != _pool._numThreads;
         });
@@ -53,7 +53,7 @@ void AudioMixerSlaveThread::wait() {
 }
 
 void AudioMixerSlaveThread::notify(bool stopping) {
-    Lock lock(_pool._mutex);
+    Lock poolLock(_pool._poolMutex);
     assert(_pool._numFinished < _pool._numThreads);
     ++_pool._numFinished;
     if (stopping) {
@@ -94,19 +94,27 @@ void AudioMixerSlavePool::run(ConstIter begin, ConstIter end) {
     });
 
     {
-        Lock lock(_mutex);
+        Lock poolLock(_poolMutex);
 
         // run
-        _numStarted = _numFinished = 0;
-        _slaveCondition.notify_all();
+        {
+            Lock slaveLock(_slaveMutex);
+            _numStarted = _numFinished = 0;
+            _slaveCondition.notify_all();
+        }
 
         // wait
-        _poolCondition.wait(lock, [&] {
+        _poolCondition.wait(poolLock, [&] {
             assert(_numFinished <= _numThreads);
             return _numFinished == _numThreads;
         });
 
-        assert(_numStarted == _numThreads);
+#ifndef NDEBUG
+        {
+            Lock slaveLock(_slaveMutex);
+            assert(_numStarted == _numThreads);
+        }
+#endif
     }
 
     assert(_queue.empty());
@@ -156,7 +164,7 @@ void AudioMixerSlavePool::resize(int numThreads) {
 
     qDebug("%s: set %d threads (was %d)", __FUNCTION__, numThreads, _numThreads);
 
-    Lock lock(_mutex);
+    Lock poolLock(_poolMutex);
 
     if (numThreads > _numThreads) {
         // start new slaves
@@ -179,9 +187,12 @@ void AudioMixerSlavePool::resize(int numThreads) {
         // ...cycle them until they do stop...
         _numStopped = 0;
         while (_numStopped != (_numThreads - numThreads)) {
-            _numStarted = _numFinished = _numStopped;
-            _slaveCondition.notify_all();
-            _poolCondition.wait(lock, [&] {
+            {
+                Lock slaveLock(_slaveMutex);
+                _numStarted = _numFinished = _numStopped;
+                _slaveCondition.notify_all();
+            }
+            _poolCondition.wait(poolLock, [&] {
                 assert(_numFinished <= _numThreads);
                 return _numFinished == _numThreads;
             });
@@ -200,6 +211,9 @@ void AudioMixerSlavePool::resize(int numThreads) {
         _slaves.erase(extraBegin, _slaves.end());
     }
 
-    _numThreads = _numStarted = _numFinished = numThreads;
+    {
+        Lock slaveLock(_slaveMutex);
+        _numThreads = _numStarted = _numFinished = numThreads;
+    }
     assert(_numThreads == (int)_slaves.size());
 }

--- a/assignment-client/src/audio/AudioMixerSlavePool.h
+++ b/assignment-client/src/audio/AudioMixerSlavePool.h
@@ -90,15 +90,16 @@ private:
     friend bool AudioMixerSlaveThread::try_pop(SharedNodePointer& node);
 
     // synchronization state
-    Mutex _mutex;
-    ConditionVariable _slaveCondition;
+    Mutex _poolMutex;
     ConditionVariable _poolCondition;
+    Mutex _slaveMutex;  // subservient to _poolMutex, do not lock _poolMutex while holding _slaveMutex!
+    ConditionVariable _slaveCondition;
     void (AudioMixerSlave::*_function)(const SharedNodePointer& node);
     std::function<void(AudioMixerSlave&)> _configure;
     int _numThreads { 0 };
-    int _numStarted { 0 }; // guarded by _mutex
-    int _numFinished { 0 }; // guarded by _mutex
-    int _numStopped { 0 }; // guarded by _mutex
+    int _numStarted { 0 }; // guarded by _slaveMutex
+    int _numFinished { 0 }; // guarded by _poolMutex
+    int _numStopped { 0 }; // guarded by _poolMutex
 
     // frame state
     Queue _queue;

--- a/assignment-client/src/avatars/AvatarMixerSlavePool.cpp
+++ b/assignment-client/src/avatars/AvatarMixerSlavePool.cpp
@@ -188,13 +188,14 @@ void AvatarMixerSlavePool::resize(int numThreads) {
         while (_numStopped != (_numThreads - numThreads)) {
             {
                 Lock slaveLock(_slaveMutex);
-                _numStarted = _numFinished = _numStopped;
+                _numStarted = _numFinished = 0;
                 _slaveCondition.notify_all();
             }
             _poolCondition.wait(poolLock, [&] {
                 assert(_numFinished <= _numThreads);
                 return _numFinished == _numThreads;
             });
+            assert(_numStopped == (_numThreads - numThreads));
         }
 
         // ...wait for threads to finish...

--- a/assignment-client/src/avatars/AvatarMixerSlavePool.cpp
+++ b/assignment-client/src/avatars/AvatarMixerSlavePool.cpp
@@ -48,15 +48,16 @@ void AvatarMixerSlaveThread::wait() {
 }
 
 void AvatarMixerSlaveThread::notify(bool stopping) {
-    {
-        Lock lock(_pool._mutex);
-        assert(_pool._numFinished < _pool._numThreads);
-        ++_pool._numFinished;
-        if (stopping) {
-            ++_pool._numStopped;
-        }
+    Lock lock(_pool._mutex);
+    assert(_pool._numFinished < _pool._numThreads);
+    ++_pool._numFinished;
+    if (stopping) {
+        ++_pool._numStopped;
     }
-    _pool._poolCondition.notify_one();
+
+    if(_pool._numFinished == _pool._numThreads) {
+        _pool._poolCondition.notify_one();
+    }
 }
 
 bool AvatarMixerSlaveThread::try_pop(SharedNodePointer& node) {

--- a/assignment-client/src/avatars/AvatarMixerSlavePool.h
+++ b/assignment-client/src/avatars/AvatarMixerSlavePool.h
@@ -95,9 +95,10 @@ private:
     friend bool AvatarMixerSlaveThread::try_pop(SharedNodePointer& node);
 
     // synchronization state
-    Mutex _mutex;
-    ConditionVariable _slaveCondition;
+    Mutex _poolMutex;
     ConditionVariable _poolCondition;
+    Mutex _slaveMutex; // subservient to _poolMutex, do not lock _poolMutex while holding _slaveMutex!
+    ConditionVariable _slaveCondition;
     void (AvatarMixerSlave::*_function)(const SharedNodePointer& node);
     std::function<void(AvatarMixerSlave&)> _configure;
 
@@ -105,9 +106,9 @@ private:
     float _priorityReservedFraction { 0.4f };
     int _numThreads { 0 };
 
-    int _numStarted { 0 }; // guarded by _mutex
-    int _numFinished { 0 }; // guarded by _mutex
-    int _numStopped { 0 }; // guarded by _mutex
+    int _numStarted { 0 }; // guarded by _slaveMutex
+    int _numFinished { 0 }; // guarded by _poolMutex
+    int _numStopped { 0 }; // guarded by _poolMutex
 
     // frame state
     Queue _queue;


### PR DESCRIPTION
This is an optimization pass over the mutex logic in AudioMixerSlavePool and AvatarMixerSlavePool (which is effectively the same code).  Changes made are:
* The single _mutex has been replaced by _poolMutex and _slaveMutex, and
* An "if" statement now wraps the _poolCondition "wake" logic, to reduce spurious wakes

I have not tested this code beyond ensuring it compiles.
I do not know whether this would resolve issue #1355 as this may not be the ultimate cause (these two assignment clients are pretty much a tight while() loop repeatedly calling the pool whether anyone is connected or not) but it hopefully reduces the amount of lock contention going on

Testing:
- Smoketesting: make sure that audio and avatars still work on a server built with this (requires a server with multiple users)
- Race conditions: exercise a server long enough to know whether there are any lockups or crashes that occur in these two areas
- Profile: see if this improves the profiling numbers that have been described in issue #1355 