### PR TITLE
Fix crash due to audio packet loss with PCM and zlib codecs.

### DIFF
--- a/plugins/pcmCodec/CMakeLists.txt
+++ b/plugins/pcmCodec/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 set(TARGET_NAME pcmCodec)
 setup_hifi_client_server_plugin()
-link_hifi_libraries(shared plugins)
+link_hifi_libraries(shared audio plugins)
 
 if (BUILD_SERVER)
   install_beside_console()

--- a/plugins/pcmCodec/src/PCMCodecManager.h
+++ b/plugins/pcmCodec/src/PCMCodecManager.h
@@ -13,6 +13,7 @@
 #define hifi__PCMCodecManager_h
 
 #include <plugins/CodecPlugin.h>
+#include <AudioConstants.h>
 
 class PCMCodec : public CodecPlugin, public Encoder, public Decoder {
     Q_OBJECT
@@ -44,6 +45,7 @@ public:
     }
 
     virtual void lostFrame(QByteArray& decodedBuffer) override {
+        decodedBuffer.resize(AudioConstants::NETWORK_FRAME_BYTES_STEREO);
         memset(decodedBuffer.data(), 0, decodedBuffer.size());
     }
 

--- a/plugins/pcmCodec/src/PCMCodecManager.h
+++ b/plugins/pcmCodec/src/PCMCodecManager.h
@@ -83,6 +83,7 @@ public:
     }
 
     virtual void lostFrame(QByteArray& decodedBuffer) override {
+        decodedBuffer.resize(AudioConstants::NETWORK_FRAME_BYTES_STEREO);
         memset(decodedBuffer.data(), 0, decodedBuffer.size());
     }
 


### PR DESCRIPTION
Fixes #1364

As explained in the bug above, when the PCM or zlib plugins detect a missing audio packet, they create a zero-sized buffer that trips up an assertion check.


