### PR TITLE
Replace the deprecated QMutex{ QMutex::Recursive} with QRecursiveMutex (solves approximately 1700 warnings).

### DIFF
--- a/interface/src/Application.h
+++ b/interface/src/Application.h
@@ -648,7 +648,7 @@ private:
 
     EntityTreePointer _entityClipboard;
 
-    mutable QMutex _viewMutex { QMutex::Recursive };
+    mutable QRecursiveMutex _viewMutex;
     ViewFrustum _viewFrustum; // current state of view frustum, perspective, orientation, etc.
     ViewFrustum _displayViewFrustum;
 
@@ -774,7 +774,7 @@ private:
     bool _isMissingSequenceNumbers { false };
 
     void checkChangeCursor();
-    mutable QMutex _changeCursorLock { QMutex::Recursive };
+    mutable QRecursiveMutex _changeCursorLock;
     Qt::CursorShape _desiredCursor{ Qt::BlankCursor };
     bool _cursorNeedsChanging { false };
 

--- a/interface/src/graphics/GraphicsEngine.h
+++ b/interface/src/graphics/GraphicsEngine.h
@@ -69,7 +69,7 @@ private:
 
 protected:
 
-    mutable QMutex _renderArgsMutex{ QMutex::Recursive };
+    mutable QRecursiveMutex _renderArgsMutex;
     AppRenderArgs _appRenderArgs;
 
     RateCounter<500> _renderLoopCounter;

--- a/interface/src/ui/overlays/Overlays.h
+++ b/interface/src/ui/overlays/Overlays.h
@@ -746,7 +746,7 @@ signals:
 private:
     void cleanupOverlaysToDelete();
 
-    mutable QMutex _mutex { QMutex::Recursive };
+    mutable QRecursiveMutex _mutex;
     QMap<QUuid, Overlay::Pointer> _overlays;
     QList<Overlay::Pointer> _overlaysToDelete;
 

--- a/libraries/display-plugins/src/display-plugins/CompositorHelper.h
+++ b/libraries/display-plugins/src/display-plugins/CompositorHelper.h
@@ -161,7 +161,7 @@ private:
     // application specific position, when it's in desktop mode, the reticle position will simply move
     // the system mouse.
     glm::vec2 _reticlePositionInHMD { 0.0f, 0.0f };
-    mutable QMutex _reticleLock { QMutex::Recursive };
+    mutable QRecursiveMutex _reticleLock;
 
     QPointF _lastKnownRealMouse;
     bool _ignoreMouseMove { false };

--- a/libraries/entities/src/EntitySimulation.h
+++ b/libraries/entities/src/EntitySimulation.h
@@ -44,7 +44,7 @@ const int DIRTY_SIMULATION_FLAGS =
 
 class EntitySimulation : public QObject, public std::enable_shared_from_this<EntitySimulation> {
 public:
-    EntitySimulation() : _mutex(QMutex::Recursive), _nextExpiry(std::numeric_limits<uint64_t>::max()), _entityTree(nullptr) { }
+    EntitySimulation() : _mutex(), _nextExpiry(std::numeric_limits<uint64_t>::max()), _entityTree(nullptr) { }
     virtual ~EntitySimulation() { setEntityTree(nullptr); }
 
     inline EntitySimulationPointer getThisPointer() const {
@@ -90,7 +90,7 @@ protected:
     void callUpdateOnEntitiesThatNeedIt(uint64_t now);
     virtual void sortEntitiesThatMoved();
 
-    QMutex _mutex{ QMutex::Recursive };
+    QRecursiveMutex _mutex;
 
     SetOfEntities _entitiesToSort; // entities moved by simulation (and might need resort in EntityTree)
     SetOfEntities _simpleKinematicEntities; // entities undergoing non-colliding kinematic motion

--- a/libraries/networking/src/HMACAuth.h
+++ b/libraries/networking/src/HMACAuth.h
@@ -39,7 +39,7 @@ public:
     HMACHash result();
 
 private:
-    QMutex _lock { QMutex::Recursive };
+    QRecursiveMutex _lock;
     struct hmac_ctx_st* _hmacContext;
     AuthMethod _authMethod;
 };

--- a/libraries/octree/src/OctreeEditPacketSender.h
+++ b/libraries/octree/src/OctreeEditPacketSender.h
@@ -93,7 +93,7 @@ protected:
     int _maxPendingMessages;
     bool _releaseQueuedMessagesPending;
     QMutex _pendingPacketsLock;
-    QMutex _packetsQueueLock{ QMutex::Recursive }; // don't let different threads release the queue while another thread is writing to it
+    QRecursiveMutex _packetsQueueLock; // don't let different threads release the queue while another thread is writing to it
     std::list<EditMessagePair> _preServerEdits; // these will get packed into other larger packets
     std::list<std::unique_ptr<NLPacket>> _preServerSingleMessagePackets; // these will go out as is
 

--- a/libraries/physics/src/PhysicalEntitySimulation.h
+++ b/libraries/physics/src/PhysicalEntitySimulation.h
@@ -129,7 +129,7 @@ private:
 
     QList<EntityDynamicPointer> _dynamicsToAdd;
     QSet<QUuid> _dynamicsToRemove;
-    QMutex _dynamicsMutex { QMutex::Recursive };
+    QRecursiveMutex _dynamicsMutex;
 
     workload::SpacePointer _space;
     uint64_t _nextBidExpiry;

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -444,7 +444,7 @@ protected:
     QVector<float> _blendedBlendshapeCoefficients;
     int _blendNumber { 0 };
 
-    mutable QMutex _mutex{ QMutex::Recursive };
+    mutable QRecursiveMutex _mutex;
 
     bool _overrideModelTransform { false };
     bool _triangleSetsValid { false };

--- a/libraries/shared/src/DependencyManager.h
+++ b/libraries/shared/src/DependencyManager.h
@@ -89,7 +89,7 @@ private:
     QHash<size_t, QSharedPointer<Dependency>> _instanceHash;
     QHash<size_t, size_t> _inheritanceHash;
 
-    mutable QMutex _instanceHashMutex { QMutex::Recursive };
+    mutable QRecursiveMutex _instanceHashMutex;
     mutable QMutex _inheritanceHashMutex;
 
     bool _exiting { false };


### PR DESCRIPTION
This fixes around 1700 warnings.