### PR TITLE
Require OpenSSL 1.1.0 during CMake.

### DIFF
--- a/cmake/macros/TargetOpenSSL.cmake
+++ b/cmake/macros/TargetOpenSSL.cmake
@@ -12,7 +12,7 @@ macro(TARGET_OPENSSL)
         set(OPENSSL_LIBRARIES "${OPENSSL_INSTALL_DIR}/lib/libcrypto.a;${OPENSSL_INSTALL_DIR}/lib/libssl.a" CACHE STRING INTERNAL)
     else()
     	# using VCPKG for OpenSSL
-        find_package(OpenSSL REQUIRED)
+        find_package(OpenSSL 1.1.0 REQUIRED)
     endif()
 
     include_directories(SYSTEM "${OPENSSL_INCLUDE_DIR}")

--- a/ice-server/CMakeLists.txt
+++ b/ice-server/CMakeLists.txt
@@ -8,7 +8,7 @@ link_hifi_libraries(embedded-webserver networking shared)
 package_libraries_for_deployment()
 
 # find OpenSSL
-find_package(OpenSSL REQUIRED)
+find_package(OpenSSL 1.1.0 REQUIRED)
 
 if (APPLE AND ${OPENSSL_INCLUDE_DIR} STREQUAL "/usr/include")
   # this is a user on OS X using system OpenSSL, which is going to throw warnings since they're deprecating for their common crypto

--- a/launchers/qt/CMakeLists.txt
+++ b/launchers/qt/CMakeLists.txt
@@ -69,7 +69,7 @@ if (WIN32)
   set(OPENSSL_ROOT_DIR ${SSL_DIR})
   message("SSL dir is ${SSL_DIR}")
   set(OPENSSL_USE_STATIC_LIBS TRUE)
-  find_package(OpenSSL REQUIRED)
+  find_package(OpenSSL 1.1.0 REQUIRED)
 
   message("-- Found OpenSSL Libs ${OPENSSL_LIBRARIES}")
 
@@ -105,7 +105,7 @@ endif()
 
 if (APPLE)
   set(OPENSSL_USE_STATIC_LIBS TRUE)
-  find_package(OpenSSL REQUIRED)
+  find_package(OpenSSL 1.1.0 REQUIRED)
 endif()
 
 find_package(Qt5 COMPONENTS Core Gui Qml Quick QuickControls2 Network REQUIRED)


### PR DESCRIPTION
Earlier versions don't work with WebRTC, and cause linking errors.

OpenSSL 1.1 is supported in Ubuntu 18.04, although 1.0 can still be installed, which will cause the build to fail. This change ensures the issue is detected right in cmake rather than having the build explode later.


Testing:

Test on Ubuntu 18.04, with OpenSSL 1.0 installed (`libssl1.0-dev` present, `libssl-dev` not present)

Before this change, cmake will say something like:
```
-- Found OpenSSL: /usr/lib64/libcrypto.so (found version "1.0.2n")  
```

and the build will probably fail with:
```
../libraries/networking/libnetworking.so: undefined reference to `BIO_meth_new'
../libraries/networking/libnetworking.so: undefined reference to `OPENSSL_init_crypto'
../libraries/networking/libnetworking.so: undefined reference to `OPENSSL_init_ssl'
../libraries/networking/libnetworking.so: undefined reference to `BIO_meth_set_write'
../libraries/networking/libnetworking.so: undefined reference to `BIO_set_data'
../libraries/networking/libnetworking.so: undefined reference to `BIO_meth_set_ctrl'
../libraries/networking/libnetworking.so: undefined reference to `BIO_meth_set_puts'
../libraries/networking/libnetworking.so: undefined reference to `BIO_get_data'
../libraries/networking/libnetworking.so: undefined reference to `BIO_set_init'
../libraries/networking/libnetworking.so: undefined reference to `BIO_set_shutdown'
../libraries/networking/libnetworking.so: undefined reference to `BIO_meth_set_create'
../libraries/networking/libnetworking.so: undefined reference to `HMAC_CTX_free'
../libraries/networking/libnetworking.so: undefined reference to `SSL_CTX_up_ref'
../libraries/networking/libnetworking.so: undefined reference to `EVP_MD_CTX_reset'
../libraries/networking/libnetworking.so: undefined reference to `EVP_MD_CTX_new'
../libraries/networking/libnetworking.so: undefined reference to `BIO_meth_set_destroy'
../libraries/networking/libnetworking.so: undefined reference to `EVP_MD_CTX_free'
../libraries/networking/libnetworking.so: undefined reference to `SSL_session_reused'
../libraries/networking/libnetworking.so: undefined reference to `X509_getm_notBefore'
../libraries/networking/libnetworking.so: undefined reference to `TLS_method'
../libraries/networking/libnetworking.so: undefined reference to `EVP_PKEY_up_ref'
../libraries/networking/libnetworking.so: undefined reference to `X509_up_ref'
../libraries/networking/libnetworking.so: undefined reference to `HMAC_CTX_new'
../libraries/networking/libnetworking.so: undefined reference to `X509_getm_notAfter'
../libraries/networking/libnetworking.so: undefined reference to `X509_STORE_CTX_get0_cert'
../libraries/networking/libnetworking.so: undefined reference to `BIO_meth_set_read'
```


With this change, cmake will say:
```
-- Found OpenSSL: /usr/lib64/libcrypto.so (found suitable version "1.1.1l", minimum required is "1.1.0")  
```

And should work correctly.

This should make no difference at all on any recent Linux distribution.


