### PR TITLE
Create app: Script indicator toggles for both entity client & server scripts.

### DIFF
--- a/scripts/system/create/entityList/entityList.js
+++ b/scripts/system/create/entityList/entityList.js
@@ -203,8 +203,8 @@ EntityListTool = function(shouldUseEditTabletApp) {
             var cameraPosition = Camera.position;
             PROFILE("getMultipleProperties", function () {
                 var multipleProperties = Entities.getMultipleEntityProperties(ids, ['position', 'name', 'type', 'locked',
-                    'visible', 'renderInfo', 'modelURL', 'materialURL', 'imageURL', 'script', 'certificateID',
-                    'skybox.url', 'ambientLight.url', 'created', 'lastEdited']);
+                    'visible', 'renderInfo', 'modelURL', 'materialURL', 'imageURL', 'script', 'serverScripts', 
+                    'certificateID', 'skybox.url', 'ambientLight.url', 'created', 'lastEdited']);
                 for (var i = 0; i < multipleProperties.length; i++) {
                     var properties = multipleProperties[i];
 
@@ -247,7 +247,7 @@ EntityListTool = function(shouldUseEditTabletApp) {
                             isBaked: entityIsBaked(properties),
                             drawCalls: (properties.renderInfo !== undefined ?
                                 valueIfDefined(properties.renderInfo.drawCalls) : ""),
-                            hasScript: properties.script !== "",
+                            hasScript: (properties.script !== "" || properties.serverScripts !== ""),
                             parentState: parentState,
                             created: formatToStringDateTime(properties.created),
                             lastEdited: formatToStringDateTime(properties.lastEdited)


### PR DESCRIPTION
In the Entity List, there is a column to indicate the presence of script on an entity.
_Before that modification, it was only present for entities having a Client Script._
**Now** it will be present if there is a **Client OR Server** script.
![image](https://user-images.githubusercontent.com/60075796/141607164-a3d1af50-6806-4b12-8d69-2883d8d18dd2.png)
