### PR TITLE
Remove second argument from some playSystemSound() calls in QML.

### DIFF
--- a/interface/resources/qml/hifi/audio/PlaySampleSound.qml
+++ b/interface/resources/qml/hifi/audio/PlaySampleSound.qml
@@ -25,10 +25,8 @@ RowLayout {
         sample = null;
     }
     function playSound() {
-        // FIXME: MyAvatar is not properly exposed to QML; MyAvatar.qmlPosition is a stopgap
-        // FIXME: AudioScriptingInterface.playSystemSound should not require position
         if (sample === null && !isPlaying) {
-            sample = AudioScriptingInterface.playSystemSound(sound, MyAvatar.qmlPosition);
+            sample = AudioScriptingInterface.playSystemSound(sound);
             isPlaying = true;
             sample.finished.connect(reset);
         }

--- a/interface/resources/qml/hifi/simplifiedUI/settingsApp/audio/Audio.qml
+++ b/interface/resources/qml/hifi/simplifiedUI/settingsApp/audio/Audio.qml
@@ -384,10 +384,8 @@ Flickable {
                     sample = null;
                 }
                 function playSound() {
-                    // FIXME: MyAvatar is not properly exposed to QML; MyAvatar.qmlPosition is a stopgap
-                    // FIXME: AudioScriptingInterface.playSystemSound should not require position
                     if (sample === null && !isPlaying) {
-                        sample = AudioScriptingInterface.playSystemSound(sound, MyAvatar.qmlPosition);
+                        sample = AudioScriptingInterface.playSystemSound(sound);
                         isPlaying = true;
                         sample.finished.connect(reset);
                     }

--- a/interface/resources/qml/hifi/simplifiedUI/settingsApp/vr/VR.qml
+++ b/interface/resources/qml/hifi/simplifiedUI/settingsApp/vr/VR.qml
@@ -386,10 +386,8 @@ Flickable {
                     sample = null;
                 }
                 function playSound() {
-                    // FIXME: MyAvatar is not properly exposed to QML; MyAvatar.qmlPosition is a stopgap
-                    // FIXME: AudioScriptingInterface.playSystemSound should not require position
                     if (sample === null && !isPlaying) {
-                        sample = AudioScriptingInterface.playSystemSound(sound, MyAvatar.qmlPosition);
+                        sample = AudioScriptingInterface.playSystemSound(sound);
                         isPlaying = true;
                         sample.finished.connect(reset);
                     }

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -170,7 +170,7 @@ class MyAvatar : public Avatar {
      * @property {Vec3} skeletonOffset - Can be used to apply a translation offset between the avatar's position and the
      *     registration point of the 3D model.
      *
-     * @property {Vec3} qmlPosition - A synonym for <code>position</code> for use by QML.
+     * @property {Vec3} qmlPosition - A synonym for <code>position</code> for use by QML. This is deprecated.
      *
      * @property {Vec3} feetPosition - The position of the avatar's feet.
      * @property {boolean} shouldRenderLocally=true - If <code>true</code> then your avatar is rendered for you in Interface,

--- a/interface/src/avatar/MyAvatar.h
+++ b/interface/src/avatar/MyAvatar.h
@@ -170,7 +170,8 @@ class MyAvatar : public Avatar {
      * @property {Vec3} skeletonOffset - Can be used to apply a translation offset between the avatar's position and the
      *     registration point of the 3D model.
      *
-     * @property {Vec3} qmlPosition - A synonym for <code>position</code> for use by QML. This is deprecated.
+     * @property {Vec3} qmlPosition - A synonym for <code>position</code> for use by QML.
+     *     <p class="important">Deprecated: This property is deprecated and will be removed.</p>
      *
      * @property {Vec3} feetPosition - The position of the avatar's feet.
      * @property {boolean} shouldRenderLocally=true - If <code>true</code> then your avatar is rendered for you in Interface,


### PR DESCRIPTION
I don't know how this code was working before or why the position was needed, but the comments suggest that removing the position argument was the initial intention and the output test seems to work fine for me without it. May or may not fix https://github.com/vircadia/vircadia/issues/1453.