### PR TITLE
Remove <thread> library from main.cpp.

### DIFF
--- a/interface/src/main.cpp
+++ b/interface/src/main.cpp
@@ -8,8 +8,6 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-#include <thread>
-
 #include <QCommandLineParser>
 #include <QtCore/QProcess>
 #include <QDebug>


### PR DESCRIPTION
Just happened to notice this. I could be wrong, but I did compile and run the interface with no apparent issues.