### PR TITLE
Replace the deprecated QVector::fromStdVector and QVector::toStdVector().

### DIFF
--- a/libraries/model-baker/src/model-baker/Baker.cpp
+++ b/libraries/model-baker/src/model-baker/Baker.cpp
@@ -32,15 +32,15 @@ namespace baker {
 
         void run(const BakeContextPointer& context, const Input& input, Output& output) {
             const auto& hfmModelIn = input;
-            output.edit0() = hfmModelIn->meshes.toStdVector();
+            output.edit0() = std::vector<hfm::Mesh>(hfmModelIn->meshes.begin(), hfmModelIn->meshes.end());
             output.edit1() = hfmModelIn->originalURL;
             output.edit2() = hfmModelIn->meshIndicesToModelNames;
             auto& blendshapesPerMesh = output.edit3();
             blendshapesPerMesh.reserve(hfmModelIn->meshes.size());
             for (int i = 0; i < hfmModelIn->meshes.size(); i++) {
-                blendshapesPerMesh.push_back(hfmModelIn->meshes[i].blendshapes.toStdVector());
+                blendshapesPerMesh.push_back(std::vector<hfm::Blendshape>(hfmModelIn->meshes[i].blendshapes.begin(), hfmModelIn->meshes[i].blendshapes.end()));
             }
-            output.edit4() = hfmModelIn->joints.toStdVector();
+            output.edit4() = std::vector<hfm::Joint>(hfmModelIn->joints.begin(), hfmModelIn->joints.end());
         }
     };
 
@@ -66,8 +66,8 @@ namespace baker {
                     const auto& normals = safeGet(normalsPerBlendshape, j);
                     const auto& tangents = safeGet(tangentsPerBlendshape, j);
                     auto& blendshape = blendshapesOut[j];
-                    blendshape.normals = QVector<glm::vec3>::fromStdVector(normals);
-                    blendshape.tangents = QVector<glm::vec3>::fromStdVector(tangents);
+                    blendshape.normals = QVector<glm::vec3>(normals.begin(), normals.end());
+                    blendshape.tangents = QVector<glm::vec3>(tangents.begin(), tangents.end());
                 }
             }
         }
@@ -91,9 +91,13 @@ namespace baker {
             for (int i = 0; i < numMeshes; i++) {
                 auto& meshOut = meshesOut[i];
                 meshOut._mesh = safeGet(graphicsMeshesIn, i);
-                meshOut.normals = QVector<glm::vec3>::fromStdVector(safeGet(normalsPerMeshIn, i));
-                meshOut.tangents = QVector<glm::vec3>::fromStdVector(safeGet(tangentsPerMeshIn, i));
-                meshOut.blendshapes = QVector<hfm::Blendshape>::fromStdVector(safeGet(blendshapesPerMeshIn, i));
+                auto stdNormals = safeGet(normalsPerMeshIn, i);
+                auto stdTangents = safeGet(tangentsPerMeshIn, i);
+                auto stdBlendshapes = safeGet(blendshapesPerMeshIn, i);
+
+                meshOut.normals = QVector<glm::vec3>(stdNormals.begin(), stdNormals.end());
+                meshOut.tangents = QVector<glm::vec3>(stdTangents.begin(), stdTangents.end());
+                meshOut.blendshapes = QVector<hfm::Blendshape>(stdBlendshapes.begin(), stdBlendshapes.end());
             }
             output = meshesOut;
         }
@@ -107,8 +111,10 @@ namespace baker {
 
         void run(const BakeContextPointer& context, const Input& input, Output& output) {
             auto hfmModelOut = input.get0();
-            hfmModelOut->meshes = QVector<hfm::Mesh>::fromStdVector(input.get1());
-            hfmModelOut->joints = QVector<hfm::Joint>::fromStdVector(input.get2());
+            auto stdMeshes = input.get1();
+            auto stdJoints = input.get2();
+            hfmModelOut->meshes = QVector<hfm::Mesh>(stdMeshes.begin(), stdMeshes.end());
+            hfmModelOut->joints = QVector<hfm::Joint>(stdJoints.begin(), stdJoints.end());
             hfmModelOut->jointRotationOffsets = input.get3();
             hfmModelOut->jointIndices = input.get4();
             hfmModelOut->flowData = input.get5();
@@ -204,7 +210,7 @@ namespace baker {
     hfm::Model::Pointer Baker::getHFMModel() const {
         return _engine->getOutput().get<BakerEngineBuilder::Output>().get0();
     }
-    
+
     MaterialMapping Baker::getMaterialMapping() const {
         return _engine->getOutput().get<BakerEngineBuilder::Output>().get1();
     }

--- a/libraries/model-baker/src/model-baker/Baker.cpp
+++ b/libraries/model-baker/src/model-baker/Baker.cpp
@@ -38,7 +38,8 @@ namespace baker {
             auto& blendshapesPerMesh = output.edit3();
             blendshapesPerMesh.reserve(hfmModelIn->meshes.size());
             for (int i = 0; i < hfmModelIn->meshes.size(); i++) {
-                blendshapesPerMesh.push_back(std::vector<hfm::Blendshape>(hfmModelIn->meshes[i].blendshapes.begin(), hfmModelIn->meshes[i].blendshapes.end()));
+                auto &blendshapes = hfmModelIn->meshes[i].blendshapes;
+                blendshapesPerMesh.push_back(std::vector<hfm::Blendshape>(blendshapes.begin(), blendshapes.end()));
             }
             output.edit4() = std::vector<hfm::Joint>(hfmModelIn->joints.begin(), hfmModelIn->joints.end());
         }

--- a/libraries/model-baker/src/model-baker/CalculateBlendshapeNormalsTask.cpp
+++ b/libraries/model-baker/src/model-baker/CalculateBlendshapeNormalsTask.cpp
@@ -31,7 +31,7 @@ void CalculateBlendshapeNormalsTask::run(const baker::BakeContextPointer& contex
             const auto& normalsIn = blendshape.normals;
             // Check if normals are already defined. Otherwise, calculate them from existing blendshape vertices.
             if (!normalsIn.empty()) {
-                normalsPerBlendshapeOut.push_back(normalsIn.toStdVector());
+                normalsPerBlendshapeOut.push_back(std::vector<glm::vec3>(normalsIn.begin(), normalsIn.end()));
             } else {
                 // Create lookup to get index in blendshape from vertex index in mesh
                 std::vector<int> reverseIndices;

--- a/libraries/model-baker/src/model-baker/CalculateBlendshapeTangentsTask.cpp
+++ b/libraries/model-baker/src/model-baker/CalculateBlendshapeTangentsTask.cpp
@@ -20,7 +20,7 @@ void CalculateBlendshapeTangentsTask::run(const baker::BakeContextPointer& conte
     const auto& blendshapesPerMesh = input.get1();
     const auto& meshes = input.get2();
     auto& tangentsPerBlendshapePerMeshOut = output;
-    
+
     tangentsPerBlendshapePerMeshOut.reserve(normalsPerBlendshapePerMesh.size());
     for (size_t i = 0; i < blendshapesPerMesh.size(); i++) {
         const auto& normalsPerBlendshape = baker::safeGet(normalsPerBlendshapePerMesh, i);
@@ -38,7 +38,7 @@ void CalculateBlendshapeTangentsTask::run(const baker::BakeContextPointer& conte
 
             // Check if we already have tangents
             if (!tangentsIn.empty()) {
-                tangentsOut = tangentsIn.toStdVector();
+                tangentsOut = std::vector<glm::vec3>(tangentsIn.begin(), tangentsIn.end());
                 continue;
             }
 

--- a/libraries/model-baker/src/model-baker/CalculateMeshNormalsTask.cpp
+++ b/libraries/model-baker/src/model-baker/CalculateMeshNormalsTask.cpp
@@ -24,7 +24,7 @@ void CalculateMeshNormalsTask::run(const baker::BakeContextPointer& context, con
         auto& normalsOut = normalsPerMeshOut[normalsPerMeshOut.size()-1];
         // Only calculate normals if this mesh doesn't already have them
         if (!mesh.normals.empty()) {
-            normalsOut = mesh.normals.toStdVector();
+            normalsOut = std::vector<glm::vec3>(mesh.normals.begin(), mesh.normals.end());
         } else {
             normalsOut.resize(mesh.vertices.size());
             baker::calculateNormals(mesh,

--- a/libraries/model-baker/src/model-baker/CalculateMeshTangentsTask.cpp
+++ b/libraries/model-baker/src/model-baker/CalculateMeshTangentsTask.cpp
@@ -29,7 +29,7 @@ void CalculateMeshTangentsTask::run(const baker::BakeContextPointer& context, co
         // Check if we already have tangents and therefore do not need to do any calculation
         // Otherwise confirm if we have the normals and texcoords needed
         if (!tangentsIn.empty()) {
-            tangentsOut = tangentsIn.toStdVector();
+            tangentsOut = std::vector<glm::vec3>(tangentsIn.begin(), tangentsIn.end());
         } else if (!normals.empty() && mesh.vertices.size() == mesh.texCoords.size()) {
             tangentsOut.resize(normals.size());
             baker::calculateTangents(mesh,

--- a/libraries/model-serializers/src/GLTFSerializer.cpp
+++ b/libraries/model-serializers/src/GLTFSerializer.cpp
@@ -811,7 +811,7 @@ void GLTFSerializer::getSkinInverseBindMatrices(std::vector<std::vector<float>>&
         GLTFAccessor& indicesAccessor = _file.accessors[skin.inverseBindMatrices];
         QVector<float> matrices;
         addArrayFromAccessor(indicesAccessor, matrices);
-        inverseBindMatrixValues.push_back(matrices.toStdVector());
+        inverseBindMatrixValues.push_back(std::vector<float>(matrices.begin(), matrices.end()));
     }
 }
 


### PR DESCRIPTION
This should make no functional difference, but get rid of ~20 warnings.

This is based on top of PR #1468 