### PR TITLE
MIDI doesn't compile?

### DIFF
--- a/libraries/midi/CMakeLists.txt
+++ b/libraries/midi/CMakeLists.txt
@@ -1,3 +1,7 @@
 set(TARGET_NAME midi)
 setup_hifi_library(Network)
 link_hifi_libraries(shared networking)
+
+if (WIN32)
+    target_link_libraries(${TARGET_NAME} winmm.lib)
+endif ()

--- a/libraries/midi/src/Midi.cpp
+++ b/libraries/midi/src/Midi.cpp
@@ -16,10 +16,9 @@
 #include <QtCore/QLoggingCategory>
 
 #if defined Q_OS_WIN32
-#include "Windows.h"
-#endif
+#include <Windows.h>
+#include <mmeapi.h>
 
-#if defined Q_OS_WIN32
 const int MIDI_BYTE_MASK = 0x0FF;
 const int MIDI_NIBBLE_MASK = 0x00F;
 const int MIDI_PITCH_BEND_MASK = 0x3F80;


### PR DESCRIPTION
I just tried to merge master into #1200 and got a compile error... because midi.cpp doesn't have access to mmeapi.h?

I'm unsure if this is related to #1200 and so am including it here for independent evaluation.