### PR TITLE
GHA: Disable compiler optimization on self-hosted runner.

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -72,6 +72,8 @@ jobs:
           if [ "${{ matrix.os }}" = "self-hosted_debian-11_aarch64" ]; then
             echo "VIRCADIA_USE_SYSTEM_QT=true" >> $GITHUB_ENV
             echo "CI_WORKSPACE=${{runner.workspace}}" >> $GITHUB_ENV
+            # Don't optimize builds to save build time.
+            echo "VIRCADIA_OPTIMIZE=false" >> $GITHUB_ENV
           fi
           if [[ "${{ matrix.os }}" = *"aarch64" ]]; then
             echo "VCPKG_FORCE_SYSTEM_BINARIES=true" >> $GITHUB_ENV


### PR DESCRIPTION
This PR disables compiler optimization for the self hosted aarch64 runner.
Apparently the compiler optimization needs ~75 minutes extra, which slows everything down quite a bit.
This has no downside, since the builds aren't even getting uploaded yet.