### PR TITLE
Remove Vircadia Web app submodule and add automatic detection instead.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vircadia-web"]
-	path = vircadia-web
-	url = ../vircadia-web.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,18 +350,22 @@ GroupSources("unpublishedScripts")
 unset(JS_SRC)
 
 # Include Vircadia Web app files if cloned into a subdirectory.
-file(GLOB_RECURSE WEB_APP_SRC vircadia-web/*.*)
-list(FILTER WEB_APP_SRC EXCLUDE REGEX "vircadia-web/(dist|node_modules|public)/*" )
-add_custom_target(vircadia-web SOURCES ${WEB_APP_SRC})
-GroupSources("vircadia-web")
-unset(WEB_APP_SRC)
+if (IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/vircadia-web")
+    file(GLOB_RECURSE WEB_APP_SRC vircadia-web/*.*)
+    list(FILTER WEB_APP_SRC EXCLUDE REGEX "vircadia-web/(dist|node_modules|public)/*" )
+    add_custom_target(vircadia-web SOURCES ${WEB_APP_SRC})
+    GroupSources("vircadia-web")
+    unset(WEB_APP_SRC)
+endif()
 
 # Include Vircadia Web SDK files if cloned into a subdirectory.
-file(GLOB_RECURSE WEB_SDK_SRC vircadia-web-sdk/*.*)
-list(FILTER WEB_SDK_SRC EXCLUDE REGEX "vircadia-web-sdk/(dist|node_modules|public)/*" )
-add_custom_target(vircadia-web-sdk SOURCES ${WEB_SDK_SRC})
-GroupSources("vircadia-web-sdk")
-unset(WEB_SDK_SRC)
+if (IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/vircadia-web-sdk")
+    file(GLOB_RECURSE WEB_SDK_SRC vircadia-web-sdk/*.*)
+    list(FILTER WEB_SDK_SRC EXCLUDE REGEX "vircadia-web-sdk/(dist|node_modules|public)/*" )
+    add_custom_target(vircadia-web-sdk SOURCES ${WEB_SDK_SRC})
+    GroupSources("vircadia-web-sdk")
+    unset(WEB_SDK_SRC)
+endif()
 
 set_packaging_parameters()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,11 +349,19 @@ GroupSources("scripts")
 GroupSources("unpublishedScripts")
 unset(JS_SRC)
 
+# Include Vircadia Web app files if cloned into a subdirectory.
 file(GLOB_RECURSE WEB_APP_SRC vircadia-web/*.*)
 list(FILTER WEB_APP_SRC EXCLUDE REGEX "vircadia-web/(dist|node_modules|public)/*" )
 add_custom_target(vircadia-web SOURCES ${WEB_APP_SRC})
 GroupSources("vircadia-web")
 unset(WEB_APP_SRC)
+
+# Include Vircadia Web SDK files if cloned into a subdirectory.
+file(GLOB_RECURSE WEB_SDK_SRC vircadia-web-sdk/*.*)
+list(FILTER WEB_SDK_SRC EXCLUDE REGEX "vircadia-web-sdk/(dist|node_modules|public)/*" )
+add_custom_target(vircadia-web-sdk SOURCES ${WEB_SDK_SRC})
+GroupSources("vircadia-web-sdk")
+unset(WEB_SDK_SRC)
 
 set_packaging_parameters()
 


### PR DESCRIPTION
This is no longer useful because the Web app no longer includes the Web SDK as a submodule. Instead, support optionally cloning the Web app and/or Web SDK into subdirectories and include their files if present in the IDE solution.