### PR TITLE
Explore App: Use the placename instead of address (ip:port).

### DIFF
--- a/scripts/communityScripts/explore/explore.html
+++ b/scripts/communityScripts/explore/explore.html
@@ -326,7 +326,7 @@
                     if (placesData[i].domain.active && placesData[i].visibility == "open" && new Date(placesData[i].last_activity_update) > activeThresholdTime) {
                         joinedData.push({
                             "index": joinedData.length,
-                            "location": placesData[i].address,
+                            "location": placesData[i].name,
                             "name": placesData[i].name,
                             "owner": placesData[i].managers[0],
                             "userCount": placesData[i].current_attendance,


### PR DESCRIPTION
Simple change that is using the placename instead of the "address" feild from the place api to build the url to connect.
For those where the placename = the domain name, Interface will be able to resolve path correctly.
using the address, this makes interface using 100% of the time the ip:/port information.