### PR TITLE
Remove extended deadlock wait on macOS

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -156,7 +156,7 @@ jobs:
           sudo apt install -y ${{ matrix.apt-dependencies }} || exit 1
         else # macOS
           echo "Downloading MacOSX10.12 SDK.."
-          curl --progress-bar -L -o macOS_SDK10.12.4.tar.xz "https://cloudflare-ipfs.com/ipfs/QmdNLMCUCw8hBTqinkc7ke88WgRb7M2mWQbccQPDsyaub8?filename=macOS_SDK10.12.4.tar.xz" || exit 1
+          curl --progress-bar -L -o macOS_SDK10.12.4.tar.xz "https://data.moto9000.moe/vircadia_packages/macOS_SDK10.12.4.tar.xz" || exit 1
           echo "  done\n"
           echo "Extracting MacOSX10.12 SDK.."
           tar -xf macOS_SDK10.12.4.tar.xz || exit 1

--- a/interface/src/Application.cpp
+++ b/interface/src/Application.cpp
@@ -381,12 +381,7 @@ const std::vector<std::pair<QString, Application::AcceptURLMethod>> Application:
 class DeadlockWatchdogThread : public QThread {
 public:
     static const unsigned long HEARTBEAT_UPDATE_INTERVAL_SECS = 1;
-    // TODO: go back to 2 min across the board, after figuring out the issues with mac
-#if defined(Q_OS_MAC)
-    static const unsigned long MAX_HEARTBEAT_AGE_USECS = 600 * USECS_PER_SECOND; // 10 mins with no checkin probably a deadlock, right now, on MAC
-#else
     static const unsigned long MAX_HEARTBEAT_AGE_USECS = 120 * USECS_PER_SECOND; // 2 mins with no checkin probably a deadlock
-#endif
     static const int WARNING_ELAPSED_HEARTBEAT = 500 * USECS_PER_MSEC; // warn if elapsed heartbeat average is large
     static const int HEARTBEAT_SAMPLES = 100000; // ~5 seconds worth of samples
 


### PR DESCRIPTION
This removes a weird workaround from HiFi times.
Whatever the reason for this was, it basically breaks crashpad for deadlocks because no one is going to sit around and wait 10 minutes for Interface to detect a deadlock when it is not responsive.
Two minutes already seems like quite a stretch in most cases.