### PR TITLE
Fixed memcpy in loadSpirvResource

### DIFF
--- a/libraries/shaders/src/shaders/Shaders.cpp
+++ b/libraries/shaders/src/shaders/Shaders.cpp
@@ -96,7 +96,7 @@ static Binary loadSpirvResource(const std::string& path) {
         if (file.open(QFile::ReadOnly)) {
             QByteArray bytes = file.readAll();
             result.resize(bytes.size());
-            memcpy(bytes.data(), result.data(), bytes.size());
+            memcpy(result.data(), bytes.data(), bytes.size());
         }
     }
     return result;


### PR DESCRIPTION
Memcpy parameters were in wrong order, so loadSpirvResource returned uninitialized memory region.
I tested change on Linux, and it doesn't break anything.