### PR TITLE
Choose right Qt version for Linux Mint 19.x

### DIFF
--- a/hifi_qt.py
+++ b/hifi_qt.py
@@ -142,18 +142,14 @@ endif()
             cpu_architecture = platform.machine()
 
             if 'x86_64' == cpu_architecture:
-                if distro.id() == 'ubuntu':
-                    u_major = int( distro.major_version() )
-                    u_minor = int( distro.minor_version() )
-
-                    if u_major == 18:
-                        self.qtUrl = self.assets_url + '/dependencies/vcpkg/qt5-install-5.15.2-ubuntu-18.04-amd64.tar.xz'
-                    elif u_major > 19:
-                        self.__no_qt_package_error()
-                    else:
-                        self.__unsupported_error()
-                else:
+                u_major = int( distro.major_version() )
+                u_minor = int( distro.minor_version() )
+                if (distro.id() == 'ubuntu' and u_major == 18) or distro.id() == 'linuxmint' and u_major == 19:
+                    self.qtUrl = self.assets_url + '/dependencies/vcpkg/qt5-install-5.15.2-ubuntu-18.04-amd64.tar.xz'
+                elif (distro.id() == 'ubuntu' and u_major > 18) or (distro.id() == 'linuxmint' and u_major > 19):
                     self.__no_qt_package_error()
+                else:
+                    self.__unsupported_error()
 
             elif 'aarch64' == cpu_architecture:
                 if distro.id() == 'ubuntu':


### PR DESCRIPTION
This PR adds Linux Mint 19.x to the Qt package selector to make building more comfortable on this operating system.