### PR TITLE
Resolve #1557 where Windows builds fail on GHA due to incompatible NSIS version.

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -173,8 +173,7 @@ jobs:
     - name: Override NSIS
       shell: pwsh
       if: startsWith(matrix.os, 'windows')
-      run: |
-        choco install nsis --version=3.06.1
+      run: choco install nsis --version=3.06.1
 
     - name: Create Build Environment
       shell: bash

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -170,6 +170,12 @@ jobs:
           echo "  done"
         fi
 
+    - name: Override NSIS
+      shell: pwsh
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        choco install nsis --version=3.06.1
+
     - name: Create Build Environment
       shell: bash
       run: cmake -E make_directory "${{runner.workspace}}/build"


### PR DESCRIPTION
As of present  just attempts to install  a previous version of NSIS. This will likely fail, but I want to see how GHA complains.