### PR TITLE
Mirror NSIS fix for PR builds to master builds on GHA.

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -136,6 +136,10 @@ jobs:
           echo "  done"
         fi
 
+    - name: Override NSIS
+      shell: pwsh
+      if: startsWith(matrix.os, 'windows')
+      run: choco install nsis --version=3.06.1
 
     - name: Install Python modules
       if: startsWith(matrix.os, 'windows') || startsWith(matrix.os, 'macOS')


### PR DESCRIPTION
Mirrors changes in #1560 to the `master_build.yml`.