### PR TITLE
Fixed some Linux distros being deemed unconditionally too old to use Qt.

### DIFF
--- a/hifi_qt.py
+++ b/hifi_qt.py
@@ -144,12 +144,16 @@ endif()
             if 'x86_64' == cpu_architecture:
                 u_major = int( distro.major_version() )
                 u_minor = int( distro.minor_version() )
-                if (distro.id() == 'ubuntu' and u_major == 18) or distro.id() == 'linuxmint' and u_major == 19:
-                    self.qtUrl = self.assets_url + '/dependencies/vcpkg/qt5-install-5.15.2-ubuntu-18.04-amd64.tar.xz'
-                elif (distro.id() == 'ubuntu' and u_major > 18) or (distro.id() == 'linuxmint' and u_major > 19):
-                    self.__no_qt_package_error()
+                if distro.id() == 'ubuntu' or distro.id() == 'linuxmint':
+                    if (distro.id() == 'ubuntu' and u_major == 18) or distro.id() == 'linuxmint' and u_major == 19:
+                        self.qtUrl = self.assets_url + '/dependencies/vcpkg/qt5-install-5.15.2-ubuntu-18.04-amd64.tar.xz'
+                    elif (distro.id() == 'ubuntu' and u_major > 18) or (distro.id() == 'linuxmint' and u_major > 19):
+                        self.__no_qt_package_error()
+                    else:
+                        self.__unsupported_error()
                 else:
-                    self.__unsupported_error()
+                    self.__no_qt_package_error()
+
 
             elif 'aarch64' == cpu_architecture:
                 if distro.id() == 'ubuntu':


### PR DESCRIPTION
I was getting a confusing "Sorry, Manjaro Linux on x86_64 is too old and won't be officially supported. Please upgrade to a more recent Linux distribution." error message from cmake instead of the usual suggestion to build Qt or use the system version. From the recent changes in hifi_qt.py it seems like this would happen on all Linux distros other than Ubuntu and Mint, so this PR fixes it to make no assumptions for distros that we don't have explicit version checks for, as before.
