### PR TITLE
Add option to render green boxes for missing models.

### DIFF
--- a/interface/src/Menu.cpp
+++ b/interface/src/Menu.cpp
@@ -35,6 +35,7 @@
 #include <MenuItemProperties.h>
 #include <ui/types/FileTypeProfile.h>
 #include <ui/types/HFWebEngineProfile.h>
+#include <SceneScriptingInterface.h>
 
 #include "Application.h"
 #include "AccountManager.h"
@@ -514,6 +515,11 @@ Menu::Menu() {
         addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::HighlightTransitions, 0, false,
             drawStatusConfig, SLOT(setShowFade(bool)));
     }
+
+    action = addCheckableActionToQMenuAndActionHash(renderOptionsMenu, MenuOption::GreenBoxesForMissingModels, 0, true);
+    connect(action, &QAction::triggered, [&](bool checked) {
+        DependencyManager::get<SceneScriptingInterface>()->setShouldRenderModelEntityPlaceholders(checked);
+    });
 
     // Developer > Assets >>>
     // Menu item is not currently needed but code should be kept in case it proves useful again at some stage.

--- a/interface/src/Menu.h
+++ b/interface/src/Menu.h
@@ -232,6 +232,7 @@ namespace MenuOption {
     const QString ComputeBlendshapes = "Compute Blendshapes";
     const QString HighlightTransitions = "Highlight Transitions";
     const QString MaterialProceduralShaders = "Enable Procedural Materials";
+    const QString GreenBoxesForMissingModels = "Green Boxes For Missing Models";
 }
 
 #endif // hifi_Menu_h

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -4,6 +4,7 @@
 //
 //  Created by Brad Hefta-Gaub on 12/6/13.
 //  Copyright 2013 High Fidelity, Inc.
+//  Copyright 2022 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -806,6 +807,7 @@ void EntityTreeRenderer::connectSignalsToSlots(EntityScriptingInterface* entityS
     connect(this, &EntityTreeRenderer::collisionWithEntity, entityScriptingInterface, &EntityScriptingInterface::collisionWithEntity);
 
     connect(DependencyManager::get<SceneScriptingInterface>().data(), &SceneScriptingInterface::shouldRenderEntitiesChanged, this, &EntityTreeRenderer::updateEntityRenderStatus, Qt::QueuedConnection);
+    connect(DependencyManager::get<SceneScriptingInterface>().data(), &SceneScriptingInterface::shouldRenderModelEntityPlaceholdersChanged, this, &EntityTreeRenderer::updateRenderModelEntityPlaceholders, Qt::QueuedConnection);
 }
 
 static glm::vec2 projectOntoEntityXYPlane(EntityItemPointer entity, const PickRay& pickRay, const RayToEntityIntersectionResult& rayPickResult) {
@@ -1261,6 +1263,10 @@ void EntityTreeRenderer::updateEntityRenderStatus(bool shouldRenderEntities) {
             deletingEntity(entityID);
         }
     }
+}
+
+void EntityTreeRenderer::updateRenderModelEntityPlaceholders(bool shouldRenderModelEntityPlaceholders) {
+    _shouldRenderModelEntityPlaceholders = shouldRenderModelEntityPlaceholders;
 }
 
 void EntityTreeRenderer::updateZone(const EntityItemID& id) {

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -4,6 +4,7 @@
 //
 //  Created by Brad Hefta-Gaub on 12/6/13.
 //  Copyright 2013 High Fidelity, Inc.
+//  Copyright 2022 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -140,6 +141,8 @@ public:
     size_t getPrevNumEntityUpdates() const { return _prevNumEntityUpdates; }
     size_t getPrevTotalNeededEntityUpdates() const { return _prevTotalNeededEntityUpdates; }
 
+    bool shouldRenderModelEntityPlaceholders() const { return _shouldRenderModelEntityPlaceholders; }
+
 signals:
     void enterEntity(const EntityItemID& entityItemID);
     void leaveEntity(const EntityItemID& entityItemID);
@@ -151,6 +154,7 @@ public slots:
     void entityScriptChanging(const EntityItemID& entityID, const bool reload);
     void entityCollisionWithEntity(const EntityItemID& idA, const EntityItemID& idB, const Collision& collision);
     void updateEntityRenderStatus(bool shouldRenderEntities);
+    void updateRenderModelEntityPlaceholders(bool shouldRenderModelEntityPlaceholders);
     void updateZone(const EntityItemID& id);
 
     // optional slots that can be wired to menu items
@@ -277,6 +281,7 @@ private:
     static std::function<bool(const QUuid&, graphics::MaterialLayer, const std::string&)> _addMaterialToAvatarOperator;
     static std::function<bool(const QUuid&, graphics::MaterialPointer, const std::string&)> _removeMaterialFromAvatarOperator;
 
+    bool _shouldRenderModelEntityPlaceholders { true };
 };
 
 

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -4,6 +4,7 @@
 //
 //  Created by Brad Hefta-Gaub on 8/6/14.
 //  Copyright 2014 High Fidelity, Inc.
+//  Copyright 2022 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -1469,12 +1470,15 @@ void ModelEntityRenderer::doRender(RenderArgs* args) {
     DETAILED_PROFILE_RANGE(render_detail, "MetaModelRender");
     DETAILED_PERFORMANCE_TIMER("RMEIrender");
 
-    // If the model doesn't have visual geometry, render our bounding box as green wireframe
-    static glm::vec4 greenColor(0.0f, 1.0f, 0.0f, 1.0f);
-    gpu::Batch& batch = *args->_batch;
-    batch.setModelTransform(getModelTransform()); // we want to include the scale as well
-    auto geometryCache = DependencyManager::get<GeometryCache>();
-    geometryCache->renderWireCubeInstance(args, batch, greenColor, geometryCache->getShapePipelinePointer(false, false, args->_renderMethod == Args::RenderMethod::FORWARD));
+    auto entityTreeRenderer = DependencyManager::get<EntityTreeRenderer>();
+    if (entityTreeRenderer->shouldRenderModelEntityPlaceholders()) {
+        // If the model doesn't have visual geometry, render our bounding box as green wireframe
+        static glm::vec4 greenColor(0.0f, 1.0f, 0.0f, 1.0f);
+        gpu::Batch& batch = *args->_batch;
+        batch.setModelTransform(getModelTransform()); // we want to include the scale as well
+        auto geometryCache = DependencyManager::get<GeometryCache>();
+        geometryCache->renderWireCubeInstance(args, batch, greenColor, geometryCache->getShapePipelinePointer(false, false, args->_renderMethod == Args::RenderMethod::FORWARD));
+    }
 
 #if WANT_EXTRA_DEBUGGING
     ModelPointer model = resultWithReadLock<ModelPointer>([&] {

--- a/libraries/script-engine/src/SceneScriptingInterface.cpp
+++ b/libraries/script-engine/src/SceneScriptingInterface.cpp
@@ -4,6 +4,7 @@
 //
 //  Created by Sam Gateau on 2/24/15.
 //  Copyright 2014 High Fidelity, Inc.
+//  Copyright 2022 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -22,5 +23,12 @@ void SceneScriptingInterface::setShouldRenderEntities(bool shouldRenderEntities)
     if (shouldRenderEntities != _shouldRenderEntities) {
         _shouldRenderEntities = shouldRenderEntities;
         emit shouldRenderEntitiesChanged(_shouldRenderEntities);
+    }
+}
+
+void SceneScriptingInterface::setShouldRenderModelEntityPlaceholders(bool shouldRenderModelEntityPlaceholders) {
+    if (shouldRenderModelEntityPlaceholders != _shouldRenderModelEntityPlaceholders) {
+        _shouldRenderModelEntityPlaceholders = shouldRenderModelEntityPlaceholders;
+        emit shouldRenderModelEntityPlaceholdersChanged(_shouldRenderModelEntityPlaceholders);
     }
 }

--- a/libraries/script-engine/src/SceneScriptingInterface.h
+++ b/libraries/script-engine/src/SceneScriptingInterface.h
@@ -4,6 +4,7 @@
 //
 //  Created by Sam Gateau on 2/24/15.
 //  Copyright 2014 High Fidelity, Inc.
+//  Copyright 2022 Vircadia contributors.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
@@ -30,6 +31,8 @@
  * @property {boolean} shouldRenderAvatars - <code>true</code> if avatars are rendered, <code>false</code> if they aren't.
  * @property {boolean} shouldRenderEntities - <code>true</code> if entities (domain, avatar, and local) are rendered, 
  *     <code>false</code> if they aren't.
+ * @property {boolean} shouldRenderModelEntityPlaceholders - <code>true</code> if green cubes are rendered when a model hasn't
+ *     loaded, <code>false</code> if they aren't.
  */
 /// Provides the <code><a href="https://apidocs.vircadia.dev/Scene.html">Scene</a></code> scripting interface
 class SceneScriptingInterface : public QObject, public Dependency {
@@ -39,10 +42,13 @@ class SceneScriptingInterface : public QObject, public Dependency {
 public:
     Q_PROPERTY(bool shouldRenderAvatars READ shouldRenderAvatars WRITE setShouldRenderAvatars)
     Q_PROPERTY(bool shouldRenderEntities READ shouldRenderEntities WRITE setShouldRenderEntities)
+    Q_PROPERTY(bool shouldRenderModelEntityPlaceholders READ shouldRenderModelEntityPlaceholders WRITE setShouldRenderModelEntityPlaceholders)
     bool shouldRenderAvatars() const { return _shouldRenderAvatars; }
     bool shouldRenderEntities() const { return _shouldRenderEntities; }
+    bool shouldRenderModelEntityPlaceholders() const { return _shouldRenderModelEntityPlaceholders; }
     void setShouldRenderAvatars(bool shouldRenderAvatars);
     void setShouldRenderEntities(bool shouldRenderEntities);
+    void setShouldRenderModelEntityPlaceholders(bool shouldRenderModelEntityPlaceholders);
 
 signals:
 
@@ -67,9 +73,19 @@ signals:
      */
     void shouldRenderEntitiesChanged(bool shouldRenderEntities);
 
+    /*@jsdoc
+     * Triggered when whether or not green boxes should be rendered for missing models changes.
+     * @function Scene.shouldRenderModelEntityPlaceholdersChanged
+     * @param {boolean} shouldRenderModelEntityPlaceholders - <code>true</code> if green boxes should be rendered for models
+     *     that haven't loaded, <code>false</code> if they shouldn't be.
+     * @returns {Signal}
+     */
+    void shouldRenderModelEntityPlaceholdersChanged(bool shouldRenderModelEntityPlaceholders);
+
 protected:
     bool _shouldRenderAvatars { true };
     bool _shouldRenderEntities { true };
+    bool _shouldRenderModelEntityPlaceholders { true };
 };
 
 #endif // hifi_SceneScriptingInterface_h 


### PR DESCRIPTION
Adds a Developer menu item: `Developer > Render > Green Boxes For Missing Models`

Also adds a property and a signal to the `Scene` scripting API. These API items are used by the Developer menu item.