### PR TITLE
Replace call to devicePixelRatio() with devicePixelRatioF().

### DIFF
--- a/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
+++ b/libraries/display-plugins/src/display-plugins/OpenGLDisplayPlugin.cpp
@@ -844,7 +844,7 @@ glm::uvec2 OpenGLDisplayPlugin::getSurfacePixels() const {
     uvec2 result;
     auto window = _container->getPrimaryWidget();
     if (window) {
-        result = toGlm(window->geometry().size() * window->devicePixelRatio());
+        result = toGlm(window->geometry().size() * window->devicePixelRatioF());
     }
     return result;
 }


### PR DESCRIPTION
Addresses: https://github.com/vircadia/vircadia/issues/794

`devicePixelRatio()` which returns an integer is unsuitable when the user's DPI is not a multiple of 100%. Changing this to `devicePixelRatioF()` allows the interface to work correctly on desktops where a fractional scale is used as it returns a float.

Tested on Linux KDE with a scale of 100% and 140% - both work fine
