### PR TITLE
Fix sdl2 linking errors when built against new Wayland.

### DIFF
--- a/cmake/ports/sdl2/fix-build-against-wayland-1_20.patch
+++ b/cmake/ports/sdl2/fix-build-against-wayland-1_20.patch
@@ -1,0 +1,28 @@
+diff -ur a/src/video/wayland/SDL_waylanddyn.h b/src/video/wayland/SDL_waylanddyn.h
+--- a/src/video/wayland/SDL_waylanddyn.h
++++ b/src/video/wayland/SDL_waylanddyn.h
+@@ -77,6 +77,9 @@
+ #define wl_proxy_add_listener (*WAYLAND_wl_proxy_add_listener)
+ #define wl_proxy_marshal_constructor (*WAYLAND_wl_proxy_marshal_constructor)
+ #define wl_proxy_marshal_constructor_versioned (*WAYLAND_wl_proxy_marshal_constructor_versioned)
++#define wl_proxy_marshal_flags (*WAYLAND_wl_proxy_marshal_flags)
++#define wl_proxy_marshal_array_flags (*WAYLAND_wl_proxy_marshal_array_flags)
++#define wl_proxy_get_version (*WAYLAND_wl_proxy_get_version)
+
+ #define wl_seat_interface (*WAYLAND_wl_seat_interface)
+ #define wl_surface_interface (*WAYLAND_wl_surface_interface)
+diff -ur a/src/video/wayland/SDL_waylandsym.h b/src/video/wayland/SDL_waylandsym.h
+--- a/src/video/wayland/SDL_waylandsym.h
++++ b/src/video/wayland/SDL_waylandsym.h
+@@ -70,6 +70,11 @@
+ SDL_WAYLAND_MODULE(WAYLAND_CLIENT_1_10)
+ SDL_WAYLAND_SYM(struct wl_proxy *, wl_proxy_marshal_constructor_versioned, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interface, uint32_t version, ...))
+
++SDL_WAYLAND_MODULE(WAYLAND_CLIENT_1_20)
++SDL_WAYLAND_SYM(struct wl_proxy*, wl_proxy_marshal_flags, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interfac, uint32_t version, uint32_t flags, ...))
++SDL_WAYLAND_SYM(struct wl_proxy*, wl_proxy_marshal_array_flags, (struct wl_proxy *proxy, uint32_t opcode, const struct wl_interface *interface, uint32_t version,  uint32_t flags, union wl_argument *args))
++SDL_WAYLAND_SYM(uint32_t, wl_proxy_get_version, (struct wl_proxy *))
++
+ SDL_WAYLAND_INTERFACE(wl_seat_interface)
+ SDL_WAYLAND_INTERFACE(wl_surface_interface)
+ SDL_WAYLAND_INTERFACE(wl_shm_pool_interface)

--- a/cmake/ports/sdl2/portfile.cmake
+++ b/cmake/ports/sdl2/portfile.cmake
@@ -12,6 +12,7 @@ vcpkg_from_github(
         fix-arm64-headers.patch
         disable-hidapi-for-uwp.patch
         fix-space-in-path.patch
+        fix-build-against-wayland-1_20.patch
 )
 
 string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" SDL_STATIC)


### PR DESCRIPTION
I was getting linking errors from hifiSDL2 plugin on Manjaro similar to what is described [here](https://www.linuxquestions.org/questions/slackware-14/regression-on-current-with-sdl2-4175704819-print/), so applied a patch in the same vein as well.


Wayland version: 1.20.0-1

<details>
  <summary>The actual errors</summary>

```
[ 82%] Linking CXX shared library libhifiSdl2.so
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandvideo.c.o): in function `wl_display_get_registry':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1032: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1032: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandvideo.c.o): in function `wl_registry_bind':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1145: undefined reference to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1145: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1145: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1145: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandvideo.c.o):/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-
rel/wayland-generated-protocols/wayland-client-protocol.h:1145: more undefined references to `wl_proxy_marshal_flags' follow
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandvideo.c.o): in function `handle_ping_xdg_wm_base':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/src/ase-2.0.10-16237a1185/src/video/wayland/SDL_waylandvideo.c:394: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandvideo.c.o): in function `xdg_wm_base_pong':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:539: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandvideo.c.o): in function `xdg_wm_base_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:482: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:482: undefined reference to `wl_proxy_m
arshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:482: undefined reference to `wl_proxy_g
et_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:482: undefined reference to `wl_proxy_m
arshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandvideo.c.o): in function `handle_ping_xdg_wm_base':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/src/ase-2.0.10-16237a1185/src/video/wayland/SDL_waylandvideo.c:394: undefined reference to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandvideo.c.o): in function `xdg_wm_base_pong':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:539: undefined reference to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_shell_surface_pong':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3092: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_surface_set_buffer_scale':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3749: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3749: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `xdg_surface_ack_configure':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1106: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1106: undefined reference to `wl_proxy_
marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_compositor_create_region':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1277: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1277: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_region_add':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:5327: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:5327: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_surface_set_opaque_region':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3614: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3614: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_surface_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `handle_configure_xdg_shell_surface':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/src/ase-2.0.10-16237a1185/src/video/wayland/SDL_waylandwindow.c:136: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/src/ase-2.0.10-16237a1185/src/video/wayland/SDL_waylandwindow.c:136: undefined reference to `wl_proxy_marshal
_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/src/ase-2.0.10-16237a1185/src/video/wayland/SDL_waylandwindow.c:136: undefined reference to `wl_proxy_get_ver
sion'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/src/ase-2.0.10-16237a1185/src/video/wayland/SDL_waylandwindow.c:136: undefined reference to `wl_proxy_marshal
_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/src/ase-2.0.10-16237a1185/src/video/wayland/SDL_waylandwindow.c:136: undefined reference to `wl_proxy_get_ver
sion'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/src/ase-2.0.10-16237a1185/src/video/wayland/SDL_waylandwindow.c:136: undefined reference to `wl_proxy_marshal
_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/src/ase-2.0.10-16237a1185/src/video/wayland/SDL_waylandwindow.c:136: undefined reference to `wl_proxy_get_ver
sion'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/src/ase-2.0.10-16237a1185/src/video/wayland/SDL_waylandwindow.c:136: undefined reference to `wl_proxy_marshal
_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/src/ase-2.0.10-16237a1185/src/video/wayland/SDL_waylandwindow.c:136: undefined reference to `wl_proxy_get_ver
sion'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/src/ase-2.0.10-16237a1185/src/video/wayland/SDL_waylandwindow.c:136: undefined reference to `wl_proxy_marshal
_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/src/ase-2.0.10-16237a1185/src/video/wayland/SDL_waylandwindow.c:136: undefined reference to `wl_proxy_get_ver
sion'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/src/ase-2.0.10-16237a1185/src/video/wayland/SDL_waylandwindow.c:136: undefined reference to `wl_proxy_marshal
_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `xdg_toplevel_unset_fullscreen':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1740: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1740: undefined reference to `wl_proxy_
marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `xdg_toplevel_set_fullscreen':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1713: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1713: undefined reference to `wl_proxy_
marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_shell_surface_set_toplevel':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3138: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3138: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `xdg_toplevel_unset_fullscreen':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1740: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1740: undefined reference to `wl_proxy_
marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_shell_surface_set_fullscreen':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3200: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3200: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `xdg_toplevel_unset_fullscreen':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1740: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1740: undefined reference to `wl_proxy_
marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `xdg_toplevel_set_fullscreen':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1713: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1713: undefined reference to `wl_proxy_
marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_shell_surface_set_toplevel':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3138: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3138: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `xdg_toplevel_unset_fullscreen':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1740: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1740: undefined reference to `wl_proxy_
marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_shell_surface_set_fullscreen':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3200: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3200: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_shell_surface_set_toplevel':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3138: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3138: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `zxdg_toplevel_decoration_v1_set_mode':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-decoration-unstable-v1-client-protocol.h:355: undefined reference to `wl_prox
y_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-decoration-unstable-v1-client-protocol.h:355: undefined referen
ce to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `xdg_toplevel_set_maximized':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1647: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1647: undefined reference to `wl_proxy_
marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_shell_surface_set_maximized':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3259: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3259: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_compositor_create_surface':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1261: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1261: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `xdg_wm_base_get_xdg_surface':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:524: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:524: undefined reference to `wl_proxy_m
arshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `xdg_surface_get_toplevel':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1011: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1011: undefined reference to `wl_proxy_
marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `xdg_toplevel_set_app_id':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1436: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1436: undefined reference to `wl_proxy_
marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `zxdg_decoration_manager_v1_get_toplevel_decoration':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-decoration-unstable-v1-client-protocol.h:197: undefined reference to `wl_prox
y_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-decoration-unstable-v1-client-protocol.h:197: undefined referen
ce to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `zxdg_toplevel_decoration_v1_set_mode':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-decoration-unstable-v1-client-protocol.h:355: undefined reference to `wl_prox
y_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-decoration-unstable-v1-client-protocol.h:355: undefined referen
ce to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_compositor_create_region':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1277: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1277: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_region_add':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:5327: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:5327: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_surface_set_opaque_region':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3614: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3614: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_surface_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_surface_commit':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3675: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3675: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `org_kde_kwin_server_decoration_manager_create':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/org-kde-kwin-server-decoration-manager-client-protocol.h:192: undefined reference
 to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/org-kde-kwin-server-decoration-manager-client-protocol.h:192: undef
ined reference to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `zxdg_toplevel_decoration_v1_set_mode':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-decoration-unstable-v1-client-protocol.h:355: undefined reference to `wl_prox
y_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-decoration-unstable-v1-client-protocol.h:355: undefined referen
ce to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `zxdg_shell_v6_get_xdg_surface':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-unstable-v6-client-protocol.h:486: undefined reference to `wl_proxy_get
_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-unstable-v6-client-protocol.h:486: undefined reference to
 `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `zxdg_surface_v6_get_toplevel':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-unstable-v6-client-protocol.h:998: undefined reference to `wl_proxy_get
_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-unstable-v6-client-protocol.h:998: undefined reference to
 `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_shell_get_shell_surface':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2821: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2821: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_shell_surface_set_class':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3294: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3294: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_surface_set_buffer_scale':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3749: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3749: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_compositor_create_region':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1277: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1277: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_region_add':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:5327: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:5327: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_surface_set_opaque_region':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3614: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3614: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_surface_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `xdg_toplevel_set_title':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1405: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1405: undefined reference to `wl_proxy_
marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_shell_surface_set_title':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3277: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3277: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_surface_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_ge
t_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_ge
t_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_ge
t_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_ge
t_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_shell_surface_pong':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3092: undefined reference to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `zxdg_toplevel_decoration_v1_set_mode':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-decoration-unstable-v1-client-protocol.h:355: undefined reference to `wl_prox
y_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandwindow.c.o): in function `wl_surface_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3450: undefined reference to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylanddatamanager.c.o): in function `wl_data_source_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2353: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2353: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylanddatamanager.c.o): in function `wl_data_offer_receive':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2040: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2040: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylanddatamanager.c.o): in function `wl_data_offer_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2052: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2052: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylanddatamanager.c.o): in function `wl_data_device_set_selection':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2624: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2624: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylanddatamanager.c.o): in function `wl_data_source_offer':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2341: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2341: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2341: undefined reference to `wl_proxy_ge
t_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2341: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2341: undefined reference to `wl_proxy_ge
t_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2341: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2341: undefined reference to `wl_proxy_ge
t_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2341: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2341: undefined reference to `wl_proxy_ge
t_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2341: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylanddatamanager.c.o): in function `wl_data_device_set_selection':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2624: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2624: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2624: undefined reference to `wl_proxy_ge
t_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2624: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2624: undefined reference to `wl_proxy_ge
t_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2624: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_seat_get_keyboard':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3980: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3980: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_seat_get_pointer':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3958: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3958: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_seat_get_touch':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:4002: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:4002: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_data_offer_accept':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2014: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2014: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_data_offer_set_actions':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2116: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_data_offer_accept':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2014: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2014: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `xdg_toplevel_resize':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1526: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1526: undefined reference to `wl_proxy_
marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_shell_surface_resize':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3124: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3124: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `xdg_toplevel_move':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1485: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1485: undefined reference to `wl_proxy_
marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_shell_surface_move':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3108: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3108: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_data_device_manager_create_data_source':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2740: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2740: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_data_source_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2353: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2353: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_registry_bind':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1145: undefined reference to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_data_device_manager_get_data_device':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2756: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2756: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_data_device_release':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2636: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2636: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_registry_bind':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1145: undefined reference to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `zwp_pointer_constraints_v1_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/pointer-constraints-unstable-v1-client-protocol.h:322: undefined reference to `wl
_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_registry_bind':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1145: undefined reference to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `zwp_pointer_constraints_v1_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/pointer-constraints-unstable-v1-client-protocol.h:322: undefined reference to `wl
_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `zwp_pointer_constraints_v1_lock_pointer':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/pointer-constraints-unstable-v1-client-protocol.h:369: undefined reference to `wl
_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/pointer-constraints-unstable-v1-client-protocol.h:369: undefined re
ference to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `zwp_relative_pointer_manager_v1_get_relative_pointer':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/relative-pointer-unstable-v1-client-protocol.h:176: undefined reference to `wl_pr
oxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/relative-pointer-unstable-v1-client-protocol.h:176: undefined refer
ence to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `zwp_pointer_constraints_v1_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/pointer-constraints-unstable-v1-client-protocol.h:322: undefined reference to `wl
_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/pointer-constraints-unstable-v1-client-protocol.h:322: undefined re
ference to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/pointer-constraints-unstable-v1-client-protocol.h:322: undefined re
ference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/pointer-constraints-unstable-v1-client-protocol.h:322: undefined re
ference to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `wl_data_offer_set_actions':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:2116: undefined reference to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandevents.c.o): in function `zwp_pointer_constraints_v1_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/pointer-constraints-unstable-v1-client-protocol.h:322: undefined reference to `wl
_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/pointer-constraints-unstable-v1-client-protocol.h:322: undefined re
ference to `wl_proxy_marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandmouse.c.o): in function `wl_shm_create_pool':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1735: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1735: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandmouse.c.o): in function `wl_shm_pool_create_buffer':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1341: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1341: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandmouse.c.o): in function `wl_shm_pool_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1359: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1359: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandmouse.c.o): in function `wl_compositor_create_surface':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1261: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1261: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandmouse.c.o): in function `wl_pointer_set_cursor':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:4495: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:4495: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandmouse.c.o): in function `wl_surface_attach':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3500: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3500: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandmouse.c.o): in function `wl_surface_damage':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3532: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3532: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandmouse.c.o): in function `wl_surface_commit':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3675: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3675: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandmouse.c.o): in function `wl_pointer_set_cursor':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:4495: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:4495: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandmouse.c.o): in function `wl_buffer_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1820: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1820: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1820: undefined reference to `wl_proxy_ge
t_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1820: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandmouse.c.o): in function `wl_compositor_create_surface':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1261: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1261: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandopengles.c.o): in function `wl_surface_set_buffer_scale':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3749: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3749: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandopengles.c.o): in function `xdg_surface_ack_configure':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1106: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/xdg-shell-client-protocol.h:1106: undefined reference to `wl_proxy_
marshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandopengles.c.o): in function `wl_compositor_create_region':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1277: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1277: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandopengles.c.o): in function `wl_region_add':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:5327: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:5327: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandopengles.c.o): in function `wl_surface_set_opaque_region':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3614: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:3614: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandopengles.c.o): in function `wl_region_destroy':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:5315: undefined reference to `wl_proxy_get_version'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:5315: undefined reference to `wl_proxy_ma
rshal_flags'
/usr/sbin/ld: /home/namark/vircadia-files/vcpkg/2f668515/installed/x64-linux/lib/libSDL2.a(SDL_waylandtouch.c.o): in function `wl_registry_bind':
/home/namark/vircadia-files/vcpkg/2f668515/buildtrees/sdl2/x64-linux-rel/wayland-generated-protocols/wayland-client-protocol.h:1145: undefined reference to `wl_proxy_marshal_flags'
collect2: error: ld returned 1 exit status
make[3]: *** [plugins/hifiSdl2/CMakeFiles/hifiSdl2.dir/build.make:257: plugins/hifiSdl2/libhifiSdl2.so] Error 1
make[2]: *** [CMakeFiles/Makefile2:6083: plugins/hifiSdl2/CMakeFiles/hifiSdl2.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:5425: interface/CMakeFiles/interface.dir/rule] Error 2
make: *** [Makefile:1723: interface] Error 2
```
</details>
