### PR TITLE
Improve audio settings

### DIFF
--- a/assignment-client/src/Agent.cpp
+++ b/assignment-client/src/Agent.cpp
@@ -332,6 +332,9 @@ void Agent::selectAudioFormat(const QString& selectedCodecName) {
             _codec = plugin;
             _receivedAudioStream.setupCodec(plugin, _selectedCodecName, AudioConstants::STEREO);
             _encoder = plugin->createEncoder(AudioConstants::SAMPLE_RATE, AudioConstants::MONO);
+
+            //TODO: _codecSettings is not being set by anything -- where do we receive the settings here?
+            _encoder->configure(_codecSettings);
             qDebug() << "Selected Codec Plugin:" << _codec.get();
             break;
         }
@@ -719,7 +722,7 @@ void Agent::processAgentAvatarAudio() {
             if (isPlayingRecording && !_shouldMuteRecordingAudio) {
                 _shouldMuteRecordingAudio = true;
             }
-            
+
             auto audioData = _avatarSound->getAudioData();
             nextSoundOutput = reinterpret_cast<const int16_t*>(audioData->rawData()
                     + _numAvatarSoundSentBytes);
@@ -880,7 +883,7 @@ void Agent::aboutToFinish() {
     {
         DependencyManager::get<ScriptEngines>()->shutdownScripting();
     }
-    
+
     DependencyManager::destroy<ScriptEngines>();
 
     DependencyManager::destroy<AssignmentDynamicFactory>();

--- a/assignment-client/src/Agent.h
+++ b/assignment-client/src/Agent.h
@@ -121,6 +121,7 @@ private:
     Encoder* _encoder { nullptr };
     QTimer _avatarAudioTimer;
     bool _flushEncoder { false };
+    std::vector<Encoder::CodecSettings> _codecSettings;
 };
 
 #endif // hifi_Agent_h

--- a/assignment-client/src/audio/AudioMixer.h
+++ b/assignment-client/src/audio/AudioMixer.h
@@ -24,6 +24,7 @@
 
 #include "AudioMixerStats.h"
 #include "AudioMixerSlavePool.h"
+#include "plugins/CodecPlugin.h"
 
 class PositionalAudioStream;
 class AvatarAudioStream;
@@ -52,6 +53,19 @@ public:
         float wetLevel;
     };
 
+/*
+    struct CodecSettings {
+        QString codec;
+        Encoder::Bandpass bandpass = Encoder::Bandpass::Fullband;
+        Encoder::ApplicationType applicationType = Encoder::ApplicationType::Audio;
+        Encoder::SignalType signalType = Encoder::SignalType::Auto;
+        int bitrate = 128000;
+        int complexity = 100;
+        bool enableFEC = 0;
+        int packetLossPercent = 0;
+        bool enableVBR = 1;
+    };
+*/
     static int getStaticJitterFrames() { return _numStaticJitterFrames; }
     static bool shouldMute(float quietestFrame) { return quietestFrame > _noiseMutingThreshold; }
     static float getAttenuationPerDoublingInDistance() { return _attenuationPerDoublingInDistance; }
@@ -59,6 +73,7 @@ public:
     static const std::vector<ZoneSettings>& getZoneSettings() { return _zoneSettings; }
     static const std::vector<ReverbSettings>& getReverbSettings() { return _zoneReverbSettings; }
     static const std::pair<QString, CodecPluginPointer> negotiateCodec(std::vector<QString> codecs);
+    static const std::vector<Encoder::CodecSettings> getCodecSettings() { return _codecSettings; }
 
     static bool shouldReplicateTo(const Node& from, const Node& to) {
         return to.getType() == NodeType::DownstreamAudioMixer &&
@@ -67,7 +82,7 @@ public:
     }
 
     virtual void aboutToFinish() override;
-    
+
 public slots:
     void run() override;
     void sendStatsPacket() override;
@@ -149,6 +164,7 @@ private:
     static std::vector<ZoneDescription> _audioZones;
     static std::vector<ZoneSettings> _zoneSettings;
     static std::vector<ReverbSettings> _zoneReverbSettings;
+    static std::vector<Encoder::CodecSettings> _codecSettings;
 
     float _throttleStartTarget = 0.9f;
     float _throttleBackoffTarget = 0.44f;

--- a/assignment-client/src/audio/AudioMixerClientData.cpp
+++ b/assignment-client/src/audio/AudioMixerClientData.cpp
@@ -165,7 +165,7 @@ void AudioMixerClientData::optionallyReplicatePacket(ReceivedMessage& message, c
 
                     packet->write(message.getMessage());
                 }
-                
+
                 nodeList->sendUnreliablePacket(*packet, *downstreamNode);
             }
         });
@@ -375,7 +375,7 @@ int AudioMixerClientData::parseData(ReceivedMessage& message) {
             qWarning() << "Received AudioStreamStats of wrong size" << message.getBytesLeftToRead()
                 << "instead of" << sizeof(AudioStreamStats) << "from"
                 << message.getSourceID() << "at" << message.getSenderSockAddr();
-            
+
             return message.getPosition();
         }
 
@@ -783,6 +783,8 @@ void AudioMixerClientData::setupCodec(CodecPluginPointer codec, const QString& c
     if (codec) {
         _encoder = codec->createEncoder(AudioConstants::SAMPLE_RATE, AudioConstants::STEREO);
         _decoder = codec->createDecoder(AudioConstants::SAMPLE_RATE, AudioConstants::MONO);
+
+        _encoder->configure(_codecSettings);
     }
 
     auto avatarAudioStream = getAvatarAudioStream();

--- a/assignment-client/src/audio/AudioMixerClientData.h
+++ b/assignment-client/src/audio/AudioMixerClientData.h
@@ -108,6 +108,7 @@ public:
     bool shouldFlushEncoder() { return _shouldFlushEncoder; }
 
     QString getCodecName() { return _selectedCodecName; }
+    void setCodecSettings(const std::vector<Encoder::CodecSettings> &settings) { _codecSettings = settings; }
 
     bool shouldMuteClient() { return _shouldMuteClient; }
     void setShouldMuteClient(bool shouldMuteClient) { _shouldMuteClient = shouldMuteClient; }
@@ -201,6 +202,7 @@ private:
     QString _selectedCodecName;
     Encoder* _encoder{ nullptr }; // for outbound mixed stream
     Decoder* _decoder{ nullptr }; // for mic stream
+    std::vector<Encoder::CodecSettings> _codecSettings;
 
     bool _shouldFlushEncoder { false };
 

--- a/assignment-client/src/scripts/EntityScriptServer.h
+++ b/assignment-client/src/scripts/EntityScriptServer.h
@@ -25,6 +25,7 @@
 #include <SimpleEntitySimulation.h>
 #include <ThreadedAssignment.h>
 #include "../entities/EntityTreeHeadlessViewer.h"
+#include "plugins/CodecPlugin.h"
 
 class EntityScriptServer : public ThreadedAssignment {
     Q_OBJECT
@@ -90,6 +91,7 @@ private:
     QString _selectedCodecName;
     CodecPluginPointer _codec;
     Encoder* _encoder { nullptr };
+    std::vector<Encoder::CodecSettings> _codecSettings;
 };
 
 #endif // hifi_EntityScriptServer_h

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -1277,7 +1277,7 @@
     {
       "name": "audio_env",
       "label": "Audio Environment",
-      "assignment-types": [ 0 ],
+      "assignment-types": [ 0, 5 ],
       "settings": [
         {
           "name": "attenuation_per_doubling_in_distance",
@@ -1417,10 +1417,62 @@
         {
           "name": "codec_preference_order",
           "label": "Audio Codec Preference Order",
-          "help": "List of codec names in order of preferred usage",
+          "help": "List of codec names in order of preferred usage -- mod2",
           "placeholder": "opus, hifiAC, zlib, pcm",
           "default": "opus,hifiAC,zlib,pcm",
           "advanced": true
+        },
+        {
+          "name": "codec_settings",
+          "label": "Audio Codec Settings",
+          "help": "Advanced settings for audio codecs",
+          "advanced": true,
+          "type": "table",
+          "numbered": false,
+          "content_setting": false,
+          "can_add_new_rows": true,
+          "columns" : [
+            {
+              "name": "codec",
+              "label": "Codec",
+              "can_set": false,
+              "placeholder": "(codec)"
+            },
+            {
+              "name": "complexity",
+              "label": "Complexity",
+              "can_set": true,
+              "type": "int",
+              "placeholder": "(percentage)"
+            },
+            {
+              "name": "bitrate",
+              "label": "Bitrate",
+              "can_set": true,
+              "placeholder": "(bps)"
+            },
+            {
+              "name": "vbr",
+              "label": "Variable Bitrate",
+              "can_set": true,
+              "type": "checkbox"
+            },
+            {
+              "name": "fec",
+              "label": "Error correction",
+              "can_set": true,
+              "type": "checkbox",
+              "placeholder": "(percentage)"
+            },
+            {
+              "name": "packet_loss",
+              "label": "Expected loss %",
+              "can_set": true,
+              "type": "int",
+              "placeholder": "(percentage)"
+            }
+
+          ]
         }
       ]
     },

--- a/libraries/audio-client/src/AudioClient.cpp
+++ b/libraries/audio-client/src/AudioClient.cpp
@@ -95,7 +95,7 @@ void AudioClient::setHmdAudioName(QAudio::Mode mode, const QString& name) {
 // thread-safe
 QList<HifiAudioDeviceInfo> getAvailableDevices(QAudio::Mode mode, const QString& hmdName) {
     //get hmd device name prior to locking device mutex. in case of shutdown, this thread will be locked and audio client
-    //cannot properly shut down. 
+    //cannot properly shut down.
     QString defDeviceName = defaultAudioDeviceName(mode);
 
     // NOTE: availableDevices() clobbers the Qt internal device list
@@ -132,7 +132,7 @@ QList<HifiAudioDeviceInfo> getAvailableDevices(QAudio::Mode mode, const QString&
                 break;
             }
         }
-        
+
         if (!hmdDevice.getDevice().isNull()) {
             newDevices.push_front(hmdDevice);
         }
@@ -159,7 +159,7 @@ void AudioClient::checkDevices() {
 
     auto inputDevices = getAvailableDevices(QAudio::AudioInput, hmdInputName);
     auto outputDevices = getAvailableDevices(QAudio::AudioOutput, hmdOutputName);
-   
+
     static const QMetaMethod devicesChangedSig= QMetaMethod::fromSignal(&AudioClient::devicesChanged);
     //only emit once the scripting interface has connected to the signal
     if (isSignalConnected(devicesChangedSig)) {
@@ -173,7 +173,7 @@ void AudioClient::checkDevices() {
             _outputDevices.swap(outputDevices);
             emit devicesChanged(QAudio::AudioOutput, _outputDevices);
         }
-    } 
+    }
 }
 
 HifiAudioDeviceInfo AudioClient::getActiveAudioDevice(QAudio::Mode mode) const {
@@ -280,7 +280,7 @@ static float computeLoudness(int16_t* samples, int numSamples) {
 
 template <int NUM_CHANNELS>
 static void applyGainSmoothing(float* buffer, int numFrames, float gain0, float gain1) {
-    
+
     // fast path for unity gain
     if (gain0 == 1.0f && gain1 == 1.0f) {
         return;
@@ -295,7 +295,7 @@ static void applyGainSmoothing(float* buffer, int numFrames, float gain0, float 
     float tStep = 1.0f / numFrames;
 
     for (int i = 0; i < numFrames; i++) {
-   
+
         // evaluate poly over t=[0,1)
         float gain = (c3 * t + c2) * t * t + c0;
         t += tStep;
@@ -386,7 +386,7 @@ AudioClient::AudioClient() {
         PacketReceiver::makeUnsourcedListenerReference<AudioClient>(this, &AudioClient::handleSelectedAudioFormat));
 
     auto& domainHandler = nodeList->getDomainHandler();
-    connect(&domainHandler, &DomainHandler::disconnectedFromDomain, this, [this] { 
+    connect(&domainHandler, &DomainHandler::disconnectedFromDomain, this, [this] {
         _solo.reset();
     });
     connect(nodeList.data(), &NodeList::nodeActivated, this, [this](SharedNodePointer node) {
@@ -578,7 +578,7 @@ QString defaultAudioDeviceName(QAudio::Mode mode) {
             waveInGetDevCaps(WAVE_MAPPER, &wic, sizeof(wic));
             //Use the received manufacturer id to get the device's real name
             waveInGetDevCaps(wic.wMid, &wic, sizeof(wic));
-#if !defined(NDEBUG) 
+#if !defined(NDEBUG)
             qCDebug(audioclient) << "input device:" << wic.szPname;
 #endif
             deviceName = wic.szPname;
@@ -588,7 +588,7 @@ QString defaultAudioDeviceName(QAudio::Mode mode) {
             waveOutGetDevCaps(WAVE_MAPPER, &woc, sizeof(woc));
             //Use the received manufacturer id to get the device's real name
             waveOutGetDevCaps(woc.wMid, &woc, sizeof(woc));
-#if !defined(NDEBUG) 
+#if !defined(NDEBUG)
             qCDebug(audioclient) << "output device:" << woc.szPname;
 #endif
             deviceName = woc.szPname;
@@ -613,8 +613,8 @@ QString defaultAudioDeviceName(QAudio::Mode mode) {
         CoUninitialize();
     }
 
-#if !defined(NDEBUG) 
-    qCDebug(audioclient) << "defaultAudioDeviceForMode mode: " << (mode == QAudio::AudioOutput ? "Output" : "Input") 
+#if !defined(NDEBUG)
+    qCDebug(audioclient) << "defaultAudioDeviceForMode mode: " << (mode == QAudio::AudioOutput ? "Output" : "Input")
 	<< " [" << deviceName << "] [" << "]";
 #endif
 
@@ -795,7 +795,7 @@ void AudioClient::start() {
 
     _desiredOutputFormat = _desiredInputFormat;
     _desiredOutputFormat.setChannelCount(OUTPUT_CHANNEL_COUNT);
-    
+
     QString inputName;
     QString outputName;
     {
@@ -803,10 +803,10 @@ void AudioClient::start() {
         inputName = _hmdInputName;
         outputName = _hmdOutputName;
     }
-    
+
     //initialize input to the dummy device to prevent starves
     switchInputToAudioDevice(HifiAudioDeviceInfo());
-    switchOutputToAudioDevice(defaultAudioDeviceForMode(QAudio::AudioOutput, QString())); 
+    switchOutputToAudioDevice(defaultAudioDeviceForMode(QAudio::AudioOutput, QString()));
 
 #if defined(Q_OS_ANDROID)
     connect(&_checkInputTimer, &QTimer::timeout, this, &AudioClient::checkInputTimeout);
@@ -1005,6 +1005,7 @@ void AudioClient::selectAudioFormat(const QString& selectedCodecName) {
             _codec = plugin;
             _receivedAudioStream.setupCodec(plugin, _selectedCodecName, AudioConstants::STEREO);
             _encoder = plugin->createEncoder(AudioConstants::SAMPLE_RATE, _isStereoInput ? AudioConstants::STEREO : AudioConstants::MONO);
+            _encoder->configure(_codecSettings);
             qCDebug(audioclient) << "Selected codec plugin:" << _codec.get();
             break;
         }
@@ -1015,7 +1016,7 @@ void AudioClient::selectAudioFormat(const QString& selectedCodecName) {
 bool AudioClient::switchAudioDevice(QAudio::Mode mode, const HifiAudioDeviceInfo& deviceInfo) {
     auto device = deviceInfo;
     if (deviceInfo.getDevice().isNull()) {
-        qCDebug(audioclient) << __FUNCTION__ << " switching to null device :" 
+        qCDebug(audioclient) << __FUNCTION__ << " switching to null device :"
             << deviceInfo.deviceName() << " : " << deviceInfo.getDevice().deviceName();
     }
 
@@ -1868,7 +1869,7 @@ void AudioClient::outputFormatChanged() {
 bool AudioClient::switchInputToAudioDevice(const HifiAudioDeviceInfo inputDeviceInfo, bool isShutdownRequest) {
     Q_ASSERT_X(QThread::currentThread() == thread(), Q_FUNC_INFO, "Function invoked on wrong thread");
 
-    qCDebug(audioclient) << __FUNCTION__ << "_inputDeviceInfo: [" << _inputDeviceInfo.deviceName() << ":" << _inputDeviceInfo.getDevice().deviceName() 
+    qCDebug(audioclient) << __FUNCTION__ << "_inputDeviceInfo: [" << _inputDeviceInfo.deviceName() << ":" << _inputDeviceInfo.getDevice().deviceName()
         << "-- inputDeviceInfo:" << inputDeviceInfo.deviceName() << ":" << inputDeviceInfo.getDevice().deviceName() << "]";
     bool supportedFormat = false;
 
@@ -1923,7 +1924,7 @@ bool AudioClient::switchInputToAudioDevice(const HifiAudioDeviceInfo inputDevice
 
     if (!inputDeviceInfo.getDevice().isNull()) {
         qCDebug(audioclient) << "The audio input device" << inputDeviceInfo.deviceName() << ":" << inputDeviceInfo.getDevice().deviceName() << "is available.";
-      
+
         //do not update UI that we're changing devices if default or same device
         _inputDeviceInfo = inputDeviceInfo;
         emit deviceChanged(QAudio::AudioInput, _inputDeviceInfo);
@@ -2097,13 +2098,13 @@ void AudioClient::outputNotify() {
 
 void AudioClient::noteAwakening() {
     qCDebug(audioclient) << "Restarting the audio devices.";
-    switchInputToAudioDevice(_inputDeviceInfo); 
+    switchInputToAudioDevice(_inputDeviceInfo);
     switchOutputToAudioDevice(_outputDeviceInfo);
 }
 
 bool AudioClient::switchOutputToAudioDevice(const HifiAudioDeviceInfo outputDeviceInfo, bool isShutdownRequest) {
     Q_ASSERT_X(QThread::currentThread() == thread(), Q_FUNC_INFO, "Function invoked on wrong thread");
-    
+
     qCDebug(audioclient) << __FUNCTION__ << "_outputdeviceInfo: [" << _outputDeviceInfo.deviceName() << ":" << _outputDeviceInfo.getDevice().deviceName()
         << "-- outputDeviceInfo:" << outputDeviceInfo.deviceName() << ":" << outputDeviceInfo.getDevice().deviceName() << "]";
     bool supportedFormat = false;
@@ -2143,7 +2144,7 @@ bool AudioClient::switchOutputToAudioDevice(const HifiAudioDeviceInfo outputDevi
 
         delete[] _localOutputMixBuffer;
         _localOutputMixBuffer = NULL;
-        
+
         _outputDeviceInfo.setDevice(QAudioDeviceInfo());
     }
 
@@ -2170,7 +2171,7 @@ bool AudioClient::switchOutputToAudioDevice(const HifiAudioDeviceInfo outputDevi
 
     if (!outputDeviceInfo.getDevice().isNull()) {
         qCDebug(audioclient) << "The audio output device" << outputDeviceInfo.deviceName() << ":" << outputDeviceInfo.getDevice().deviceName() << "is available.";
-        
+
         //do not update UI that we're changing devices if default or same device
         _outputDeviceInfo = outputDeviceInfo;
         emit deviceChanged(QAudio::AudioOutput, _outputDeviceInfo);
@@ -2398,7 +2399,7 @@ qint64 AudioClient::AudioOutputIODevice::readData(char * data, qint64 maxSize) {
             qCDebug(audiostream, "Read %d samples from injectors (%d available, %d requested)", injectorSamplesPopped, _localInjectorsStream.samplesAvailable(), samplesRequested);
         }
     }
-    
+
     // prepare injectors for the next callback
      _audio->_localPrepInjectorFuture = QtConcurrent::run(QThreadPool::globalInstance(), [this] {
         _audio->prepareLocalAudioInjectors();

--- a/libraries/audio-client/src/AudioClient.h
+++ b/libraries/audio-client/src/AudioClient.h
@@ -124,7 +124,7 @@ public:
         AudioClient* _audio;
         int _unfulfilledReads;
     };
-    
+
     void startThread();
     void negotiateAudioFormat();
     void selectAudioFormat(const QString& selectedCodecName);
@@ -170,7 +170,7 @@ public:
 
     HifiAudioDeviceInfo getActiveAudioDevice(QAudio::Mode mode) const;
     QList<HifiAudioDeviceInfo> getAudioDevices(QAudio::Mode mode) const;
-  
+
     void enablePeakValues(bool enable) { _enablePeakValues = enable; }
     bool peakValuesAvailable() const;
 
@@ -186,6 +186,7 @@ public:
     void setAudioPaused(bool pause);
 
     AudioSolo& getAudioSolo() override { return _solo; }
+    void setCodecSettings(const std::vector<Encoder::CodecSettings> &settings ) { _codecSettings = settings; }
 
 #ifdef Q_OS_WIN
     static QString getWinDeviceName(wchar_t* guid);
@@ -225,10 +226,10 @@ public slots:
 
     void setNoiseReduction(bool isNoiseGateEnabled, bool emitSignal = true);
     bool isNoiseReductionEnabled() const { return _isNoiseGateEnabled; }
-    
+
     void setNoiseReductionAutomatic(bool isNoiseGateAutomatic, bool emitSignal = true);
     bool isNoiseReductionAutomatic() const { return _isNoiseReductionAutomatic; }
-    
+
     void setNoiseReductionThreshold(float noiseReductionThreshold, bool emitSignal = true);
     float noiseReductionThreshold() const { return _noiseReductionThreshold; }
 
@@ -338,6 +339,7 @@ private:
     bool mixLocalAudioInjectors(float* mixBuffer);
     float azimuthForSource(const glm::vec3& relativePosition);
     float gainForSource(float distance, float volume);
+    std::vector<Encoder::CodecSettings> _codecSettings;
 
 #ifdef Q_OS_ANDROID
     QTimer _checkInputTimer{ this };
@@ -527,7 +529,7 @@ private:
 #endif
 
     AudioSolo _solo;
-    
+
     QFuture<void> _localPrepInjectorFuture;
     QReadWriteLock _hmdNameLock;
     Mutex _checkDevicesMutex;

--- a/libraries/plugins/src/plugins/CodecPlugin.h
+++ b/libraries/plugins/src/plugins/CodecPlugin.h
@@ -10,13 +10,197 @@
 //
 #pragma once
 
+#include <algorithm>
 #include "Plugin.h"
+#include <QDebug>
+
+#ifndef VIRCADIA_CODECPLUGIN_H
+#define VIRCADIA_CODECPLUGIN_H
 
 class Encoder {
 public:
+    enum class EncoderBandpass {
+        Narrowband, Mediumband, Wideband, Superwideband, Fullband
+    };
+
+    enum class EncoderSignal {
+        Auto, Voice, Music
+    };
+
+    enum class EncoderApplication {
+        VOIP, Audio, LowDelay
+    };
+
+/*
+    enum class Capabilities : int {
+        None = 0x00,
+        Lossless = 0x01,
+        Complexity = 0x02,
+        Bitrate = 0x04,
+        FEC = 0x08,
+        Bandpass = 0x10,
+        SignalType = 0x20,
+        VBR = 0x40
+    };
+*/
+
+
     virtual ~Encoder() { }
     virtual void encode(const QByteArray& decodedBuffer, QByteArray& encodedBuffer) = 0;
+
+    /**
+     * @brief Get the codec's name
+     *
+     * Returns the name of the codec, for usage in debug output and UI.
+     *
+     * @return QString Codec's name
+     */
+    virtual const QString getName() const { return "Encoder"; }
+
+    virtual bool isLossless() const { return false; }
+
+    /**
+     * @brief Get the codec's capabilities
+     *
+     * This is a bit field of which of the possible settings have effect on this codec.
+     *
+     * For example, a codec capable of adding redundancy to compensate for packet loss will have the FEC flag set.
+     *
+     * @return Capabilities
+     */
+    //virtual Capabilities getCapabilities() { return Capabilities::None; }
+
+    virtual void setApplication(EncoderApplication app) { _application = app; }
+    virtual bool hasApplication() const { return false; }
+    EncoderApplication getApplication() const { return _application; }
+
+    /**
+     * @brief Set the codec's complexity (CPU usage)
+     *
+     * This defines how much CPU time is spent on encoding. Lower values are expected to have
+     * lower quality or higher bandwidth usage, depending on the codec.
+     *
+     * @param complexity A value from 0 to 100.
+     */
+    virtual void setComplexity(int complexity) { _complexity = qBound(complexity, 0, 100); }
+    virtual bool hasComplexity() const { return false; }
+    int getComplexity() const { return _complexity; }
+
+    /**
+     * @brief Set the bitrate
+     *
+     * How many bits per second the codec is going to use. This only applies to lossy codecs.
+     *
+     * @param bitrate A rate in bits per second from 500 to 512000
+     */
+    virtual void setBitrate(int bitrate) { _bitrate = qBound(bitrate, 500, 512000); }
+    virtual bool hasBitrate() const { return false; }
+    int getBitrate() const { return _bitrate; }
+
+    /**
+     * @brief Sets whether to use Forward Error Correction
+     *
+     * When enabled, redundant data is included in the codec's output to compensate for packet loss
+     * @param enabled
+     */
+    virtual void setFEC(bool enabled) { _useFEC = enabled; }
+    virtual bool hasFEC() const { return false; }
+    bool getFEC() const { return _useFEC; }
+
+    /**
+     * @brief Set how much packet loss to tolerate
+     *
+     * This is how much loss we expect to have. Higher values may consume bandwidth or lower quality to compensate.
+     *
+     * @param percent 0 to 100
+     */
+    virtual void setPacketLossPercent(int percent) { _packetLossPercent = qBound(percent, 0, 100); }
+    virtual bool hasPacketLossPercent() const { return false; }
+    int getPacketLossPercent() const { return _packetLossPercent; }
+
+    /**
+     * @brief Set the bandpass
+     *
+     * @param bandpass
+     */
+    virtual void setBandpass(EncoderBandpass bandpass) { _bandpass = bandpass;}
+    virtual bool hasBandpass() const { return false; }
+    EncoderBandpass getBandpass() const { return _bandpass; }
+
+    /**
+     * @brief Set the type of audio signal
+     *
+     * @param signal
+     */
+    virtual void setSignalType(EncoderSignal signal) { _signal = signal;}
+    virtual bool hasSignalType() const { return false; }
+    EncoderSignal getSignalType() const { return _signal; }
+
+    /**
+     * @brief Whether to use variable bitrate
+     *
+     * @param use_vbr
+     */
+    virtual void setVBR(bool use_vbr) { _useVBR = use_vbr; }
+    virtual bool hasVBR() const { return false; }
+    bool getVBR() const { return _useVBR; }
+
+    QDebug operator<<(QDebug debug) {
+        debug << "{ Codec = " << getName();
+        if ( hasComplexity() ) {
+            debug << "; Complexity = " << getComplexity();
+        }
+
+        if ( hasBitrate() ) {
+            debug << "; Bitrate = " << getBitrate();
+        }
+
+        if ( hasFEC() ) {
+            debug << "; FEC = " << getFEC();
+        }
+
+        if ( hasPacketLossPercent() ) {
+            debug << "; PacketLoss = " << getPacketLossPercent();
+        }
+
+        if ( hasBandpass() ) {
+            debug << "; Bandpass = " << (int)getBandpass();
+        }
+
+        if ( hasSignalType() ) {
+            debug << "; Signal = " << (int)getSignalType();
+        }
+
+        if ( hasVBR() ) {
+            debug << "; VBR = " << getVBR();
+        }
+
+        debug << "}";
+
+        return debug;
+    }
+
+/*
+    Encoder::Capabilities operator|(Encoder::Capabilities lhs, Encoder::Capabilities rhs) {
+    return static_cast<Encoder::Capabilities>(
+        static_cast<std::underlying_type<Encoder::Capabilities>::type>(lhs) |
+        static_cast<std::underlying_type<Encoder::Capabilities>::type>(rhs)
+    );
+
+}
+   */
+protected:
+    int _complexity;
+    int _bitrate;
+    bool _useFEC;
+    bool _useVBR;
+    int _packetLossPercent;
+    EncoderBandpass _bandpass;
+    EncoderSignal _signal;
+    EncoderApplication _application;
 };
+
+
 
 class Decoder {
 public:
@@ -26,6 +210,9 @@ public:
     virtual void lostFrame(QByteArray& decodedBuffer) = 0;
 };
 
+
+
+
 class CodecPlugin : public Plugin {
 public:
     virtual Encoder* createEncoder(int sampleRate, int numChannels) = 0;
@@ -33,3 +220,5 @@ public:
     virtual void releaseEncoder(Encoder* encoder) = 0;
     virtual void releaseDecoder(Decoder* decoder) = 0;
 };
+
+#endif

--- a/plugins/opusCodec/src/OpusEncoder.h
+++ b/plugins/opusCodec/src/OpusEncoder.h
@@ -23,14 +23,14 @@ public:
     virtual void encode(const QByteArray& decodedBuffer, QByteArray& encodedBuffer) override;
 
 
-    int getComplexity() const;
-    void setComplexity(int complexity);
+    int getComplexity() const override;
+    void setComplexity(int complexity) override;
 
-    int getBitrate() const;
-    void setBitrate(int bitrate);
+    int getBitrate() const override;
+    void setBitrate(int bitrate) override;
 
-    int getVBR() const;
-    void setVBR(int vbr);
+    bool getVBR() const override;
+    void setVBR(bool vbr) override;
 
     int getVBRConstraint() const;
     void setVBRConstraint(int vbrConstraint);
@@ -41,19 +41,19 @@ public:
     int getBandwidth() const;
     void setBandwidth(int bandwidth);
 
-    int getSignal() const;
-    void setSignal(int signal);
+    Encoder::SignalType getSignalType() const override;
+    void setSignalType(Encoder::SignalType signal) override;
 
-    int getApplication() const;
-    void setApplication(int application);
+    ApplicationType getApplication() const override;
+    void setApplication(ApplicationType application) override;
 
     int getLookahead() const;
 
-    int getInbandFEC() const;
-    void setInbandFEC(int inBandFEC);
+    bool getFEC() const override;
+    void setFEC(bool inBandFEC) override;
 
-    int getExpectedPacketLossPercentage() const;
-    void setExpectedPacketLossPercentage(int percentage);
+    int getPacketLossPercent() const override;
+    void setPacketLossPercent(int percentage) override;
 
     int getDTX() const;
     void setDTX(int dtx);


### PR DESCRIPTION
This implements configurable config settings for audio codecs. It's still at an early stage, and only being submitted for feedback and collaboration.

TODO list:

* Cleanup code
* Figure out the final list of audio parameters
* Pass the codec configuration to `Agent`.
* Pre-fill the list of codecs in the domain page
* Implement the methods in non-Opus codecs: PCM, zlib, hifiac
* Implement settings in API
* Implement settings in interface