### PR TITLE
Safer linux distro version checks in Qt installation script.

### DIFF
--- a/hifi_qt.py
+++ b/hifi_qt.py
@@ -142,8 +142,11 @@ endif()
             cpu_architecture = platform.machine()
 
             if 'x86_64' == cpu_architecture:
-                u_major = int( distro.major_version() )
-                u_minor = int( distro.minor_version() )
+                try:
+                    u_major = int( distro.major_version() )
+                except ValueError:
+                    u_major = 0
+
                 if distro.id() == 'ubuntu' or distro.id() == 'linuxmint':
                     if (distro.id() == 'ubuntu' and u_major == 18) or distro.id() == 'linuxmint' and u_major == 19:
                         self.qtUrl = self.assets_url + '/dependencies/vcpkg/qt5-install-5.15.2-ubuntu-18.04-amd64.tar.xz'
@@ -157,8 +160,10 @@ endif()
 
             elif 'aarch64' == cpu_architecture:
                 if distro.id() == 'ubuntu':
-                    u_major = int( distro.major_version() )
-                    u_minor = int( distro.minor_version() )
+                    try:
+                        u_major = int( distro.major_version() )
+                    except ValueError:
+                        u_major = 0
 
                     if u_major == 18:
                         self.qtUrl = 'http://motofckr9k.ddns.net/vircadia_packages/qt5-install-5.15.2-ubuntu-18.04-aarch64_test.tar.xz'
@@ -168,7 +173,10 @@ endif()
                         self.__unsupported_error()
 
                 elif distro.id() == 'debian':
-                    u_major = int( distro.major_version() )
+                    try:
+                        u_major = int( distro.major_version() )
+                    except ValueError:
+                        u_major = 0
 
                     if u_major == 10:
                         self.qtUrl = 'https://data.moto9000.moe/vircadia_packages/qt5-install-5.15.2-debian-10-aarch64.tar.xz'


### PR DESCRIPTION
This error was reported on discord
```
-- EXTERNAL_BUILD_ASSETS: https://athena-public.s3.amazonaws.com
-- GLES_OPTION:
Using the Python interpreter located at: /usr/bin/python3.10
-- The CXX compiler identification is GNU 11.1.0
GCC compiler detected, adding -O3 -fPIC -ggdb flags
-- VIRCADIA_OPTIMIZE: true
Adding CPU architecture flags: -march=native -mtune=native
-- VIRCADIA_CPU_ARCHITECTURE: -march=native -mtune=native
 -O3 -fPIC -ggdb -march=native -mtune=native
['/home/ben/build/vircadia/prebuild.py', '--release-type', 'DEV', '--build-root', '/home/ben/build/vircadia/build']
Using a packaged Qt
Traceback (most recent call last):
  File "/home/ben/build/vircadia/prebuild.py", line 194, in <module>
    main()
  File "/home/ben/build/vircadia/prebuild.py", line 119, in main
    qt = hifi_qt.QtDownloader(args)
  File "/home/ben/build/vircadia/hifi_qt.py", line 145, in __init__
    u_major = int( distro.major_version() )
ValueError: invalid literal for int() with base 10: ''
CMake Error at CMakeLists.txt:159 (message):
  prebuild.py failed with error 1
```
building on Arch linux. According to the docs [here](https://distro.readthedocs.io/en/latest/) the version getters may return an empty string, and otherwise nothing suggest they are necessarily always integers. This PR defaults the major version variables to 0 when parsing the version string as int fails, and removes the unused minor version variables.