### PR TITLE
Update API documentation for Window.prompt().

### DIFF
--- a/interface/src/scripting/WindowScriptingInterface.h
+++ b/interface/src/scripting/WindowScriptingInterface.h
@@ -112,10 +112,10 @@ public slots:
      * @function Window.prompt
      * @param {string} message - The question to display.
      * @param {string} defaultText - The default answer text.
-     * @returns {string} The text that the user entered if they select "OK", otherwise "".
+     * @returns {string} The text that the user entered if they select "OK", otherwise null.
      * @example <caption>Ask the user a question requiring a text answer.</caption>
      * var answer = Window.prompt("Question", "answer");
-     * if (answer === "") {
+     * if (answer === null) {
      *     print("User canceled");
      * } else {
      *     print("User answer: " + answer);


### PR DESCRIPTION
[Documentation](https://apidocs.vircadia.dev/Window.html#.prompt) for ```Window.prompt()``` states that if the user click "Cancel" it will return ```""```
It does, in fact return ```null```, I don't know if that is intentional but arguments could be made for both.

This just updates the documentation and the example .