### PR TITLE
Fixed python prebuild script getting stuck trying to lock a file without permission.

### DIFF
--- a/hifi_singleton.py
+++ b/hifi_singleton.py
@@ -48,7 +48,7 @@ class Singleton:
                     self.fh = None
                 # print is horked here so write directly to stdout.
                 with open(1, mode="w", closefd=False) as _stdout:
-                    _stdout.write("Couldn't aquire lock, retrying in 10 seconds\n")
+                    _stdout.write("Couldn't acquire lock, retrying in 10 seconds\n")
                     _stdout.flush()
                 time.sleep(10)
         return self

--- a/hifi_singleton.py
+++ b/hifi_singleton.py
@@ -37,6 +37,8 @@ class Singleton:
                     self.fh = open(self.path, 'x')
                     fcntl.lockf(self.fh, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 success = True
+            except PermissionError:
+                raise
             except EnvironmentError as err:
                 if self.fh is not None:
                     if self.windows:

--- a/prebuild.py
+++ b/prebuild.py
@@ -123,10 +123,18 @@ def main():
             # qtInstallPath is None when we're doing a system Qt build
             print("cmake path: " + qtInstallPath)
 
-            with hifi_singleton.Singleton(qt.lockFile) as lock:
-                with timer('Qt'):
-                    qt.installQt()
-                    qt.writeConfig()
+            try:
+                with hifi_singleton.Singleton(qt.lockFile) as lock:
+                    with timer('Qt'):
+                        qt.installQt()
+                        qt.writeConfig()
+            except PermissionError:
+                lockDir, lockName = os.path.split(qt.lockFile)
+                with hifi_singleton.Singleton(lockName) as lock:
+                    with timer('Qt'):
+                        qt.installQt()
+                        qt.writeConfig()
+
         else:
             if (os.environ["VIRCADIA_USE_SYSTEM_QT"]):
                 print("System Qt selected")


### PR DESCRIPTION
The build was getting stuck for me with the following output
```
$ cmake ..                                                                                                                    
-- GLES_OPTION:                                                                                                                                                                       
Using the Python interpreter located at: /usr/bin/python3.8                                                                                                                           
-- The CXX compiler identification is GNU 9.3.0                                            
GCC compiler detected, adding -O3 -fPIC -ggdb flags                                        
-- VIRCADIA_OPTIMIZE: true                                                                                                                                                            
Adding CPU architecture flags: -march=native -mtune=native                                 
-- VIRCADIA_CPU_ARCHITECTURE: -march=native -mtune=native                                  
 -O3 -fPIC -ggdb -march=native -mtune=native                                               
['/home/namark/dev/vircadia/prebuild.py', '--release-type', 'DEV', '--build-root', '/home/namark/dev/vircadia/build']
Using Qt from /opt/qt515                                                                                                                                                              
Qt5 check passed, found /opt/qt515/lib/cmake/Qt5                                           
Found pre-built Qt5                                                                        
cmake path: /opt/qt515/lib/cmake                                                                                                                                                      
Couldn't aquire lock, retrying in 10 seconds                                               
Couldn't aquire lock, retrying in 10 seconds                                                                                                                                          
Couldn't aquire lock, retrying in 10 seconds                                                                                                                                          
Couldn't aquire lock, retrying in 10 seconds                                                                                                                                          
Couldn't aquire lock, retrying in 10 seconds                                               
Couldn't aquire lock, retrying in 10 seconds                                               
Couldn't aquire lock, retrying in 10 seconds                                               
Couldn't aquire lock, retrying in 10 seconds                                                                                                                                          
Couldn't aquire lock, retrying in 10 seconds                                                                                                                                          
Couldn't aquire lock, retrying in 10 seconds                                               
Couldn't aquire lock, retrying in 10 seconds                                               
Couldn't aquire lock, retrying in 10 seconds                                               
Couldn't aquire lock, retrying in 10 seconds
.
.
.
```
since it had no write permissions to the custom Qt directory I specified using VIRCADIA_QT_PATH environment variable. I guess it makes sense to assume write access if the script installed Qt from pre-built package itself, but in case of user specified path it's not a safe assumption. This PR fixes the problem by detecting the permission error and trying to lock a file in the current directory instead. It's unclear what the purpose of these locks is, but in general there is no point in retrying after a permission error, as it's not something that can change without user intervention. 