### PR TITLE
Disabled vcpkg bootstrapping on aarch64.

### DIFF
--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -195,7 +195,7 @@ endif()
             downloadVcpkg = True
 
         if downloadVcpkg:
-            if "HIFI_VCPKG_BOOTSTRAP" in os.environ:
+            if "HIFI_VCPKG_BOOTSTRAP" in os.environ and 'aarch64' != platform.machine():
                 print("Cloning vcpkg from github to {}".format(self.path))
                 hifi_utils.executeSubprocess(['git', 'clone', 'https://github.com/microsoft/vcpkg', self.path])
                 print("Bootstrapping vcpkg")


### PR DESCRIPTION
https://github.com/vircadia/vircadia/pull/1606 broke the self-hosted_debian-11_aarch64 build, can't figure out why exactly, so just disabling it on that architecture for now.