### PR TITLE
Downgraded GHA Windows environment to Server 2019.

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [windows-latest, macOS-10.15, ubuntu-18.04]
+        os: [windows-2019, macOS-10.15, ubuntu-18.04]
         # build_type: [full, client]
         build_type: [full]
         include:
@@ -70,7 +70,7 @@ jobs:
           echo "APP_TARGET_NAME=Vircadia" >> $GITHUB_ENV
         fi
         # Windows build variables
-        if [ "${{ matrix.os }}" = "windows-latest" ]; then
+        if [ "${{ matrix.os }}" = "windows-2019" ]; then
           echo "PYTHON_EXEC=python" >> $GITHUB_ENV
           echo "ZIP_COMMAND=7z" >> $GITHUB_ENV
           echo "ZIP_ARGS=a" >> $GITHUB_ENV

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
         matrix:
           include:
-            - os: windows-latest
+            - os: windows-2019
               build_type: full
             - os: macOS-10.15
               build_type: full
@@ -95,7 +95,7 @@ jobs:
           echo "APP_TARGET_NAME=Vircadia" >> $GITHUB_ENV
         fi
         # Windows build variables
-        if [ "${{ matrix.os }}" = "windows-latest" ]; then
+        if [ "${{ matrix.os }}" = "windows-2019" ]; then
           echo "PYTHON_EXEC=python" >> $GITHUB_ENV
           echo "INSTALLER_EXT=exe" >> $GITHUB_ENV
           if [ "${{ matrix.build_type }}" = "full" ]; then
@@ -226,7 +226,7 @@ jobs:
       run: cmake --build . --config $BUILD_TYPE --target assignment-client $CMAKE_BUILD_EXTRA
 
     - name: Build Console
-      if: matrix.build_type == 'full' || matrix.os == 'windows-latest'
+      if: matrix.build_type == 'full' || matrix.os == 'windows-2019'
       working-directory: ${{runner.workspace}}/build
       shell: bash
       run: cmake --build . --config $BUILD_TYPE --target packaged-server-console $CMAKE_BUILD_EXTRA
@@ -292,7 +292,7 @@ jobs:
         df -h
 
     - name: Output Installer Logs
-      if: failure() && matrix.os == 'windows-latest'
+      if: failure() && matrix.os == 'windows-2019'
       shell: bash
       working-directory: ${{runner.workspace}}/build
       run: cat ./_CPack_Packages/win64/NSIS/NSISOutput.log


### PR DESCRIPTION
as Visual Studio 2022 couldn't build nvidia texture tools with an
internal compiler error. This is likely a bug on their side and hopefully will be fixed in future releases. 