### PR TITLE
Disable VCPKG bootstrapping in automated builds.

### DIFF
--- a/.github/workflows/master_build.yml
+++ b/.github/workflows/master_build.yml
@@ -11,7 +11,8 @@ env:
   BUILD_NUMBER: ${{ github.run_number }}
   CI_BUILD: Github
   GIT_COMMIT: ${{ github.sha }}
-  HIFI_VCPKG_BOOTSTRAP: true
+  # VCPKG did not build well on OSX disabling HIFI_VCPKG_BOOTSTRAP, which invokes a download to a working version of vcpkg
+  # HIFI_VCPKG_BOOTSTRAP: true
   RELEASE_TYPE: PRODUCTION
   RELEASE_NUMBER: ${{ github.run_number }}
   STABLE_BUILD: 0

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -9,6 +9,7 @@ env:
   BUILD_TYPE: Release
   CI_BUILD: Github
   GIT_COMMIT: ${{ github.sha }}
+  # VCPKG did not build well on OSX disabling HIFI_VCPKG_BOOTSTRAP, which invokes a download to a working version of vcpkg
   HIFI_VCPKG_BOOTSTRAP: true
   RELEASE_TYPE: PR
   RELEASE_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -10,7 +10,7 @@ env:
   CI_BUILD: Github
   GIT_COMMIT: ${{ github.sha }}
   # VCPKG did not build well on OSX disabling HIFI_VCPKG_BOOTSTRAP, which invokes a download to a working version of vcpkg
-  HIFI_VCPKG_BOOTSTRAP: true
+  # HIFI_VCPKG_BOOTSTRAP: true
   RELEASE_TYPE: PR
   RELEASE_NUMBER: ${{ github.event.number }}
   VERSION_CODE: ${{ github.event.number }}


### PR DESCRIPTION
This PR reverts https://github.com/vircadia/vircadia/pull/1606 as it's no longer necessary after https://github.com/vircadia/vircadia/pull/1616, and it breaks the aarch64 build. 
This is an alternative for https://github.com/vircadia/vircadia/pull/1632 and https://github.com/vircadia/vircadia/pull/1608.