### PR TITLE
Fixed client library context destruction. 

### DIFF
--- a/libraries/networking/src/udt/NetworkSocket.h
+++ b/libraries/networking/src/udt/NetworkSocket.h
@@ -35,13 +35,14 @@ public:
     /// @param parent Qt parent object.
     NetworkSocket(QObject* parent);
 
+    virtual ~NetworkSocket() override;
 
     /// @brief Set the value of a UDP or WebRTC socket option.
     /// @param socketType The type of socket for which to set the option value.
     /// @param option The option to set the value of.
     /// @param value The option value.
     void setSocketOption(SocketType socketType, QAbstractSocket::SocketOption option, const QVariant& value);
-    
+
     /// @brief Gets the value of a UDP or WebRTC socket option.
     /// @param socketType The type of socket for which to get the option value.
     /// @param option The option to get the value of.
@@ -54,7 +55,7 @@ public:
     /// @param address The address to bind to.
     /// @param port The port to bind to.
     void bind(SocketType socketType, const QHostAddress& address, quint16 port = 0);
-    
+
     /// @brief Immediately closes and resets the socket.
     /// @param socketType The type of socket to close and reset.
     void abort(SocketType socketType);
@@ -89,11 +90,11 @@ public:
     /// @brief Gets whether there is a pending datagram waiting to be read.
     /// @return <code>true</code> if there is a datagram waiting to be read, <code>false</code> if there isn't.
     bool hasPendingDatagrams() const;
-    
+
     /// @brief Gets the size of the next pending datagram, alternating between socket types if both have datagrams to read.
     /// @return The size of the next pending datagram.
     qint64 pendingDatagramSize();
-    
+
     /// @brief Reads the next datagram per the most recent pendingDatagramSize call if made, otherwise alternating between
     /// socket types if both have datagrams to read.
     /// @param data The destination to write the data into.
@@ -102,7 +103,7 @@ public:
     /// @return The number of bytes if successfully read, otherwise <code>-1</code>.
     qint64 readDatagram(char* data, qint64 maxSize, SockAddr* sockAddr = nullptr);
 
-    
+
     /// @brief Gets the state of the UDP or WebRTC socket.
     /// @param socketType The type of socket for which to get the state.
     /// @return The socket state.
@@ -136,9 +137,9 @@ signals:
     /// @param socketState The socket's new state.
     void stateChanged(SocketType socketType, QAbstractSocket::SocketState socketState);
 
-    /// @brief 
-    /// @param socketType 
-    /// @param socketError 
+    /// @brief
+    /// @param socketType
+    /// @param socketError
     void socketError(SocketType socketType, QAbstractSocket::SocketError socketError);
 
 private slots:

--- a/libraries/networking/src/udt/Socket.h
+++ b/libraries/networking/src/udt/Socket.h
@@ -55,11 +55,12 @@ class Socket : public QObject {
 
 public:
     using StatsVector = std::vector<std::pair<SockAddr, ConnectionStats::Stats>>;
- 
+
     Socket(QObject* object = 0, bool shouldChangeSocketOptions = true);
-    
+    virtual ~Socket() override;
+
     quint16 localPort(SocketType socketType) const { return _networkSocket.localPort(socketType); }
-    
+
     // Simple functions writing to the socket with no processing
     qint64 writeBasePacket(const BasePacket& packet, const SockAddr& sockAddr);
     qint64 writePacket(const Packet& packet, const SockAddr& sockAddr);
@@ -67,7 +68,7 @@ public:
     qint64 writePacketList(std::unique_ptr<PacketList> packetList, const SockAddr& sockAddr);
     qint64 writeDatagram(const char* data, qint64 size, const SockAddr& sockAddr);
     qint64 writeDatagram(const QByteArray& datagram, const SockAddr& sockAddr);
-    
+
     void bind(SocketType socketType, const QHostAddress& address, quint16 port = 0);
     void rebind(SocketType socketType, quint16 port);
     void rebind(SocketType socketType);
@@ -78,16 +79,16 @@ public:
     void setMessageFailureHandler(MessageFailureHandler handler) { _messageFailureHandler = handler; }
     void setConnectionCreationFilterOperator(ConnectionCreationFilterOperator filterOperator)
         { _connectionCreationFilterOperator = filterOperator; }
-    
+
     void addUnfilteredHandler(const SockAddr& senderSockAddr, BasePacketHandler handler)
         { _unfilteredHandlers[senderSockAddr] = handler; }
-    
+
     void setCongestionControlFactory(std::unique_ptr<CongestionControlVirtualFactory> ccFactory);
     void setConnectionMaxBandwidth(int maxBandwidth);
 
     void messageReceived(std::unique_ptr<Packet> packet);
     void messageFailed(Connection* connection, Packet::MessageNumber messageNumber);
-    
+
     StatsVector sampleStatsForAllConnections();
 
 #if defined(WEBRTC_DATA_CHANNELS)
@@ -116,16 +117,16 @@ private slots:
 private:
     void setSystemBufferSizes(SocketType socketType);
     Connection* findOrCreateConnection(const SockAddr& sockAddr, bool filterCreation = false);
-   
+
     // privatized methods used by UDTTest - they are private since they must be called on the Socket thread
     ConnectionStats::Stats sampleStatsForConnection(const SockAddr& destination);
-    
+
     std::vector<SockAddr> getConnectionSockAddrs();
     void connectToSendSignal(const SockAddr& destinationAddr, QObject* receiver, const char* slot);
-    
+
     Q_INVOKABLE void writeReliablePacket(Packet* packet, const SockAddr& sockAddr);
     Q_INVOKABLE void writeReliablePacketList(PacketList* packetList, const SockAddr& sockAddr);
-    
+
     NetworkSocket _networkSocket;
     PacketFilterOperator _packetFilterOperator;
     PacketHandler _packetHandler;
@@ -151,10 +152,10 @@ private:
     int _lastPacketSizeRead { 0 };
     SequenceNumber _lastReceivedSequenceNumber;
     SockAddr _lastPacketSockAddr;
-    
+
     friend UDTTest;
 };
-    
+
 } // namespace udt
 
 #endif // hifi_Socket_h

--- a/libraries/vircadia-client/src/internal/Context.cpp
+++ b/libraries/vircadia-client/src/internal/Context.cpp
@@ -52,7 +52,6 @@ namespace vircadia::client {
             nodeListParams, userAgent, info
         ] () {
             setupHifiApplication(info.name, info.organization, info.domain, info.version);
-            Setting::init();
 
             QCoreApplication qtApp{argc, &argv};
 
@@ -112,12 +111,10 @@ namespace vircadia::client {
                 QThreadPool::globalInstance()->waitForDone();
 
                 DependencyManager::destroy<MessagesClient>();
-
-                // TODO: these are still being used after this point, so need a better way to make sure all threads and pending operations have finished before destroying
-                // DependencyManager::destroy<NodeList>();
-                // DependencyManager::destroy<AddressManager>();
-                // DependencyManager::destroy<DomainAccountManager>();
-                // DependencyManager::destroy<AccountManager>();
+                DependencyManager::destroy<NodeList>();
+                DependencyManager::destroy<AddressManager>();
+                DependencyManager::destroy<DomainAccountManager>();
+                DependencyManager::destroy<AccountManager>();
 
 
             });


### PR DESCRIPTION
Based on #1630
Apparently the settings thread was lingering and preventing proper cleanup, which caused a lot of problems like not being able to run all unit tests in the same process or run Unity SDK code in Unity Editor more than once. This might be indicative of some other problem, but for now just disabling it seems to work fine.