### PR TITLE
Fixed download function call for android dependencies.

### DIFF
--- a/hifi_vcpkg.py
+++ b/hifi_vcpkg.py
@@ -302,7 +302,7 @@ endif()
             url = hifi_android.getPackageUrl(package)
             zipFile = package['file'].endswith('.zip')
             print("Android archive {}".format(package['file']))
-            hifi_utils.downloadAndExtract(url, dest, isZip=zipFile, hash=package['checksum'], hasher=hashlib.md5())
+            hifi_utils.downloadAndExtract([url], dest, hash=package['checksum'], hasher=hashlib.md5)
 
     def writeTag(self):
         if self.noClean:


### PR DESCRIPTION
This function changed when IPFS support was added to the build system, but the android code path was overlooked since the build was failing anyway. Stumbled upon this when hacking together an android build for native client library. Now the android build will still fail, but with a different error. 