### PR TITLE
Removed unnecessary QtGui include in shared library.

### DIFF
--- a/libraries/shared/src/shared/FileLogger.cpp
+++ b/libraries/shared/src/shared/FileLogger.cpp
@@ -13,7 +13,6 @@
 
 #include <QtCore/QDateTime>
 #include <QtCore/QDir>
-#include <QtGui/QDesktopServices>
 
 #include "FileUtils.h"
 #include "NetworkUtils.h"


### PR DESCRIPTION
Shared library was refactored (split in two parts) to not depend on QtGui. Since this header is unused it doesn't result in a runtime dependency, but it is preventing building native client library using custom Qt build without GUI headers/module.