### PR TITLE
Update INSTALLER notes for Windows.

### DIFF
--- a/INSTALLER.md
+++ b/INSTALLER.md
@@ -32,7 +32,7 @@ To produce an executable installer on Windows, the following are required:
     1. Extract Zip
     1. Copy `Include\nsProcess.nsh` to `C:\Program Files (x86)\NSIS\Include\`
     1. Copy `Plugins\nsProcess.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-ansi\`
-    1. Copy `Plugins\nsProcessW.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-unicode\` and rename the filename to nsProcess.dll (remove the 'W' charactor)
+    1. Copy `Plugins\nsProcessW.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-unicode\` and rename the filename to `nsProcess.dll` (remove the 'W' character)
 
 1. [InetC Plug-in for Nullsoft](http://nsis.sourceforge.net/Inetc_plug-in) - 1.0
     1. Extract Zip

--- a/INSTALLER.md
+++ b/INSTALLER.md
@@ -32,22 +32,24 @@ To produce an executable installer on Windows, the following are required:
     1. Extract Zip
     1. Copy `Include\nsProcess.nsh` to `C:\Program Files (x86)\NSIS\Include\`
     1. Copy `Plugins\nsProcess.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-ansi\`
-    1. Copy `Plugins\nsProcessW.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-unicode\`
+    1. Copy `Plugins\nsProcessW.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-unicode\` and rename the filename to nsProcess.dll (remove the 'W' charactor)
 
 1. [InetC Plug-in for Nullsoft](http://nsis.sourceforge.net/Inetc_plug-in) - 1.0
     1. Extract Zip
     1. Copy `Plugin\x86-ansi\InetC.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-ansi\`
     1. Copy `Plugin\x86-unicode\InetC.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-unicode\`
     
-1. [NSISpcre Plug-in for Nullsoft](http://nsis.sourceforge.net/NSISpcre_plug-in) - 1.0
+1. [NSISpcre Plug-in for Nullsoft](https://github.com/mazinsw/NSISpcre/archive/refs/heads/master.zip) - 1.0
     1. Extract Zip
-    1. Copy `NSISpre.nsh` to `C:\Program Files (x86)\NSIS\Include\`
-    1. Copy `NSISpre.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-ansi\`
+    1. Copy `include\NSISpre.nsh` to `C:\Program Files (x86)\NSIS\Include\`
+    1. Copy `bin\x86-ansi\NSISpre.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-ansi\`
+    1. Copy `bin\x86-unicode\NSISpre.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-unicode\`
+    
 
 1. [nsisSlideshow Plug-in for Nullsoft](<http://wiz0u.free.fr/prog/nsisSlideshow/>) - 1.7
    1.  Extract Zip
    1.  Copy `bin\nsisSlideshow.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-ansi\`
-   1.  Copy `bin\nsisSlideshowW.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-unicode\`
+   1.  Copy `bin\nsisSlideshowW.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-unicode\` and rename the filename to nsisSlideshow.dll (remove the 'W' charactor)
 
 1. [Nsisunz plug-in for Nullsoft](http://nsis.sourceforge.net/Nsisunz_plug-in)
    1.  Download both Zips and unzip

--- a/INSTALLER.md
+++ b/INSTALLER.md
@@ -49,7 +49,7 @@ To produce an executable installer on Windows, the following are required:
 1. [nsisSlideshow Plug-in for Nullsoft](<http://wiz0u.free.fr/prog/nsisSlideshow/>) - 1.7
    1.  Extract Zip
    1.  Copy `bin\nsisSlideshow.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-ansi\`
-   1.  Copy `bin\nsisSlideshowW.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-unicode\` and rename the filename to nsisSlideshow.dll (remove the 'W' charactor)
+   1.  Copy `bin\nsisSlideshowW.dll` to `C:\Program Files (x86)\NSIS\Plugins\x86-unicode\` and rename the filename to `nsisSlideshow.dll` (remove the 'W' character)
 
 1. [Nsisunz plug-in for Nullsoft](http://nsis.sourceforge.net/Nsisunz_plug-in)
    1.  Download both Zips and unzip


### PR DESCRIPTION
Fix the issue of "Plugin not found, cannot call xxxx::xxx " when using x86-unicode. (e.g. Plugin not found, cannot call nsProcess::_FindProcess)