### PR TITLE
Create app: Adds a "Distance" UI field to Light Entity

### DIFF
--- a/scripts/system/create/assets/data/createAppTooltips.json
+++ b/scripts/system/create/assets/data/createAppTooltips.json
@@ -380,8 +380,11 @@
     "intensity": {
         "tooltip": "The brightness of the light."
     },
+    "lightDistance": {
+        "tooltip": "The distance in meters from the light's center where the light ends."
+    },
     "falloffRadius": {
-        "tooltip": "The distance from the light's center where the intensity is reduced."
+        "tooltip": "The distance in meters from the light's center where the intensity is reduced."
     },
     "isSpotlight": {
         "tooltip": "If enabled, then the light is directional, otherwise the light is a point light which emits light in all directions."

--- a/scripts/system/create/entityProperties/html/js/entityProperties.js
+++ b/scripts/system/create/entityProperties/html/js/entityProperties.js
@@ -834,6 +834,17 @@ const GROUPS = [
                 propertyID: "intensity",
             },
             {
+                label: "Distance", //This is a shortcut to set the "dimensions.z" property for a more intuitive UI.
+                type: "number-draggable",
+                min: 0,
+                max: 64000,
+                step: 0.01,
+                decimals: 4,
+                unit: "m",
+                propertyID: "lightDistance",
+                propertyName: "dimensions.z", // actual entity property name
+            },            
+            {
                 label: "Fall-Off Radius",
                 type: "number-draggable",
                 min: 0,
@@ -2339,7 +2350,7 @@ function createDragEndFunction(property) {
 }
 
 function createEmitNumberPropertyUpdateFunction(property) {
-    return function() {
+    return function() {       
         let value = parseFloat(applyOutputNumberPropertyModifiers(parseFloat(this.value), property.data));
         updateProperty(property.name, value, property.isParticleProperty);
     };
@@ -4410,6 +4421,7 @@ function handleEntitySelectionUpdate(selections, isPropertiesToolUpdate) {
         if (doSelectElement && typeof activeElement.select !== "undefined") {
             activeElement.select();
         }
+
     }
 }
 

--- a/scripts/system/create/entityProperties/html/js/entityProperties.js
+++ b/scripts/system/create/entityProperties/html/js/entityProperties.js
@@ -4420,7 +4420,6 @@ function handleEntitySelectionUpdate(selections, isPropertiesToolUpdate) {
         if (doSelectElement && typeof activeElement.select !== "undefined") {
             activeElement.select();
         }
-
     }
 }
 

--- a/scripts/system/create/entityProperties/html/js/entityProperties.js
+++ b/scripts/system/create/entityProperties/html/js/entityProperties.js
@@ -2350,7 +2350,7 @@ function createDragEndFunction(property) {
 }
 
 function createEmitNumberPropertyUpdateFunction(property) {
-    return function() {       
+    return function() {
         let value = parseFloat(applyOutputNumberPropertyModifiers(parseFloat(this.value), property.data));
         updateProperty(property.name, value, property.isParticleProperty);
     };
@@ -4222,7 +4222,6 @@ function handleEntitySelectionUpdate(selections, isPropertiesToolUpdate) {
                             property.elInput.checked = inverse ? !subPropertyValue : subPropertyValue;
                             property.elInput.classList.remove('multi-diff');
                         }
-
                     } else {
                         if (isMultiDiffValue) {
                             property.elInput.checked = false;


### PR DESCRIPTION
This PR adds a "Distance" pseudo-property to Light Entity.
The new UI fields is actually plugged to the "dimensions.z" property of the entity.

People had difficulty to figure that the light's effective distance was related to the dimensions of the entity. Some tried to mess with the intensity hoping to setup the entity without succes.

To solve this, I simply added a "Distance" UI field in the "Light" tab, plugged to the property "dimensions.z".

![image](https://user-images.githubusercontent.com/60075796/176817179-fb50fae4-b5f5-497a-9525-88ba6680da00.png)

The tooltip keeps transparent that it is actually the "dimension.z" that is edited.

![image](https://user-images.githubusercontent.com/60075796/176817287-7e697cfc-a880-46cb-b028-1a29ecdc0472.png)
