### PR TITLE
Remove self-hosted GitHub Actions Runner and Runner dependent code.

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -46,10 +46,6 @@ jobs:
             - os: ubuntu-18.04
               build_type: android
               apt-dependencies: mesa-common-dev libegl1 libglvnd-dev libdouble-conversion1 libpulse0
-            # Do not change the names of self-hosted runners without knowing what you are doing, as they correspond to labels that have to be set on the runner.
-            - os: self-hosted_debian-11_aarch64
-              build_type: full
-              apt-dependencies: qtbase5-dev qtbase5-private-dev qtwebengine5-dev qtwebengine5-dev-tools qtmultimedia5-dev libqt5opengl5-dev qtscript5-dev libqt5scripttools5 libqt5webchannel5-dev libqt5websockets5-dev qtxmlpatterns5-dev-tools qttools5-dev libqt5xmlpatterns5-dev libqt5svg5-dev qml-module-qtwebchannel build-essential curl freeglut3-dev git libasound2 libasound2-dev libdouble-conversion-dev libdrm-dev libfontconfig1 libgl1-mesa-dev libglvnd-dev libharfbuzz-dev libjack-dev libjack0 libnspr4 libnss3 libpcre2-16-0 libpulse0 libsdl2-dev libssl-dev libudev-dev libxcb-xinerama0-dev libxcb-xinput0 libxcomposite1 libxcursor1 libxi-dev libxmu-dev libxrandr-dev libxslt1.1 libxtst6 make mesa-common-dev mesa-utils nodejs npm patchelf python2 python3 python3-distro xdg-user-dirs zlib1g-dev ninja-build zip
         fail-fast: false
     runs-on: ${{matrix.os}}
     if: github.event.action != 'labeled' || github.event.label.name == 'rebuild'
@@ -67,12 +63,6 @@ jobs:
           echo "PYTHON_EXEC=python3" >> $GITHUB_ENV
           echo "INSTALLER_EXT=*" >> $GITHUB_ENV
           echo "CMAKE_BUILD_EXTRA=-- -j$(nproc)" >> $GITHUB_ENV
-          if [ "${{ matrix.os }}" = "self-hosted_debian-11_aarch64" ]; then
-            echo "VIRCADIA_USE_SYSTEM_QT=true" >> $GITHUB_ENV
-            echo "CI_WORKSPACE=${{runner.workspace}}" >> $GITHUB_ENV
-            # Don't optimize builds to save build time.
-            echo "VIRCADIA_OPTIMIZE=false" >> $GITHUB_ENV
-          fi
           if [[ "${{ matrix.os }}" = *"aarch64" ]]; then
             echo "VCPKG_FORCE_SYSTEM_BINARIES=true" >> $GITHUB_ENV
           fi
@@ -155,15 +145,6 @@ jobs:
           echo "Installing apt packages"
           sudo apt install -y ${{ matrix.apt-dependencies }} || exit 1
 
-          if [ "${{ matrix.os }}" = "self-hosted_debian-11_aarch64" ]; then
-            echo "Installing cmake from source"
-            wget https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2.tar.gz
-            tar -zxvf cmake-3.22.2.tar.gz
-            cd cmake-3.22.2
-            ./bootstrap
-            make -j$(nproc)
-            sudo make install -j$(nproc)
-          fi
         else # macOS
           echo "Downloading MacOSX10.12 SDK.."
           # TODO: do this in cmake or python build scripts to make use of centralized external asset configuration with fallback gateways.


### PR DESCRIPTION
I am shutting down the self-hosted aarch64 GitHub Actions Runner, so this PR removes it from the pipeline and removes code that is specific to the Runner.

I will keep the Runner online for a couple of days more, to not cause checks to suddently fail and people wondering why their builds are failing.