### PR TITLE
Handle skeleton joints from other clients having different order.

### DIFF
--- a/interface/src/avatar/OtherAvatar.cpp
+++ b/interface/src/avatar/OtherAvatar.cpp
@@ -48,6 +48,9 @@ OtherAvatar::OtherAvatar(QThread* thread) : Avatar(thread) {
     connect(_skeletonModel.get(), &Model::setURLFinished, this, &Avatar::setModelURLFinished);
     connect(_skeletonModel.get(), &Model::rigReady, this, &Avatar::rigReady);
     connect(_skeletonModel.get(), &Model::rigReset, this, &Avatar::rigReset);
+
+    // Skeleton data of remote avatar may be received after the local client has already loaded the rig for it.
+    connect(this, &AvatarData::skeletonDataChanged, this, &Avatar::onSkeletonDataChanged);
 }
 
 OtherAvatar::~OtherAvatar() {

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -2643,13 +2643,18 @@ void Rig::copyJointsFromJointData(const QVector<JointData>& jointDataVec) {
         return;
     }
 
+    if (numJoints != _remoteToLocalJointMap.size()) {
+        // jointData mapping is not yet set up.
+        return;
+    }
+
     // make a vector of rotations in absolute-model-frame
     std::vector<glm::quat> rotations;
     rotations.reserve(numJoints);
     const glm::quat rigToGeometryRot(glmExtractRotation(_rigToGeometryTransform));
 
     for (int i = 0; i < numJoints; i++) {
-        const JointData& data = jointDataVec.at(i);
+        const JointData& data = jointDataVec.at(_remoteToLocalJointMap[i]);
         if (data.rotationIsDefaultPose) {
             rotations.push_back(absoluteDefaultPoses[i].rot());
         } else {
@@ -2667,7 +2672,7 @@ void Rig::copyJointsFromJointData(const QVector<JointData>& jointDataVec) {
     }
     const AnimPoseVec& relativeDefaultPoses = _animSkeleton->getRelativeDefaultPoses();
     for (int i = 0; i < numJoints; i++) {
-        const JointData& data = jointDataVec.at(i);
+        const JointData& data = jointDataVec.at(_remoteToLocalJointMap[i]);
         _internalPoseSet._relativePoses[i].rot() = rotations[i];
         if (data.translationIsDefaultPose) {
             _internalPoseSet._relativePoses[i].trans() = relativeDefaultPoses[i].trans();

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -259,6 +259,10 @@ public:
     bool getNetworkGraphActive() const;
     void setDirectionalBlending(const QString& targetName, const glm::vec3& blendingTarget, const QString& alphaName, float alpha);
 
+    void setSkeletonJointMap(const std::vector<uint>& remoteToLocalJointMap) {
+        _remoteToLocalJointMap = remoteToLocalJointMap;
+    };
+
 signals:
     void onLoadComplete();
     void onLoadFailed();
@@ -485,6 +489,8 @@ protected:
     ControllerParameters _previousControllerParameters;
     Flow _internalFlow;
     Flow _networkFlow;
+
+    std::vector<uint> _remoteToLocalJointMap;
 };
 
 #endif /* defined(__hifi__Rig__) */

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1524,9 +1524,7 @@ std::vector<uint> Avatar::calculateRemoteToLocalJointMap() {
         }
     } else {
         qWarning() << "Remote and local skeletons for avatar are different sizes.";
-        for (int i = 0; i < jointNames.size(); i++) {
-            remoteToLocalJointMap[i] = i;
-        }
+        remoteToLocalJointMap.resize(0);  // Don't attempt to control avatar's joints.
     }
 
     return remoteToLocalJointMap;

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1617,6 +1617,10 @@ void Avatar::rigReset() {
     clearSpine2SplineRatioCache();
 }
 
+void Avatar::onSkeletonDataChanged() {
+    getSkeletonModel()->getRig().setSkeletonJointMap(calculateRemoteToLocalJointMap());
+}
+
 void Avatar::computeMultiSphereShapes() {
     const Rig& rig = getSkeletonModel()->getRig();
     const HFMModel& geometry = getSkeletonModel()->getHFMModel();

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.cpp
@@ -1618,7 +1618,9 @@ void Avatar::rigReset() {
 }
 
 void Avatar::onSkeletonDataChanged() {
-    getSkeletonModel()->getRig().setSkeletonJointMap(calculateRemoteToLocalJointMap());
+    if (getSkeletonModel()->isLoaded()) {
+        getSkeletonModel()->getRig().setSkeletonJointMap(calculateRemoteToLocalJointMap());
+    }
 }
 
 void Avatar::computeMultiSphereShapes() {

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -204,6 +204,7 @@ public:
     virtual QStringList getJointNames() const override;
 
     std::vector<AvatarSkeletonTrait::UnpackedJointData> getSkeletonDefaultData();
+    std::vector<uint> calculateRemoteToLocalJointMap();
 
     /*@jsdoc
      * Gets the default rotation of a joint (in the current avatar) relative to its parent.

--- a/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
+++ b/libraries/avatars-renderer/src/avatars-renderer/Avatar.h
@@ -630,6 +630,13 @@ public slots:
     // Hooked up to Model::rigReset signal
     void rigReset();
 
+    /*@jsdoc
+     * @function MyAvatar.onSkeletonDataChanged
+     * @deprecated This function is deprecated and will be removed.
+     */
+    // Hooked up to AvatarData::skeletonDataChanged signal
+    void onSkeletonDataChanged();
+
 protected:
     float getUnscaledEyeHeightFromSkeleton() const;
     void buildUnscaledEyeHeightCache();

--- a/libraries/avatars/src/AvatarData.cpp
+++ b/libraries/avatars/src/AvatarData.cpp
@@ -3236,6 +3236,8 @@ void AvatarData::setSkeletonData(const std::vector<AvatarSkeletonTrait::Unpacked
     _avatarSkeletonDataLock.withWriteLock([&] {
         _avatarSkeletonData = skeletonData;
     });
+
+    emit skeletonDataChanged();
 }
 
 std::vector<AvatarSkeletonTrait::UnpackedJointData> AvatarData::getSkeletonData() const {

--- a/libraries/avatars/src/AvatarData.h
+++ b/libraries/avatars/src/AvatarData.h
@@ -1886,6 +1886,9 @@ protected:
     bool updateAvatarGrabData(const QUuid& grabID, const QByteArray& grabData);
     virtual void clearAvatarGrabData(const QUuid& grabID);
 
+signals:
+    void skeletonDataChanged();
+
 private:
     Q_DISABLE_COPY(AvatarData)
 


### PR DESCRIPTION
In particular, for a particular avatar, the Web client sends a skeleton and joint with different joint order to that which the native client loads to render the Web client avatar. Thus, the order of the joints data received needs to be mapped onto the native client avatar model / rig.

Known issue: When a Web avatar is first rendered in the native client, it can be rendered distorted for up to a few seconds. The cause of this issue is unknown and a work-around has not been found to date.