### PR TITLE
Added metaverse server URL setting in domain server admin panel.

### DIFF
--- a/assignment-client/src/entities/EntityServer.cpp
+++ b/assignment-client/src/entities/EntityServer.cpp
@@ -22,7 +22,6 @@
 #include <plugins/PluginManager.h>
 #include <EntityEditFilters.h>
 #include <NetworkingConstants.h>
-#include <MetaverseAPI.h>
 #include <hfm/ModelFormatRegistry.h>
 
 #include "../AssignmentDynamicFactory.h"
@@ -279,7 +278,7 @@ int EntityServer::sendSpecialPackets(const SharedNodePointer& node, OctreeQueryN
 
     #ifdef EXTRA_ERASE_DEBUGGING
         if (packetsSent > 0) {
-            qDebug() << "EntityServer::sendSpecialPackets() sent " << packetsSent << "special packets of " 
+            qDebug() << "EntityServer::sendSpecialPackets() sent " << packetsSent << "special packets of "
                         << totalBytes << " total bytes to node:" << node->getUUID();
         }
     #endif
@@ -345,14 +344,14 @@ void EntityServer::readAdditionalConfiguration(const QJsonObject& settingsSectio
     } else {
         tree->setEntityScriptSourceWhitelist("");
     }
-    
+
     auto entityEditFilters = DependencyManager::get<EntityEditFilters>();
-    
+
     QString filterURL;
     if (readOptionString("entityEditFilter", settingsSectionObject, filterURL) && !filterURL.isEmpty()) {
         // connect the filterAdded signal, and block edits until you hear back
         connect(entityEditFilters.data(), &EntityEditFilters::filterAdded, this, &EntityServer::entityFilterAdded);
-        
+
         entityEditFilters->addFilter(EntityItemID(), filterURL);
     }
 }
@@ -386,7 +385,7 @@ void EntityServer::nodeKilled(SharedNodePointer node) {
 
 // FIXME - this stats tracking is somewhat temporary to debug the Whiteboard issues. It's not a bad
 // set of stats to have, but we'd probably want a different data structure if we keep it very long.
-// Since this version uses a single shared QMap for all senders, there could be some lock contention 
+// Since this version uses a single shared QMap for all senders, there could be some lock contention
 // on this QWriteLocker
 void EntityServer::trackSend(const QUuid& dataID, quint64 dataLastEdited, const QUuid& sessionID) {
     QWriteLocker locker(&_viewerSendingStatsLock);

--- a/domain-server/resources/describe-settings.json
+++ b/domain-server/resources/describe-settings.json
@@ -4,7 +4,14 @@
     {
       "name": "metaverse",
       "label": "Networking / Metaverse",
+      "assignment-types": [ 0, 1, 2, 3, 4, 5, 6 ],
       "settings": [
+        {
+          "name": "server_url",
+          "label": "Metaverse Server URL",
+          "placeholder": "Optional",
+          "advanced": true
+        },
         {
           "name": "access_token",
           "label": "Access Token",

--- a/domain-server/src/DomainServer.cpp
+++ b/domain-server/src/DomainServer.cpp
@@ -250,6 +250,12 @@ DomainServer::DomainServer(int argc, char* argv[]) :
     }
     _settingsManager.setupConfigMap(userConfigFilename);
 
+    auto settingsMetaverseUrl = _settingsManager.valueForKeyPath(MetaverseAPI::Settings::URL_KEY_PATH);
+    if (settingsMetaverseUrl.isValid()) {
+        MetaverseAPI::Settings::getInstance()->setSettingsUrl(settingsMetaverseUrl.toString());
+    }
+
+
     // setup a shutdown event listener to handle SIGTERM or WM_CLOSE for us
 #ifdef _WIN32
     installNativeEventFilter(&ShutdownEventListener::getInstance());

--- a/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableWebEntityItem.cpp
@@ -30,7 +30,6 @@
 
 #include "EntitiesRendererLogging.h"
 #include <NetworkingConstants.h>
-#include <MetaverseAPI.h>
 
 using namespace render;
 using namespace render::entities;
@@ -188,7 +187,7 @@ void WebEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scene
 
         if (_webSurface) {
             if (_webSurface->getRootItem()) {
-                if (_contentType == ContentType::HtmlContent && _sourceURL != newSourceURL) {            
+                if (_contentType == ContentType::HtmlContent && _sourceURL != newSourceURL) {
                     if (localSafeContext) {
                         ::hifi::scripting::setLocalAccessSafeThread(true);
                     }
@@ -226,15 +225,15 @@ void WebEntityRenderer::doRenderUpdateSynchronousTyped(const ScenePointer& scene
                     }
                 }
 
-                { 
+                {
                     auto useBackground = entity->getUseBackground();
                     if (_useBackground != useBackground) {
                         _webSurface->getRootItem()->setProperty(USE_BACKGROUND_PROPERTY, useBackground);
                         _useBackground = useBackground;
                     }
                 }
-                
-                { 
+
+                {
                     auto userAgent = entity->getUserAgent();
                     if (_userAgent != userAgent) {
                         _webSurface->getRootItem()->setProperty(USER_AGENT_PROPERTY, userAgent);

--- a/libraries/material-networking/src/material-networking/TextureCache.cpp
+++ b/libraries/material-networking/src/material-networking/TextureCache.cpp
@@ -46,7 +46,6 @@
 #include <NetworkLogging.h>
 #include "MaterialNetworkingLogging.h"
 #include <NetworkingConstants.h>
-#include <MetaverseAPI.h>
 #include <Trace.h>
 #include <StatTracker.h>
 

--- a/libraries/networking/src/AssetUtils.cpp
+++ b/libraries/networking/src/AssetUtils.cpp
@@ -21,7 +21,6 @@
 #include "NetworkAccessManager.h"
 #include "NetworkLogging.h"
 #include "NetworkingConstants.h"
-#include "MetaverseAPI.h"
 
 #include "ResourceManager.h"
 
@@ -93,7 +92,7 @@ bool saveToCache(const QUrl& url, const QByteArray& file) {
             }
         }
     }
-    
+
     return false;
 }
 

--- a/libraries/networking/src/DomainHandler.h
+++ b/libraries/networking/src/DomainHandler.h
@@ -34,7 +34,6 @@
 #include "Node.h"
 #include "ReceivedMessage.h"
 #include "NetworkingConstants.h"
-#include "MetaverseAPI.h"
 
 const unsigned short DEFAULT_DOMAIN_SERVER_PORT =
     QProcessEnvironment::systemEnvironment()
@@ -83,7 +82,7 @@ const quint16 DOMAIN_SERVER_EXPORTER_PORT =
             .value("VIRCADIA_DOMAIN_SERVER_EXPORTER_PORT")
             .toUInt()
         : 9703;
-        
+
 const quint16 DOMAIN_SERVER_METADATA_EXPORTER_PORT =
     QProcessEnvironment::systemEnvironment()
     .contains("VIRCADIA_DOMAIN_SERVER_METADATA_EXPORTER_PORT")

--- a/libraries/networking/src/FileResourceRequest.cpp
+++ b/libraries/networking/src/FileResourceRequest.cpp
@@ -23,7 +23,6 @@
 #include "NetworkLogging.h"
 #include "ResourceManager.h"
 #include "NetworkingConstants.h"
-#include "MetaverseAPI.h"
 
 void FileResourceRequest::doSend() {
     auto statTracker = DependencyManager::get<StatTracker>();
@@ -85,7 +84,7 @@ void FileResourceRequest::doSend() {
             _result = ResourceRequest::NotFound;
         }
     }
-    
+
     _state = Finished;
     emit finished();
 

--- a/libraries/networking/src/MetaverseAPI.cpp
+++ b/libraries/networking/src/MetaverseAPI.cpp
@@ -4,6 +4,7 @@
 //
 //  Created by Kalila L. on 2019-12-16.
 //  Copyright 2019, 2022 Vircadia contributors.
+//  Copyright 2022 DigiSomni LLC.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/libraries/networking/src/MetaverseAPI.h
+++ b/libraries/networking/src/MetaverseAPI.h
@@ -12,6 +12,8 @@
 #ifndef athena_MetaverseAPI_h
 #define athena_MetaverseAPI_h
 
+#include <optional>
+
 #include <QtCore/QProcessEnvironment>
 #include <QtCore/QUrl>
 
@@ -20,7 +22,13 @@ namespace MetaverseAPI {
     class Settings : public QObject {
         Q_OBJECT
     public:
+        static const QString GROUP;
+        static const QString URL_KEY;
+        static const QString URL_KEY_PATH;
+
         static Settings* getInstance();
+
+        void setSettingsUrl(const QUrl& value);
 
     public slots:
         QUrl getBaseUrl();
@@ -29,6 +37,9 @@ namespace MetaverseAPI {
 
     protected:
         Settings(QObject* parent = nullptr);
+
+    private:
+        std::optional<QUrl> settingsURL;
     };
 
     QUrl getCurrentMetaverseServerURL();

--- a/libraries/networking/src/MetaverseAPI.h
+++ b/libraries/networking/src/MetaverseAPI.h
@@ -4,6 +4,7 @@
 //
 //  Created by Kalila L. on 2019-12-16.
 //  Copyright 2019, 2022 Vircadia contributors.
+//  Copyright 2022 DigiSomni LLC.
 //
 //  Distributed under the Apache License, Version 2.0.
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html

--- a/libraries/procedural/src/procedural/Procedural.cpp
+++ b/libraries/procedural/src/procedural/Procedural.cpp
@@ -20,7 +20,6 @@
 #include <NumericalConstants.h>
 #include <GLMHelpers.h>
 #include <NetworkingConstants.h>
-#include <MetaverseAPI.h>
 #include <shaders/Shaders.h>
 
 #include "ShaderConstants.h"

--- a/libraries/qml/src/qml/OffscreenSurface.cpp
+++ b/libraries/qml/src/qml/OffscreenSurface.cpp
@@ -24,7 +24,6 @@
 #include <gl/OffscreenGLCanvas.h>
 #include <shared/ReadWriteLockable.h>
 #include <NetworkingConstants.h>
-#include <MetaverseAPI.h>
 
 #include "Logging.h"
 #include "impl/SharedObject.h"
@@ -35,7 +34,7 @@
 using namespace hifi::qml;
 using namespace hifi::qml::impl;
 
-QmlUrlValidator OffscreenSurface::validator = [](const QUrl& url) -> bool { 
+QmlUrlValidator OffscreenSurface::validator = [](const QUrl& url) -> bool {
     if (url.isRelative()) {
         return true;
     }


### PR DESCRIPTION
Not perfect in terms of communicating the setting to assignment clients https://github.com/vircadia/vircadia/issues/1727, but should be good at least for use cases that don't rely on that. Also the ICE server needs to be separately configured with the same Metaverse URL to authenticate domain servers https://github.com/vircadia/vircadia/issues/1729.